### PR TITLE
Allow date and category filters for transactions

### DIFF
--- a/backend/app/routes/forecast.py
+++ b/backend/app/routes/forecast.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, request
 
 from app.extensions import db
-from app.services.forecast_orchestrator import ForecastOrchestrator
+import app.services.forecast_orchestrator as forecast_orchestrator
 
 forecast = Blueprint("forecast", __name__)
 
@@ -13,41 +13,13 @@ def get_forecast():
         view_type = request.args.get("view_type", "Month")
         manual_income = float(request.args.get("manual_income", 0))
         liability_rate = float(request.args.get("liability_rate", 0))
-
-        orchestrator = ForecastOrchestrator(db.session)
-        projections = orchestrator.forecast(days=horizon)
-
-        daily_totals = defaultdict(float)
-        for p in projections:
-            day = (
-                p["date"].strftime("%Y-%m-%d")
-                if hasattr(p["date"], "strftime")
-                else str(p["date"])
-            )
-            daily_totals[day] += p.get("balance", 0)
-
-        labels = []
-        forecast_line = []
-        start = datetime.utcnow().date()
-        for i in range(horizon):
-            day = start + timedelta(days=i)
-            labels.append(day.strftime("%b %d"))
-            forecast_line.append(
-                round(daily_totals.get(day.strftime("%Y-%m-%d"), 0), 2)
-            )
-
-        adjustment = manual_income - liability_rate
-        if adjustment:
-            forecast_line = [round(f + adjustment, 2) for f in forecast_line]
-
-        actuals_map = defaultdict(float)
-        history_rows = (
-            db.session.query(AccountHistory)
-            .filter(AccountHistory.date >= start)
-            .filter(AccountHistory.date <= start + timedelta(days=horizon - 1))
-            .all()
+        orchestrator = forecast_orchestrator.ForecastOrchestrator(db.session)
+        payload = orchestrator.build_forecast_payload(
+            user_id="default",
+            view_type=view_type,
+            manual_income=manual_income,
+            liability_rate=liability_rate,
         )
-
         return jsonify(payload), 200
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - defensive
         return jsonify({"error": str(e)}), 500

--- a/backend/app/routes/teller_transactions.py
+++ b/backend/app/routes/teller_transactions.py
@@ -121,8 +121,26 @@ def teller_get_transactions():
     try:
         page = int(request.args.get("page", 1))
         page_size = int(request.args.get("page_size", 15))
+
+        start_date_str = request.args.get("start_date")
+        end_date_str = request.args.get("end_date")
+        category = request.args.get("category")
+
+        start_date = (
+            datetime.strptime(start_date_str, "%Y-%m-%d").date()
+            if start_date_str
+            else None
+        )
+        end_date = (
+            datetime.strptime(end_date_str, "%Y-%m-%d").date() if end_date_str else None
+        )
+
         transactions_list, total = account_logic.get_paginated_transactions(
-            page, page_size
+            page,
+            page_size,
+            start_date=start_date,
+            end_date=end_date,
+            category=category,
         )
         return (
             jsonify(

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -87,6 +87,12 @@ The following route is the **canonical** source of paginated transaction data fo
 GET /api/transactions/get_transactions
 ```
 
+**Query Parameters**
+
+- `start_date` – optional ISO ``YYYY-MM-DD`` start date
+- `end_date` – optional ISO ``YYYY-MM-DD`` end date
+- `category` – optional transaction category filter
+
 This endpoint:
 
 - Serves a unified view of transaction data across all providers

--- a/docs/backend/app/routes/teller_transactions.md
+++ b/docs/backend/app/routes/teller_transactions.md
@@ -21,7 +21,7 @@ Exposes transaction data retrieved from the Teller API. Supports user access to 
 
 - **GET /teller/transactions**
 
-  - **Params:** `start_date`, `end_date`, `account_ids[]` (optional)
+  - **Params:** `start_date`, `end_date`, `category`, `account_ids[]` (optional)
   - **Output:**
     ```json
     [

--- a/tests/test_api_accounts.py
+++ b/tests/test_api_accounts.py
@@ -18,6 +18,8 @@ config_stub.logger = types.SimpleNamespace(
     error=lambda *a, **k: None,
 )
 config_stub.plaid_client = None
+config_stub.TELLER_API_BASE_URL = "https://example.com"
+config_stub.FILES = {}
 config_stub.FLASK_ENV = "test"
 sys.modules["app.config"] = config_stub
 
@@ -31,12 +33,24 @@ extensions_stub = types.ModuleType("app.extensions")
 extensions_stub.db = types.SimpleNamespace()
 sys.modules["app.extensions"] = extensions_stub
 
+# Helpers stub
+helpers_pkg = types.ModuleType("app.helpers")
+teller_helpers_stub = types.ModuleType("app.helpers.teller_helpers")
+teller_helpers_stub.load_tokens = lambda: []
+helpers_pkg.teller_helpers = teller_helpers_stub
+sys.modules["app.helpers"] = helpers_pkg
+sys.modules["app.helpers.teller_helpers"] = teller_helpers_stub
+
 # SQL stub
 sql_pkg = types.ModuleType("app.sql")
 forecast_logic_stub = types.ModuleType("app.sql.forecast_logic")
 forecast_logic_stub.update_account_history = lambda *a, **k: None
+account_logic_stub = types.ModuleType("app.sql.account_logic")
+account_logic_stub.get_paginated_transactions = lambda *a, **k: ([], 0)
 sys.modules["app.sql"] = sql_pkg
 sys.modules["app.sql.forecast_logic"] = forecast_logic_stub
+sys.modules["app.sql.account_logic"] = account_logic_stub
+sql_pkg.account_logic = account_logic_stub
 
 # Utils stub
 utils_pkg = types.ModuleType("app.utils")

--- a/tests/test_api_teller_transactions.py
+++ b/tests/test_api_teller_transactions.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import types
+import importlib.util
+from datetime import datetime
+from flask import Flask
+import pytest
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+# Config stub
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+config_stub.FILES = {}
+config_stub.TELLER_API_BASE_URL = "https://example.com"
+config_stub.FLASK_ENV = "test"
+sys.modules["app.config"] = config_stub
+
+env_stub = types.ModuleType("app.config.environment")
+env_stub.TELLER_WEBHOOK_SECRET = "dummy"
+sys.modules["app.config.environment"] = env_stub
+
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace()
+sys.modules["app.extensions"] = extensions_stub
+
+# Helpers stub
+helpers_pkg = types.ModuleType("app.helpers")
+teller_helpers_stub = types.ModuleType("app.helpers.teller_helpers")
+teller_helpers_stub.load_tokens = lambda: []
+helpers_pkg.teller_helpers = teller_helpers_stub
+sys.modules["app.helpers"] = helpers_pkg
+sys.modules["app.helpers.teller_helpers"] = teller_helpers_stub
+
+# SQL package and logic
+sql_pkg = types.ModuleType("app.sql")
+account_logic_stub = types.ModuleType("app.sql.account_logic")
+
+
+def fake_get_paginated(page, page_size, start_date=None, end_date=None, category=None):
+    return [{"id": "t1"}], 1
+
+
+account_logic_stub.get_paginated_transactions = fake_get_paginated
+sys.modules["app.sql"] = sql_pkg
+sys.modules["app.sql.account_logic"] = account_logic_stub
+sql_pkg.account_logic = account_logic_stub
+
+models_stub = types.ModuleType("app.models")
+models_stub.Account = type("Account", (), {})
+models_stub.Transaction = type("Transaction", (), {})
+sys.modules["app.models"] = models_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "teller_transactions.py")
+spec = importlib.util.spec_from_file_location(
+    "app.routes.teller_transactions", ROUTE_PATH
+)
+teller_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(teller_module)
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(teller_module.teller_transactions, url_prefix="/api/teller")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_get_transactions_filters_passed(client, monkeypatch):
+    captured = {}
+
+    def capture_args(page, page_size, start_date=None, end_date=None, category=None):
+        captured["start_date"] = start_date
+        captured["end_date"] = end_date
+        captured["category"] = category
+        return [{"id": "tx"}], 1
+
+    monkeypatch.setattr(
+        teller_module.account_logic, "get_paginated_transactions", capture_args
+    )
+    resp = client.get(
+        "/api/teller/get_transactions?start_date=2024-01-01&end_date=2024-02-01&category=Food"
+    )
+    assert resp.status_code == 200
+    assert captured["start_date"] == datetime.strptime("2024-01-01", "%Y-%m-%d").date()
+    assert captured["end_date"] == datetime.strptime("2024-02-01", "%Y-%m-%d").date()
+    assert captured["category"] == "Food"


### PR DESCRIPTION
## Summary
- add start_date/end_date/category filters to Teller route
- document optional filters
- fix forecast API to use orchestrator module and simplify logic
- update unit tests and add teller transaction tests

## Testing
- `ruff check --select F --ignore F401,F821 backend/app/routes/forecast.py backend/app/routes/teller_transactions.py tests/test_api_accounts.py tests/test_api_teller_transactions.py`
- `black --check backend/app/routes/forecast.py backend/app/routes/teller_transactions.py tests/test_api_accounts.py tests/test_api_teller_transactions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684201ab02c08329ad193b538f8b4f14