### PR TITLE
Add scan recurring transactions button

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ Base URL: `http://127.0.0.1:5000/api`
 
 Plaid and Teller integrations handled in `/backend/app/helpers/`.
 
+## Running Tests
+
+Ensure backend dependencies are installed before executing the test suite:
+
+```bash
+pip install -r backend/requirements.txt
+pytest -q
+```
+
+
 ---
 
 ## Logs

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -4,10 +4,8 @@ from datetime import datetime
 from app.extensions import db
 from app.models import RecurringTransaction, Account
 from app.sql.forecast_logic import update_account_history
-from app.sql import account_logic
 from app.utils.finance_utils import normalize_account_balance
-from app.helpers.teller_helpers import load_tokens
-from app.config import logger, FILES, TELLER_API_BASE_URL
+from app.config import logger
 
 # Blueprint for generic accounts routes
 accounts = Blueprint("accounts", __name__)
@@ -20,11 +18,16 @@ def refresh_all_accounts():
     Iterates through all accounts and refreshes data based on link_type.
     """
     try:
+        from app.sql import account_logic
+        from app.config import FILES, TELLER_API_BASE_URL
+
         logger.debug("Starting refresh of all linked accounts.")
         accounts = Account.query.all()
         updated_accounts = []
 
         # Load Teller tokens once
+        from app.helpers.teller_helpers import load_tokens
+
         teller_tokens = load_tokens()
 
         for account in accounts:
@@ -89,6 +92,9 @@ def refresh_all_accounts():
 @accounts.route("/<account_id>/refresh", methods=["POST"])
 def refresh_single_account(account_id):
     """Refresh a single account with an optional date range."""
+    from app.sql import account_logic
+    from app.config import FILES, TELLER_API_BASE_URL
+
     data = request.get_json() or {}
     start_date = data.get("start_date")
     end_date = data.get("end_date")
@@ -117,6 +123,8 @@ def refresh_single_account(account_id):
 
     elif account.link_type == "Teller":
         access_token = None
+        from app.helpers.teller_helpers import load_tokens
+
         tokens = load_tokens()
         for t in tokens:
             if t.get("user_id") == account.user_id:

--- a/backend/app/routes/recurring.py
+++ b/backend/app/routes/recurring.py
@@ -224,3 +224,35 @@ def delete_recurring_tx(account_id):
     except Exception as e:
         logger.error(f"Failed to delete recurring transaction: {e}", exc_info=True)
         return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@recurring.route("/scan/<account_id>", methods=["POST"])
+def scan_account_for_recurring(account_id):
+    """Scan account transactions for recurring patterns and return reminders."""
+    try:
+        from app.services.recurring_bridge import RecurringBridge
+
+        transactions = (
+            Transaction.query.with_entities(
+                Transaction.amount, Transaction.description, Transaction.date
+            )
+            .filter_by(account_id=account_id)
+            .all()
+        )
+
+        tx_list = [
+            {
+                "amount": float(t.amount),
+                "description": t.description or "",
+                "date": t.date.strftime("%Y-%m-%d"),
+            }
+            for t in transactions
+        ]
+
+        bridge = RecurringBridge(tx_list)
+        bridge.sync_to_db()
+
+        return get_structured_recurring(account_id)
+    except Exception as e:
+        logger.error(f"Error scanning recurring transactions: {e}", exc_info=True)
+        return jsonify({"status": "error", "message": str(e)}), 500

--- a/frontend/src/api/recurring.js
+++ b/frontend/src/api/recurring.js
@@ -1,18 +1,22 @@
-
 // src/api/recurring.js
-import axios from "axios";
+import axios from 'axios'
 
 export const getRecurringTransactions = async (accountId) => {
-  const response = await axios.get(`/api/recurring/${accountId}/recurring`);
-  return response.data;
-};
+  const response = await axios.get(`/api/recurring/${accountId}/recurring`)
+  return response.data
+}
 
 export const saveRecurringTransaction = async (accountId, payload) => {
-  const response = await axios.put(`/api/recurring/${accountId}/recurringTx`, payload);
-  return response.data;
-};
+  const response = await axios.put(`/api/recurring/${accountId}/recurringTx`, payload)
+  return response.data
+}
 
 export const createRecurringTransaction = async (transactionId, payload) => {
-  const response = await axios.post(`/api/transactions/${transactionId}/recurring`, payload);
-  return response.data;
-};
+  const response = await axios.post(`/api/transactions/${transactionId}/recurring`, payload)
+  return response.data
+}
+
+export const scanRecurringTransactions = async (accountId) => {
+  const response = await axios.post(`/api/recurring/scan/${accountId}`)
+  return response.data
+}

--- a/frontend/src/components/recurring/RecurringTransactionSection.vue
+++ b/frontend/src/components/recurring/RecurringTransactionSection.vue
@@ -3,6 +3,7 @@
     <h2 class="heading-md mb-4">Recurring Transactions</h2>
     <!-- Form Modal Toggle -->
     <button @click="resetForm" class="btn">+ Add Recurring Transaction Rule</button>
+    <button @click="scanForRecurring" class="btn">Scan for Recurring</button>
     <!-- Form -->
     <div v-if="showForm" class="recurring-form">
       <input v-model="transactionId" placeholder="Transaction ID (e.g. tx_abc123)" />
@@ -56,7 +57,8 @@
       <h3 class="subheading">Detected Reminders</h3>
       <ul>
         <li v-for="(reminder, i) in autoReminders" :key="i" class="note">
-          {{ reminder.description }} (${{ reminder.amount.toFixed(2) }}) due on {{ reminder.next_due_date }}
+          {{ reminder.description }} (${{ reminder.amount.toFixed(2) }}) due on
+          {{ reminder.next_due_date }}
         </li>
       </ul>
     </div>
@@ -66,7 +68,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { createRecurringTransaction } from '@/api/recurring'
+import { createRecurringTransaction, scanRecurringTransactions } from '@/api/recurring'
 import axios from 'axios'
 
 const route = useRoute()
@@ -109,9 +111,23 @@ function editRule(rule) {
 async function deleteRule(rule) {
   try {
     await axios.delete(`/api/accounts/${accountId}/recurringTx`, { data: rule })
-    userRules.value = userRules.value.filter(r => r.description !== rule.description || r.amount !== rule.amount)
+    userRules.value = userRules.value.filter(
+      (r) => r.description !== rule.description || r.amount !== rule.amount,
+    )
   } catch (err) {
     console.error('Failed to delete rule:', err)
+  }
+}
+
+async function scanForRecurring() {
+  try {
+    const res = await scanRecurringTransactions(accountId)
+    if (Array.isArray(res?.reminders)) {
+      userRules.value = res.reminders.filter((r) => r.source === 'user')
+      autoReminders.value = res.reminders.filter((r) => r.source === 'auto')
+    }
+  } catch (err) {
+    console.error('Failed to scan recurring transactions:', err)
   }
 }
 
@@ -124,10 +140,12 @@ async function saveRecurring() {
       amount: amount.value,
       frequency: frequency.value,
       next_due_date: nextDueDate.value,
-      notes: notes.value || description.value || 'Untitled Recurring'
+      notes: notes.value || description.value || 'Untitled Recurring',
     }
     await axios.put(`/api/accounts/${accountId}/recurringTx`, payload)
-    userRules.value = userRules.value.filter(r => r.description !== payload.description || r.amount !== payload.amount)
+    userRules.value = userRules.value.filter(
+      (r) => r.description !== payload.description || r.amount !== payload.amount,
+    )
     userRules.value.push(payload)
     resetForm()
   } catch (err) {
@@ -139,7 +157,8 @@ async function saveRecurring() {
 
 const formatAmount = (val) => {
   return new Intl.NumberFormat('en-US', {
-    style: 'currency', currency: 'USD'
+    style: 'currency',
+    currency: 'USD',
   }).format(parseFloat(val || 0))
 }
 
@@ -147,15 +166,14 @@ onMounted(async () => {
   try {
     const res = await axios.get(`/api/accounts/${accountId}/recurring`)
     if (Array.isArray(res.data?.reminders)) {
-      userRules.value = res.data.reminders.filter(r => r.source === 'user')
-      autoReminders.value = res.data.reminders.filter(r => r.source === 'auto')
+      userRules.value = res.data.reminders.filter((r) => r.source === 'user')
+      autoReminders.value = res.data.reminders.filter((r) => r.source === 'auto')
     }
   } catch (err) {
     console.error('Failed to load recurring reminders:', err)
   }
 })
 </script>
-
 
 <style scoped>
 .recurring-manager {

--- a/tests/test_forecast_route.py
+++ b/tests/test_forecast_route.py
@@ -133,6 +133,12 @@ def test_forecast_route(client, monkeypatch):
     monkeypatch.setattr(
         forecast_orchestrator.ForecastOrchestrator, "forecast", dummy_forecast
     )
+    monkeypatch.setattr(
+        sys.modules["app.services.forecast_orchestrator"].ForecastOrchestrator,
+        "forecast",
+        dummy_forecast,
+        raising=False,
+    )
     resp = client.get("/api/forecast")
     assert resp.status_code == 200
     data = resp.get_json()
@@ -150,6 +156,11 @@ def test_forecast_route_missing_data(client, monkeypatch):
 
     monkeypatch.setattr(
         forecast_orchestrator.ForecastOrchestrator,
+        "build_forecast_payload",
+        empty_payload,
+    )
+    monkeypatch.setattr(
+        sys.modules["app.services.forecast_orchestrator"].ForecastOrchestrator,
         "build_forecast_payload",
         empty_payload,
     )


### PR DESCRIPTION
## Summary
- support scanning recurring transactions from the API
- expose a new "Scan for Recurring" button
- lazily import heavy modules in accounts routes
- restore simplified forecast route and update forecast route tests
- document how to run the test suite
- add backend route to scan account transactions for recurring patterns

## Testing
- `black backend/app/routes/accounts.py backend/app/routes/forecast.py backend/app/routes/recurring.py tests/test_forecast_route.py`
- `ruff check --select F --ignore F401,F821 backend/app scripts tests`
- `pytest -q`
- `npx prettier --write frontend/src/api/recurring.js frontend/src/components/recurring/RecurringTransactionSection.vue`


------
https://chatgpt.com/codex/tasks/task_e_6842021942a48329973ae1eda46a4912