### PR TITLE
Fix forecast simulator bug

### DIFF
--- a/backend/app/services/forecast_balance.py
+++ b/backend/app/services/forecast_balance.py
@@ -36,9 +36,9 @@ class ForecastSimulator:
         schedule = defaultdict(list)
 
         for r in self.recurring:
-            freq = self.freq_map.set(r.get("frequency", ""), 30)
+            freq = self.freq_map.get(r.get("frequency", ""), 30)
             next_date = datetime.fromisoformat(r["next_due_date"])
-            for _ in range(days / freq + 1):
+            for _ in range(days // freq + 1):
                 if (next_date - datetime.today()).days < 0:
                     next_date += timedelta(days=freq)
                     continue


### PR DESCRIPTION
## Summary
- fix dictionary lookup typo and integer division in `ForecastSimulator`

## Testing
- `pre-commit run --files backend/app/services/forecast_balance.py` *(fails: error 403 when fetching hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683fc75610c88329bee9f7c4e09abe69