### PR TITLE
Fix account endpoints & docs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -22,6 +22,7 @@
 ```
 GET    /api/transactions/get_transactions
 GET    /api/accounts/get_accounts
+POST   /api/accounts/refresh_accounts
 DELETE /api/accounts/delete_account
 ```
 

--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -1,13 +1,14 @@
 // src/api/accounts.js
+// Utility functions for interacting with the backend accounts endpoints.
 import axios from 'axios'
 
 export const getAccounts = async () => {
-  const response = await axios.get('/api/accounts/list')
+  const response = await axios.get('/api/accounts/get_accounts')
   return response.data
 }
 
 export const refreshAccounts = async () => {
-  const response = await axios.get('/api/accounts/refresh_accounts')
+  const response = await axios.post('/api/accounts/refresh_accounts')
   return response.data
 }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -15,7 +15,7 @@ export default {
   },
 
   async refreshAccounts() {
-    const response = await apiClient.post("/teller/transactions/refresh_balances");
+    const response = await apiClient.post('/accounts/refresh_accounts');
     return response.data;
   },
 


### PR DESCRIPTION
## Summary
- correct frontend API calls to account routes
- adjust refresh account path in API service
- document unified refresh endpoint in API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a138f49348329a1e54654afeef1ae