### PR TITLE
Add backend module documentation

### DIFF
--- a/docs/backend/app/__init__.md
+++ b/docs/backend/app/__init__.md
@@ -1,0 +1,13 @@
+## 📘 `__init__.py`
+```markdown
+# Application Factory
+
+Initializes the Flask application. Sets up CORS, loads configuration, initializes
+SQLAlchemy and migrations, then registers all route blueprints. The
+`create_app()` function returns a configured `Flask` instance used by `run.py`
+and the CLI tools. CLI commands like `sync-accounts` are attached here and the
+available routes are logged on startup.
+
+**Dependencies**: `Flask`, `flask_cors`, `flask_migrate`, `app.config`,
+`app.extensions`, various route modules.
+```

--- a/docs/backend/app/cli/sync.md
+++ b/docs/backend/app/cli/sync.md
@@ -1,0 +1,11 @@
+## 📘 `sync.py`
+```markdown
+# CLI Sync Command
+
+Defines the `sync-accounts` Click command used for manual account refreshes.
+When executed, it calls `refresh_all_accounts()` from
+`app.helpers.account_refresh_dispatcher` within the Flask application context.
+Useful for scheduled jobs or development.
+
+**Dependencies**: `click`, `flask.cli`, `refresh_dispatcher.refresh_all_accounts`.
+```

--- a/docs/backend/app/config/__init__.md
+++ b/docs/backend/app/config/__init__.md
@@ -1,0 +1,8 @@
+## 📘 `__init__.py`
+```markdown
+# Configuration Package
+
+Aggregates configuration helpers and initializes the application logger and
+Plaid API client. Imports environment variables, constant paths, and logging
+setup so other modules can simply `from app.config import logger` and similar.
+```

--- a/docs/backend/app/config/constants.md
+++ b/docs/backend/app/config/constants.md
@@ -1,0 +1,8 @@
+## 📘 `constants.py`
+```markdown
+# Constant Definitions
+
+Defines common filesystem locations such as the data directory, archive
+locations, and theme paths. Builds the database URI and toggles telemetry
+options. Values are derived from `paths.py` and environment variables.
+```

--- a/docs/backend/app/config/environment.md
+++ b/docs/backend/app/config/environment.md
@@ -1,0 +1,8 @@
+## 📘 `environment.py`
+```markdown
+# Environment Variables
+
+Loads `.env` values using `python-dotenv`. Defines keys for Plaid and Teller,
+application mode (`FLASK_ENV`), and other runtime settings. This module centralizes
+all environment lookups so the rest of the code can import settings directly.
+```

--- a/docs/backend/app/config/log_setup.md
+++ b/docs/backend/app/config/log_setup.md
@@ -1,0 +1,9 @@
+## 📘 `log_setup.py`
+```markdown
+# Logger Initialization
+
+Creates a root logger with console and file handlers. Supports an optional
+`VERBOSE` log level which can be toggled via environment variables. Provides a
+`with_verbose_logging` decorator for temporary verbose output. Used by most
+modules via `from app.config import logger`.
+```

--- a/docs/backend/app/config/paths.md
+++ b/docs/backend/app/config/paths.md
@@ -1,0 +1,8 @@
+## 📘 `paths.py`
+```markdown
+# Application Paths
+
+Defines `BASE_DIR` and a mapping of important directories (data, logs, certs,
+archive, etc.). Each path is created if it does not exist so other modules can
+assume directories are present.
+```

--- a/docs/backend/app/config/plaid_config.md
+++ b/docs/backend/app/config/plaid_config.md
@@ -1,0 +1,9 @@
+## 📘 `plaid_config.py`
+```markdown
+# Plaid API Client
+
+Configures the Plaid SDK `ApiClient` based on the selected environment
+(`sandbox`, `development`, etc.) and exposes `plaid_client` for the rest of the
+application. Values like client ID and secret are imported from
+`environment.py`.
+```

--- a/docs/backend/app/extensions.md
+++ b/docs/backend/app/extensions.md
@@ -1,0 +1,7 @@
+## 📘 `extensions.py`
+```markdown
+# Flask Extensions
+
+Currently initializes the `SQLAlchemy` instance used across the app. Additional
+Flask extensions would be instantiated here to keep `__init__.py` thin.
+```

--- a/docs/backend/app/helpers/account_history_helper.md
+++ b/docs/backend/app/helpers/account_history_helper.md
@@ -1,0 +1,10 @@
+## 📘 `account_history_helper.py`
+```markdown
+# Account History Aggregation
+
+Contains `update_account_history()` which sums daily transaction totals for each
+account and persists them in the `AccountHistory` table. This provides the data
+needed for forecasting account balances.
+
+**Dependencies**: `app.extensions.db`, `app.models.Transaction`, `app.models.AccountHistory`.
+```

--- a/docs/backend/app/helpers/account_refresh_dispatcher.md
+++ b/docs/backend/app/helpers/account_refresh_dispatcher.md
@@ -1,0 +1,11 @@
+## 📘 `account_refresh_dispatcher.py`
+```markdown
+# Account Refresh Dispatcher
+
+Provides `refresh_all_accounts()` which iterates through stored accounts and
+triggers synchronization for each via either `teller_helpers` or
+`plaid_helpers`. Runs within an application context and logs progress.
+
+**Dependencies**: `app`, `app.models.Account`, `app.helpers.teller_helpers`,
+`app.helpers.plaid_helpers`, `app.config.logger`.
+```

--- a/docs/backend/app/helpers/helpers.md
+++ b/docs/backend/app/helpers/helpers.md
@@ -1,0 +1,11 @@
+## 📘 `helpers.py`
+```markdown
+# Plaid Helper Utilities
+
+Collection of helper functions for interacting with Plaid and handling API
+responses. Includes token exchange, item info retrieval, category population,
+and link token generation. Also contains placeholder PDF import logic.
+
+**Dependencies**: `requests`, `plaid_api` models, `app.config`, database models,
+`app.sql` modules.
+```

--- a/docs/backend/app/helpers/import_helpers.md
+++ b/docs/backend/app/helpers/import_helpers.md
@@ -1,0 +1,10 @@
+## 📘 `import_helpers.py`
+```markdown
+# Import Helpers
+
+Provides `dispatch_import()` to route uploaded files to the appropriate parser.
+Currently supports CSV transaction imports with a parser tailored for Synchrony
+exports and a placeholder for PDF parsing.
+
+**Dependencies**: `csv`, `datetime`, `app.config.logger`.
+```

--- a/docs/backend/app/helpers/normalize.md
+++ b/docs/backend/app/helpers/normalize.md
@@ -1,0 +1,10 @@
+## 📘 `normalize.py`
+```markdown
+# Amount Normalization
+
+Defines `normalize_amount()` which converts various currency strings or dict
+forms into a standard float. Handles symbols, thousand separators, and infers
+sign based on transaction type.
+
+**Dependencies**: none besides Python stdlib.
+```

--- a/docs/backend/app/helpers/plaid_exchange_helpers.md
+++ b/docs/backend/app/helpers/plaid_exchange_helpers.md
@@ -1,0 +1,11 @@
+## 📘 `plaid_exchange_helpers.py`
+```markdown
+# Plaid Token Exchange
+
+Single function `exchange_public_token_for_product()` that wraps the Plaid
+client to exchange a public token for an access token while tagging the product
+being linked. Intended as a more explicit replacement for a helper in
+`plaid_helpers`.
+
+**Dependencies**: `plaid.Client`, local API key loader.
+```

--- a/docs/backend/app/helpers/plaid_helpers.md
+++ b/docs/backend/app/helpers/plaid_helpers.md
@@ -1,0 +1,11 @@
+## 📘 `plaid_helpers.py`
+```markdown
+# Plaid Integration Helpers
+
+Wrapper functions around the Plaid SDK for common operations like fetching
+accounts, transactions, holdings, and generating link tokens. Also includes a
+helper to store transactions JSON and a deprecated category refresh call.
+
+**Dependencies**: `plaid_api` models, `app.config.plaid_client`,
+`app.sql.forecast_logic`, `app.models.Category`, `app.extensions.db`.
+```

--- a/docs/backend/app/helpers/refresh_dispatcher.md
+++ b/docs/backend/app/helpers/refresh_dispatcher.md
@@ -1,0 +1,11 @@
+## 📘 `refresh_dispatcher.py`
+```markdown
+# Deprecated Refresh Dispatcher
+
+Legacy version of account refresh logic. Duplicates
+`account_refresh_dispatcher.py` and has been superseded by that module and the
+new `sync_service`. Retained for reference but should be removed.
+
+**Dependencies**: `app.models.Account`, `teller_helpers`, `plaid_helpers`,
+`app.config.logger`.
+```

--- a/docs/backend/app/helpers/teller_helpers.md
+++ b/docs/backend/app/helpers/teller_helpers.md
@@ -1,0 +1,11 @@
+## 📘 `teller_helpers.py`
+```markdown
+# Teller API Helpers
+
+Utilities for interacting with the Teller API. Fetches accounts using client
+certificates and stores results in `AccountHistory`. Also handles saving and
+loading Teller tokens from disk.
+
+**Dependencies**: `requests`, `app.config`, `app.sql.forecast_logic`,
+`json` module.
+```

--- a/docs/backend/app/models.md
+++ b/docs/backend/app/models.md
@@ -1,0 +1,11 @@
+## 📘 `models.py`
+```markdown
+# Database Models
+
+Defines the SQLAlchemy models for the application including `Account`,
+`PlaidAccount`, `TellerAccount`, `AccountHistory`, `Transaction`, and related
+entities. Mixes in timestamp columns and sets up relationships used throughout
+services and routes.
+
+**Dependencies**: `flask_sqlalchemy` via `app.extensions.db`.
+```

--- a/docs/backend/app/utils/finance_utils.md
+++ b/docs/backend/app/utils/finance_utils.md
@@ -1,0 +1,8 @@
+## 📘 `finance_utils.py`
+```markdown
+# Finance Utility Functions
+
+Provides helpers to normalize account balances and transaction amounts depending
+on account type, as well as functions to display or transform transaction data.
+Intended for reuse across services and views.
+```

--- a/docs/backend/app/utils/normalization.md
+++ b/docs/backend/app/utils/normalization.md
@@ -1,0 +1,7 @@
+## 📘 `normalization.py`
+```markdown
+# Deprecated Normalization Helpers
+
+Legacy helper for normalizing balances. The file logs a deprecation warning and
+should be replaced with `finance_utils.normalize_account_balance`.
+```

--- a/docs/backend/cron_sync.md
+++ b/docs/backend/cron_sync.md
@@ -1,0 +1,9 @@
+## 📘 `cron_sync.py`
+```markdown
+# Cron Sync Script
+
+Standalone entry point intended to be run on a schedule (e.g., via cron). It
+configures logging to `cron.log` and calls
+`account_refresh_dispatcher.refresh_all_accounts()` to keep account data up to
+date.
+```

--- a/docs/backend/load_transactions.md
+++ b/docs/backend/load_transactions.md
@@ -1,0 +1,8 @@
+## 📘 `load_transactions.py`
+```markdown
+# Synthetic Transaction Loader
+
+Utility script that generates fake transaction data for development. Creates
+randomized transactions for each account over a configurable number of months and
+saves them to the database.
+```

--- a/docs/backend/refreshtest.md
+++ b/docs/backend/refreshtest.md
@@ -1,0 +1,8 @@
+## 📘 `refreshtest.py`
+```markdown
+# Teller Refresh Test Utility
+
+Small script to iterate through stored accounts and refresh data using Teller
+API tokens loaded from disk. Intended for development verification that refresh
+flows work outside of the main application server.
+```

--- a/docs/backend/run.md
+++ b/docs/backend/run.md
@@ -1,0 +1,7 @@
+## 📘 `run.py`
+```markdown
+# Application Entrypoint
+
+Creates the Flask application via `create_app()` and runs it in development mode
+on port 5000. Used when launching the backend directly with Python.
+```

--- a/docs/backend/scripts/map_component_use.md
+++ b/docs/backend/scripts/map_component_use.md
@@ -1,0 +1,8 @@
+## 📘 `map_component_use.py`
+```markdown
+# Component Usage Mapper
+
+Scans the Vue.js `frontend/src/views` directory to report which components are
+referenced in each view file. Helpful for understanding component dependencies
+and identifying unused components.
+```

--- a/docs/backend/temp_migrations/versions/7343a4630d46_adding_sync_cursor_webhook_log_for_plaid.md
+++ b/docs/backend/temp_migrations/versions/7343a4630d46_adding_sync_cursor_webhook_log_for_plaid.md
@@ -1,0 +1,8 @@
+## 📘 `7343a4630d46_adding_sync_cursor_webhook_log_for_plaid.py`
+```markdown
+# Migration: Add Plaid Sync Cursor
+
+Alembic migration script that adds `sync_cursor`, `is_active`, and `last_error`
+columns to the `plaid_accounts` table. Also creates a table for webhook logs.
+Used during the transition to cursor-based transaction sync.
+```

--- a/docs/backend/test.md
+++ b/docs/backend/test.md
@@ -1,0 +1,8 @@
+## 📘 `test.py`
+```markdown
+# Teller Development Utility
+
+Command-line helper that simulates linking an account using provided access
+token information. Fetches accounts from the Teller API and upserts them into the
+database for testing purposes.
+```


### PR DESCRIPTION
## Summary
- document backend core modules under `docs/backend`
- mirror missing Python paths with markdown summaries

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840018e2f3c83298a9216bed49bc2d4