### PR TITLE
charts

### DIFF
--- a/backend/app/routes/charts.py
+++ b/backend/app/routes/charts.py
@@ -216,7 +216,7 @@ def get_net_assets():
             }
         )
 
-    return jsonify(data)
+    return jsonify({"status": "success", "data": data}), 200
 
 
 @charts.route("/daily_net", methods=["GET"])

--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -2,8 +2,9 @@
   <div class="chart-container card">
     <h2 class="heading-md">Top {{ accountSubtype }} Accounts</h2>
 
-    <div v-if="filteredAccounts.length" class="bar-chart">
-      <div v-for="account in filteredAccounts" :key="account.id" class="bar-row">
+    <div v-if="positiveAccounts.length" class="bar-chart">
+      <h3 class="subheading">Assets</h3>
+      <div v-for="account in positiveAccounts" :key="`p-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
           <div class="bar-fill" :style="{ width: barWidth(account) }">
@@ -13,7 +14,21 @@
       </div>
     </div>
 
-    <p v-else class="no-data-msg">No accounts available for this subtype.</p>
+    <div v-if="negativeAccounts.length" class="bar-chart">
+      <h3 class="subheading">Liabilities</h3>
+      <div v-for="account in negativeAccounts" :key="`n-${account.id}`" class="bar-row">
+        <span class="bar-label">{{ account.name }}</span>
+        <div class="bar-outer">
+          <div class="bar-fill" :style="{ width: barWidth(account) }">
+            <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p v-if="!positiveAccounts.length && !negativeAccounts.length" class="no-data-msg">
+      No accounts available for this subtype.
+    </p>
   </div>
 </template>
 
@@ -24,7 +39,7 @@ import axios from 'axios'
 const props = defineProps({
   accountSubtype: {
     type: String,
-    required: true,
+    default: '',
   },
 })
 
@@ -36,17 +51,31 @@ const format = val => new Intl.NumberFormat('en-US', {
   currency: 'USD',
 }).format(val)
 
-const barWidth = (account) => {
-  const max = Math.max(...filteredAccounts.value.map(a => Math.abs(a.adjusted_balance)), 1)
-  return `${(Math.abs(account.adjusted_balance) / max) * 100}%`
-}
+const filterSubtype = (acc) =>
+  props.accountSubtype
+    ? (acc.subtype || '').toLowerCase() === props.accountSubtype.toLowerCase()
+    : true
 
-const filteredAccounts = computed(() =>
+const positiveAccounts = computed(() =>
   accounts.value
-    .filter(a => a.subtype?.toLowerCase() === props.accountSubtype.toLowerCase())
+    .filter(acc => !acc.is_hidden && filterSubtype(acc) && acc.adjusted_balance >= 0)
     .sort((a, b) => b.adjusted_balance - a.adjusted_balance)
     .slice(0, 5)
 )
+
+const negativeAccounts = computed(() =>
+  accounts.value
+    .filter(acc => !acc.is_hidden && filterSubtype(acc) && acc.adjusted_balance < 0)
+    .sort((a, b) => a.adjusted_balance - b.adjusted_balance)
+    .slice(0, 5)
+)
+
+const allVisibleAccounts = computed(() => [...positiveAccounts.value, ...negativeAccounts.value])
+
+const barWidth = (account) => {
+  const max = Math.max(...allVisibleAccounts.value.map(a => Math.abs(a.adjusted_balance)), 1)
+  return `${(Math.abs(account.adjusted_balance) / max) * 100}%`
+}
 
 const fetchAccounts = async () => {
   try {
@@ -54,7 +83,7 @@ const fetchAccounts = async () => {
     if (data?.status === 'success') {
       accounts.value = data.accounts.map(acc => ({
         ...acc,
-        adjusted_balance: Math.abs(acc.balance ?? 0),
+        adjusted_balance: acc.balance ?? 0,
       }))
     }
   } catch (err) {
@@ -65,6 +94,10 @@ const fetchAccounts = async () => {
 }
 
 onMounted(fetchAccounts)
+
+defineExpose({
+  refresh: fetchAccounts,
+})
 </script>
 
 
@@ -121,6 +154,13 @@ onMounted(fetchAccounts)
   top: -1.5rem;
   font-size: 0.8rem;
   color: #ccd;
+}
+
+.subheading {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
 }
 
 .no-data-msg {

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -104,6 +104,7 @@ import RefreshControls from "@/components/widgets/RefreshControls.vue";
 export default {
   name: "AccountsTable",
   components: { RefreshControls },
+  emits: ["refresh"],
   props: {
     provider: {
       type: String,
@@ -184,6 +185,7 @@ export default {
         this.error = err.message || "Error fetching accounts.";
       } finally {
         this.loading = false;
+        this.$emit('refresh');
       }
     },
     async deleteAccount(accountId) {

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -37,14 +37,14 @@
         <AssetsBarTrended />
       </div>
       <div class="p-4 bg-[var(--color-bg-secondary)] rounded-lg shadow-md">
-        <AccountsReorderChart />
+        <AccountsReorderChart ref="reorderChart" />
       </div>
     </section>
 
     <!-- Accounts Table -->
     <transition name="slide-horizontal" mode="out-in">
       <div class="card section-container" :key="activeAccountGroup">
-        <AccountsTable :accountGroup="activeAccountGroup" />
+        <AccountsTable :accountGroup="activeAccountGroup" @refresh="refreshCharts" />
       </div>
     </transition>
 
@@ -82,6 +82,11 @@ import TokenUpload from '@/components/forms/TokenUpload.vue'
 
 // ✅ NEW: Import product scope selector
 import PlaidProductScopeSelector from '@/components/forms//PlaidProductScopeSelector.vue'
+
+const reorderChart = ref(null)
+function refreshCharts() {
+  reorderChart.value?.refresh()
+}
 
 // Meta & State
 const userName = import.meta.env.VITE_USER_ID_PLAID || ''


### PR DESCRIPTION
## Summary
- return status flag in `/net_assets` endpoint
- make `AccountsReorderChart`'s subtype prop optional and guard filter
- refresh accounts chart when hiding/unhiding accounts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411ab2ad3c8329891153dbc5be4d99