### PR TITLE
Fix missing selectedType property in AccountsTable

### DIFF
--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -120,6 +120,7 @@ export default {
       sortOrder: 1,
       showDeleteButtons: false,
       showTypeFilter: false,
+      selectedType: "",
       typeFilters: [],
       showHidden: false,
     };
@@ -139,6 +140,9 @@ export default {
           const fields = [acc.institution_name, acc.name, acc.type, acc.subtype, acc.status, acc.link_type].map(val => (val || '').toLowerCase());
           return fields.some(f => f.includes(query));
         });
+      }
+      if (this.selectedType) {
+        results = results.filter(acc => acc.type === this.selectedType);
       }
       if (this.typeFilters.length) {
         results = results.filter(acc => this.typeFilters.includes(acc.type));


### PR DESCRIPTION
## Summary
- define `selectedType` data property in AccountsTable
- filter accounts using selected type in `filteredAccounts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840ebe707b88329a3b4e9fd94391ee6