### PR TITLE
Add CI workflow for formatting, linting, and testing frontend/backend

### DIFF
--- a/.github/workflows/format_and_test.yaml
+++ b/.github/workflows/format_and_test.yaml
@@ -1,0 +1,1 @@
+Temporary Placeholder

--- a/.github/workflows/format_and_test.yaml
+++ b/.github/workflows/format_and_test.yaml
@@ -1,53 +1,59 @@
-name: Lint, Test, and Build
 
-no:
+name: Format & Test
+
+on:
   push:
     branches: [main, workflows]
   pull_request:
     branches: [main, workflows]
 
-djobs: 
+jobs:
   backend:
+    name: Backend (Python)
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    steps: 
-      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install backend dependencies
-        run: ||
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
-          pip install -r test-requirements.txt
+          pip install -r requirements.txt
 
-      - name: Check code formatting
+      - name: Check formatting with black
         run: black . --check
 
-      - name: Run tests
+      - name: Run tests with pytest
         run: pytest
 
   frontend:
+    name: Frontend (Vue)
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@f4
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Lint Vue app
+      - name: Lint code
         run: npm run lint
 
-      - name: Build frontend
+      - name: Build project
         run: npm run build

--- a/.github/workflows/format_and_test.yaml
+++ b/.github/workflows/format_and_test.yaml
@@ -1,1 +1,53 @@
-Temporary Placeholder
+name: Lint, Test, and Build
+
+no:
+  push:
+    branches: [main, workflows]
+  pull_request:
+    branches: [main, workflows]
+
+djobs: 
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps: 
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        run: ||
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+
+      - name: Check code formatting
+        run: black . --check
+
+      - name: Run tests
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@f4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Lint Vue app
+        run: npm run lint
+
+      - name: Build frontend
+        run: npm run build

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,59 +10,53 @@ from app.config.environment import TELLER_WEBHOOK_SECRET
 
 def create_app():
     app = Flask(__name__)
-
-    # Core setup
     CORS(app)
     app.config.from_object("app.config")
     db.init_app(app)
     Migrate(app, db)
+    # Always register routes (for all environments)
+    from app.routes.frontend import frontend
+    from app.routes.transactions import transactions
+    from app.routes.accounts import accounts
+    from app.routes.recurring import recurring
+    from app.routes.forecast import forecast
+    from app.routes.manual_io import manual_up
+    from app.routes.charts import charts
+    from app.routes.categories import categories
+    from app.routes.export import export
+    from app.routes.plaid import plaid_bp
+    from app.routes.plaid_investments import plaid_investments
+    from app.routes.plaid_transactions import plaid_transactions
+    from app.routes.teller_transactions import teller_transactions
+    from app.routes.teller_webhook import webhooks, disabled_webhooks
 
-    # DEV-ONLY: Automatically create all tables if missing
+    app.register_blueprint(frontend, url_prefix="/")
+    app.register_blueprint(export, url_prefix="/api/export")
+    app.register_blueprint(categories, url_prefix="/api/categories")
+    app.register_blueprint(transactions, url_prefix="/api/transactions")
+    app.register_blueprint(accounts, url_prefix="/api/accounts")
+    app.register_blueprint(manual_up, url_prefix="/api/import")
+    app.register_blueprint(charts, url_prefix="/api/charts")
+    app.register_blueprint(forecast, url_prefix="/api/forecast")
+    app.register_blueprint(recurring, url_prefix="/api/recurring")
+    app.register_blueprint(plaid_bp, url_prefix="/api/plaid")
+    app.register_blueprint(plaid_transactions, url_prefix="/api/plaid/transactions")
+    app.register_blueprint(plaid_investments, url_prefix="/api/plaid/investments")
+    app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
+
+    if TELLER_WEBHOOK_SECRET:
+        app.register_blueprint(webhooks, url_prefix="/api/webhooks")
+    else:
+        app.register_blueprint(disabled_webhooks, url_prefix="/api/webhooks")
+
+    # DEV-only DB setup
     if FLASK_ENV == "development":
         with app.app_context():
             db.create_all()
 
-        # Import blueprints
-        from app.routes.frontend import frontend
-        from app.routes.transactions import transactions
-        from app.routes.accounts import accounts
-        from app.routes.recurring import recurring
-        from app.routes.forecast import forecast
-        from app.routes.manual_io import manual_up
-        from app.routes.charts import charts
-        from app.routes.categories import categories
-        from app.routes.export import export
-        from app.routes.plaid import plaid_bp
-        from app.routes.plaid_investments import plaid_investments
-        from app.routes.plaid_transactions import plaid_transactions
-        from app.routes.teller_transactions import teller_transactions
-        from app.routes.teller_webhook import webhooks, disabled_webhooks
-
-        # Register blueprints with prefixes
-        app.register_blueprint(frontend, url_prefix="/")
-        app.register_blueprint(export, url_prefix="/api/export")
-        app.register_blueprint(categories, url_prefix="/api/categories")
-        app.register_blueprint(transactions, url_prefix="/api/transactions")
-        app.register_blueprint(accounts, url_prefix="/api/accounts")
-        app.register_blueprint(manual_up, url_prefix="/api/import")
-        app.register_blueprint(charts, url_prefix="/api/charts")
-        app.register_blueprint(forecast, url_prefix="/api/forecast")
-        app.register_blueprint(recurring, url_prefix="/api/recurring")
-        app.register_blueprint(plaid_bp, url_prefix="/api/plaid")
-        app.register_blueprint(plaid_transactions, url_prefix="/api/plaid/transactions")
-        app.register_blueprint(plaid_investments, url_prefix="/api/plaid/investments")
-        app.register_blueprint(
-            teller_transactions, url_prefix="/api/teller/transactions"
-        )
-
-        # Conditionally enable Teller webhook
-        if TELLER_WEBHOOK_SECRET:
-            app.register_blueprint(webhooks, url_prefix="/api/webhooks")
-        else:
-            app.register_blueprint(disabled_webhooks, url_prefix="/api/webhooks")
-
-        with app.app_context():
-            routes = " \n ".join(str(rule) for rule in app.url_map.iter_rules())
-            logger.verbose("🔍 Registered Routes:\n%s", routes)
+    # Optional: always log routes
+    with app.app_context():
+        routes = " \n ".join(str(rule) for rule in app.url_map.iter_rules())
+        logger.verbose("🔍 Registered Routes:\n%s", routes)
 
     return app


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow for both the backend and frontend:

- **Backend (Python)**
  - Uses Python 3.11
  - Installs dependencies
  - Runs `black` for formatting check
  - Executes tests using `pytest`

- **Frontend (Vue)**
  - Uses Node.js 20
  - Installs dependencies via `npm ci`
  - Runs `npm run lint`
  - Builds the project

This ensures all pushes and PRs to `main` or `workflows` are automatically validated.