### PR TITLE
Fix syntax errors in recurring API JS

### DIFF
--- a/backend/app/utils/finance_utils.py
+++ b/backend/app/utils/finance_utils.py
@@ -26,15 +26,11 @@ def normalize_transaction_amount(amount, account_type):
     # charges appear negative and payments appear positive.
     if account_type in ["credit card", "credit", "loan", "liability"]:
         adjusted = -amt
-        logger.info(
-            f"Normalized transaction amount for credit account to {adjusted}"
-        )
+        logger.info(f"Normalized transaction amount for credit account to {adjusted}")
         return adjusted
 
     # For asset/depository accounts we keep the provider's sign intact.
-    logger.info(
-        f"Preserving transaction amount {amt} for account type {account_type}"
-    )
+    logger.info(f"Preserving transaction amount {amt} for account type {account_type}")
     return amt
 
 

--- a/frontend/src/api/recurring.js
+++ b/frontend/src/api/recurring.js
@@ -1,22 +1,22 @@
 // src/api/recurring.js
-import axios from 'axios'
+import axios from 'axios';
 
 export const getRecurringTransactions = async (accountId) => {
-  const response = await axios.get(`/api/recurring/${accountId}/recurring`)
-  return response.data
-}
+  const response = await axios.get(`/api/recurring/${accountId}/recurring`);
+  return response.data;
+};
 
 export const saveRecurringTransaction = async (accountId, payload) => {
-  const response = await axios.put(`/api/recurring/${accountId}/recurringTx`, payload)
-  return response.data
-}
+  const response = await axios.put(`/api/recurring/${accountId}/recurringTx`, payload);
+  return response.data;
+};
 
 export const createRecurringTransaction = async (transactionId, payload) => {
-  const response = await axios.post(`/api/transactions/${transactionId}/recurring`, payload)
-  return response.data
-}
+  const response = await axios.post(`/api/transactions/${transactionId}/recurring`, payload);
+  return response.data;
+};
 
 export const scanRecurringTransactions = async (accountId) => {
-  const response = await axios.post(`/api/recurring/scan/${accountId}`)
-  return response.data
-}
+  const response = await axios.post(`/api/recurring/scan/${accountId}`);
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- format recurring.js with semicolons to avoid vite import analysis error

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68437966abf483299f3c308da03375ee