### PR TITLE
Fix tailwind font-sans error

### DIFF
--- a/frontend/src/assets/css/theme.css
+++ b/frontend/src/assets/css/theme.css
@@ -22,4 +22,6 @@
   --color-hover-light: rgba(255, 255, 255, 0.06);
   --color-error: #f87171;
   --color-bg-sec: rgba(255, 255, 255, 0.1);
+  /* Font family */
+  --font-sans: 'Source Code Pro', ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,6 +10,14 @@ export default {
         'neon-purple': '#c084fc',
         'neon-mint': '#2fffa7',
       },
+      fontFamily: {
+        sans: [
+          'Source Code Pro',
+          'ui-sans-serif',
+          'system-ui',
+          'sans-serif',
+        ],
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- define custom font family in Tailwind config
- expose font variable in theme CSS

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68424df51ce08329997820decbf97f2b