### PR TITLE
Unify refresh account endpoint

### DIFF
--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -62,7 +62,7 @@ export default {
     async handlePlaidRefresh() {
       this.isRefreshing = true;
       try {
-        const response = await axios.post("/api/plaid/transactions/refresh_accounts", {
+        const response = await axios.post("/api/accounts/refresh_accounts", {
           user_id: this.user_id,
           start_date: this.startDate,
           end_date: this.endDate,

--- a/frontend/src/components/widgets/RefreshTellerControls.vue
+++ b/frontend/src/components/widgets/RefreshTellerControls.vue
@@ -23,7 +23,7 @@ export default {
     async handleTellerRefresh() {
       this.isRefreshing = true;
       try {
-        const response = await axios.post("/api/teller/transactions/refresh_accounts");
+        const response = await axios.post("/api/accounts/refresh_accounts");
         if (response.data.status === "success") {
           const updated = response.data.updated_accounts;
           alert("Teller accounts refreshed: " + updated.join(", "));

--- a/tests/test_api_plaid_transactions.py
+++ b/tests/test_api_plaid_transactions.py
@@ -1,10 +1,11 @@
+import importlib.util
 import os
 import sys
 import types
-import importlib.util
 from datetime import datetime
-from flask import Flask
+
 import pytest
+from flask import Flask
 
 BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
 sys.path.insert(0, BASE_BACKEND)
@@ -127,9 +128,7 @@ plaid_module.joinedload = lambda *a, **k: None
 @pytest.fixture
 def client():
     app = Flask(__name__)
-    app.register_blueprint(
-        plaid_module.plaid_transactions, url_prefix="/api/plaid/transactions"
-    )
+    app.register_blueprint(plaid_module.plaid_transactions, url_prefix="/api/accounts")
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c
@@ -153,7 +152,7 @@ def test_refresh_accounts_filters_and_dates(client, monkeypatch):
     )
 
     resp = client.post(
-        "/api/plaid/transactions/refresh_accounts",
+        "/api/accounts/refresh_accounts",
         json={
             "user_id": "u1",
             "start_date": "2024-01-01",


### PR DESCRIPTION
## Summary
- point RefreshPlaidControls and RefreshTellerControls to the unified `/api/accounts/refresh_accounts` route
- adjust Plaid refresh test to use the new endpoint path

## Testing
- `pre-commit run --files frontend/src/components/widgets/RefreshPlaidControls.vue frontend/src/components/widgets/RefreshTellerControls.vue tests/test_api_plaid_transactions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a23ccaabc8329be2d587ab703bb3c