### PR TITLE
Fix charts data load and optional prop

### DIFF
--- a/backend/app/routes/charts.py
+++ b/backend/app/routes/charts.py
@@ -216,7 +216,7 @@ def get_net_assets():
             }
         )
 
-    return jsonify(data)
+    return jsonify({"status": "success", "data": data}), 200
 
 
 @charts.route("/daily_net", methods=["GET"])

--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -24,7 +24,7 @@ import axios from 'axios'
 const props = defineProps({
   accountSubtype: {
     type: String,
-    required: true,
+    default: '',
   },
 })
 
@@ -43,7 +43,11 @@ const barWidth = (account) => {
 
 const filteredAccounts = computed(() =>
   accounts.value
-    .filter(a => a.subtype?.toLowerCase() === props.accountSubtype.toLowerCase())
+    .filter(a =>
+      props.accountSubtype
+        ? a.subtype?.toLowerCase() === props.accountSubtype.toLowerCase()
+        : true,
+    )
     .sort((a, b) => b.adjusted_balance - a.adjusted_balance)
     .slice(0, 5)
 )


### PR DESCRIPTION
## Summary
- return status flag in `/net_assets` endpoint
- make `AccountsReorderChart`'s subtype prop optional and guard filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411ab2ad3c8329891153dbc5be4d99