### PR TITLE
Add dashboard account snapshot

### DIFF
--- a/frontend/src/components/widgets/AccountSnapshot.vue
+++ b/frontend/src/components/widgets/AccountSnapshot.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="card space-y-4">
+    <div class="flex-between">
+      <h2 class="text-xl font-semibold">Account Snapshot</h2>
+      <button class="btn btn-sm btn-outline" @click="showConfig = !showConfig">
+        {{ showConfig ? 'Done' : 'Configure' }}
+      </button>
+    </div>
+
+    <div v-if="showConfig" class="space-y-2">
+      <p class="text-sm text-gray-400">Select up to 5 accounts</p>
+      <div v-for="acc in accounts" :key="acc.account_id" class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          :id="acc.account_id"
+          v-model="selectedIds"
+          :value="acc.account_id"
+          :disabled="!selectedIds.includes(acc.account_id) && selectedIds.length >= 5"
+        />
+        <label :for="acc.account_id">{{ acc.institution_name || acc.name }}</label>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div
+        v-for="acc in selectedAccounts"
+        :key="acc.account_id"
+        class="p-4 bg-[var(--color-bg-dark)] rounded-lg shadow space-y-1"
+      >
+        <div class="font-semibold">{{ acc.name }}</div>
+        <div class="text-sm text-gray-400">{{ acc.institution_name }}</div>
+        <div class="text-right font-mono text-green-400">
+          {{ formatCurrency(acc.balance) }}
+        </div>
+        <ul v-if="reminders[acc.account_id]?.length" class="mt-2 text-sm space-y-1">
+          <li
+            v-for="rem in reminders[acc.account_id]"
+            :key="rem.description + rem.next_due_date"
+            class="flex justify-between gap-2"
+          >
+            <span class="flex-1">{{ rem.description }}</span>
+            <span class="font-mono">{{ formatCurrency(rem.amount) }}</span>
+            <span class="text-xs text-gray-500">{{ rem.next_due_date }}</span>
+          </li>
+        </ul>
+        <p v-else class="text-sm text-gray-500 mt-2 italic">No upcoming bills</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useSnapshotAccounts } from '@/composables/useSnapshotAccounts.js'
+
+const showConfig = ref(false)
+const { accounts, selectedAccounts, selectedIds, reminders } = useSnapshotAccounts()
+
+function formatCurrency(val) {
+  const num = parseFloat(val || 0)
+  return num.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+  })
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/composables/useSnapshotAccounts.js
+++ b/frontend/src/composables/useSnapshotAccounts.js
@@ -1,0 +1,75 @@
+// src/composables/useSnapshotAccounts.js
+/**
+ * Manage selected accounts for the dashboard snapshot view.
+ * Fetches account data and upcoming recurring reminders.
+ */
+import { ref, computed, watch, onMounted } from 'vue'
+import axios from 'axios'
+
+export function useSnapshotAccounts(maxSelection = 5) {
+  const accounts = ref([])
+  const selectedIds = ref([])
+  const reminders = ref({})
+
+  function initSelection() {
+    const stored = localStorage.getItem('snapshotAccounts')
+    if (stored) {
+      try {
+        selectedIds.value = JSON.parse(stored).slice(0, maxSelection)
+      } catch (e) {
+        selectedIds.value = []
+      }
+    } else if (accounts.value.length) {
+      selectedIds.value = accounts.value.slice(0, maxSelection).map(a => a.account_id)
+    }
+  }
+
+  const loadAccounts = async () => {
+    try {
+      const res = await axios.get('/api/accounts/get_accounts')
+      if (res.data.status === 'success') {
+        accounts.value = res.data.accounts
+        initSelection()
+      }
+    } catch (err) {
+      console.error('Failed to load accounts', err)
+    }
+  }
+
+  const fetchReminders = async () => {
+    const all = {}
+    for (const id of selectedIds.value) {
+      try {
+        const res = await axios.get(`/api/recurring/${id}/recurring`)
+        if (res.data.status === 'success') {
+          all[id] = res.data.reminders
+        }
+      } catch (err) {
+        console.error('Failed to load reminders for', id, err)
+      }
+    }
+    reminders.value = all
+  }
+
+  watch(
+    selectedIds,
+    val => {
+      localStorage.setItem('snapshotAccounts', JSON.stringify(val.slice(0, maxSelection)))
+      fetchReminders()
+    },
+    { deep: true }
+  )
+
+  onMounted(async () => {
+    await loadAccounts()
+    if (selectedIds.value.length) {
+      fetchReminders()
+    }
+  })
+
+  const selectedAccounts = computed(() =>
+    accounts.value.filter(acc => selectedIds.value.includes(acc.account_id))
+  )
+
+  return { accounts, selectedAccounts, selectedIds, reminders, loadAccounts }
+}

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -7,6 +7,7 @@
     </template>
 
     <div class="space-y-8">
+      <AccountSnapshot />
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <BaseCard>
           <DailyNetChart @bar-click="openDayModal" />
@@ -44,6 +45,7 @@ import CategoryBreakdownChart from '@/components/charts/CategoryBreakdownChart.v
 import AccountsTable from '@/components/tables/AccountsTable.vue'
 import TransactionsTable from '@/components/tables/TransactionsTable.vue'
 import TransactionModal from '@/components/modals/TransactionModal.vue'
+import AccountSnapshot from '@/components/widgets/AccountSnapshot.vue'
 import axios from 'axios'
 import { ref } from 'vue'
 


### PR DESCRIPTION
## Summary
- provide `useSnapshotAccounts` composable to manage snapshot selection and reminders
- create `AccountSnapshot` component for quick view of up to 5 accounts and upcoming bills
- insert snapshot component on Dashboard page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68466075c9508329ab46b277865ff5a8