### PR TITLE
Add Tailwind text theme

### DIFF
--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -6,7 +6,7 @@
 /* Base styles */
 @layer base {
   body {
-    @import var(--font-sans);
+    font-family: var(--font-sans);
     background-color: var(--color-bg-dark);
     color: var(--color-text-light);
   }

--- a/frontend/src/assets/css/theme.css
+++ b/frontend/src/assets/css/theme.css
@@ -2,8 +2,10 @@
   /* Dark mode colors */
   --color-bg-dark: #1e1e1e;
   --color-bg-secondary: #242424;
-  --color-text-light: #f5f5f5;
-  --color-text-muted: #a1a1aa;
+  --text-primary: #f5f5f5;
+  --color-text-light: var(--text-primary);
+  --text-muted: #a1a1aa;
+  --color-text-muted: var(--text-muted);
   --color-border-secondary: #3f3f46;
   --divider: rgba(255, 255, 255, 0.12);
   --shadow: rgba(0, 0, 0, 0.6);
@@ -23,5 +25,5 @@
   --color-error: #f87171;
   --color-bg-sec: rgba(255, 255, 255, 0.1);
   /* Font family */
-  --var(--font-sans): 'Source Code Pro', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Source Code Pro', ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -1,9 +1,9 @@
 <template>
   <AppLayout>
     <template #header>
-      <h1 class="text-3xl font-bold text-blue-600">Hello {{ userName }}</h1>
-      <h2 class="mt-1 text-gray-600">Today is {{ currentDate }}</h2>
-      <h2 class="mt-1 text-gray-600 italic">and things are looking quite bleak.</h2>
+      <h1 class="text-3xl font-bold text-neon-purple">Hello {{ userName }}</h1>
+      <h2 class="mt-1 text-muted">Today is {{ currentDate }}</h2>
+      <h2 class="mt-1 text-muted italic">and things are looking quite bleak.</h2>
     </template>
 
     <div class="space-y-8">

--- a/frontend/src/views/RecurringTX.vue
+++ b/frontend/src/views/RecurringTX.vue
@@ -2,7 +2,7 @@
   <div class="p-6 space-y-6">
     <!-- App Header -->
     <div class="flex justify-between items-center">
-      <h1 class="text-2xl font-bold text-gray-800">pyNance Dashboard</h1>
+      <h1 class="text-2xl font-bold text-primary">pyNance Dashboard</h1>
       <button
         @click="refreshData"
         class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
@@ -14,26 +14,26 @@
     <!-- Summary Cards -->
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
       <div class="bg-white shadow rounded-lg p-4">
-        <p class="text-sm text-gray-500">Net Worth</p>
+        <p class="text-sm text-muted">Net Worth</p>
         <p class="text-xl font-semibold text-green-600">$24,893.22</p>
       </div>
       <div class="bg-white shadow rounded-lg p-4">
-        <p class="text-sm text-gray-500">YTD Spending</p>
+        <p class="text-sm text-muted">YTD Spending</p>
         <p class="text-xl font-semibold text-red-500">$9,340.12</p>
       </div>
       <div class="bg-white shadow rounded-lg p-4">
-        <p class="text-sm text-gray-500">Total Accounts</p>
-        <p class="text-xl font-semibold text-gray-800">6</p>
+        <p class="text-sm text-muted">Total Accounts</p>
+        <p class="text-xl font-semibold text-primary">6</p>
       </div>
       <div class="bg-white shadow rounded-lg p-4">
-        <p class="text-sm text-gray-500">Upcoming Bills</p>
+        <p class="text-sm text-muted">Upcoming Bills</p>
         <p class="text-xl font-semibold text-yellow-600">$1,203.55</p>
       </div>
     </div>
 
     <!-- Remote Webhook Command Trigger -->
     <div class="bg-white shadow rounded p-6 space-y-4 max-w-md">
-      <h2 class="text-lg font-bold text-gray-800">Remote Command Trigger</h2>
+      <h2 class="text-lg font-bold text-primary">Remote Command Trigger</h2>
 
       <input
         v-model="payload.command"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,18 +9,12 @@ export default {
   theme: {
     extend: {
       colors: {
-        bg: {
-          dark: '#1e1e1e',
-          secondary: '#242424',
-          sec: 'rgba(255, 255, 255, 0.1)',
-        },
-        text: {
-          light: '#f5f5f5',
-          muted: '#a1a1aa',
-        },
-        border: {
-          secondary: '#3f3f46',
-        },
+        'bg-dark': '#1e1e1e',
+        'bg-secondary': '#242424',
+        'bg-sec': 'rgba(255, 255, 255, 0.1)',
+        'text-primary': '#f5f5f5',
+        'text-muted': '#a1a1aa',
+        'border-secondary': '#3f3f46',
         divider: 'rgba(255, 255, 255, 0.12)',
         shadow: 'rgba(0, 0, 0, 0.6)',
         neon: {
@@ -38,21 +32,36 @@ export default {
           light: 'rgba(255, 255, 255, 0.06)',
           glow: 'rgba(192, 132, 252, 0.6)',
         },
-        frosted: {
-          bg: 'rgba(255, 255, 255, 0.08)',
-        },
-        fontFamily: {
-          sans: [
-            'Source Code Pro',
-            'ui-sans-serif',
-            'Inter',
-            'system-ui',
-            'sans-serif',
-          ],
-        },
+        'frosted-bg': 'rgba(255, 255, 255, 0.08)',
       },
+      fontFamily: {
+        sans: [
+          'Source Code Pro',
+          'ui-sans-serif',
+          'Inter',
+          'system-ui',
+          'sans-serif',
+        ],
+      },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            color: theme('colors.text-primary'),
+            a: {
+              color: theme('colors.neon.purple'),
+              '&:hover': {
+                color: theme('colors.accent.purpleHover'),
+              },
+            },
+            h1: { color: theme('colors.text-primary') },
+            h2: { color: theme('colors.text-primary') },
+            h3: { color: theme('colors.text-primary') },
+            strong: { color: theme('colors.text-primary') },
+            code: { color: theme('colors.accent.yellow') },
+          },
+        },
+      }),
     },
-    plugins: [forms, typography, aspectRatio],
-    darkMode: 'class',
-  }
+  },
+  plugins: [forms, typography, aspectRatio],
 }


### PR DESCRIPTION
## Summary
- add text color palette and custom typography to Tailwind config
- expose CSS variables for new text colors
- use text-primary/muted styles in dashboard and recurring views
- fix base font family reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: flask, chromadb, pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_684960a2a9e08329a737c3efc0f47cdd