### PR TITLE
Refactor chart data fetching

### DIFF
--- a/frontend/src/components/charts/AssetsBarTrended.vue
+++ b/frontend/src/components/charts/AssetsBarTrended.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup>
-import axios from 'axios'
+import api from '@/services/api'
 import { Chart } from 'chart.js/auto'
 import { onMounted, ref, nextTick } from 'vue'
 
@@ -31,7 +31,7 @@ const parseDate = str =>
 
 async function fetchData() {
   try {
-    const { data } = await axios.get('/api/charts/net_assets')
+    const data = await api.fetchNetAssets()
     chartData.value = Array.isArray(data?.data) ? data.data : []
     await nextTick()
     render()

--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -17,7 +17,7 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
 import { Chart } from 'chart.js/auto'
-import axios from 'axios'
+import api from '@/services/api'
 
 const emit = defineEmits(['bar-click'])
 
@@ -38,12 +38,13 @@ watch([startDate, endDate], () => fetchData())
 
 async function fetchData() {
   try {
-    const response = await axios.get('/api/charts/category_breakdown', {
-      params: { start_date: startDate.value, end_date: endDate.value },
+    const response = await api.fetchCategoryBreakdown({
+      start_date: startDate.value,
+      end_date: endDate.value,
     })
 
-    if (response.data.status === 'success') {
-      chartData.value.raw = (response.data.data || []).filter((entry) => {
+    if (response.status === 'success') {
+      chartData.value.raw = (response.data || []).filter((entry) => {
         const isValid = entry && typeof entry.amount === 'number' && !isNaN(entry.amount)
         if (!isValid) console.warn('Skipping invalid entry:', entry)
         return isValid

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import axios from 'axios'
+import api from '@/services/api'
 import { ref, onMounted, nextTick, computed } from 'vue'
 import { Chart } from 'chart.js/auto'
 
@@ -32,9 +32,9 @@ export default {
 
     const fetchData = async () => {
       try {
-        const response = await axios.get('/api/charts/daily_net')
-        if (response.data.status === 'success') {
-          chartData.value = response.data.data
+        const response = await api.fetchDailyNet()
+        if (response.status === 'success') {
+          chartData.value = response.data
           updateChart()
         }
       } catch (error) {

--- a/frontend/src/components/charts/NetIncomeCharts.vue
+++ b/frontend/src/components/charts/NetIncomeCharts.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import api from "@/services/api";
 import { ref, onMounted, nextTick, computed } from "vue";
 import { Chart } from "chart.jsauto";
 
@@ -38,11 +38,11 @@ export default {
 
     const fetchData = async () => {
       try {
-        const response = await axios.get("/api/charts/cash_flow", {
-          params: { granularity: granularity.value },
+        const response = await api.fetchCashFlow({
+          granularity: granularity.value,
         });
-        if (response.data.status === "success") {
-          chartData.value = response.data.data;
+        if (response.status === "success") {
+          chartData.value = response.data;
           updateChart();
         }
       } catch (error) {

--- a/frontend/src/components/charts/NetYearComparisonChart.vue
+++ b/frontend/src/components/charts/NetYearComparisonChart.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import axios from 'axios'
+import api from '@/services/api'
 import { ref, onMounted, nextTick } from 'vue'
 import { Chart } from 'chart.js/auto'
 
@@ -58,7 +58,7 @@ function formatCurrency(val) {
 
 async function fetchData() {
   try {
-    const { data } = await axios.get('/api/charts/net_assets')
+    const data = await api.fetchNetAssets()
     chartData.value = Array.isArray(data?.data) ? data.data : []
     await nextTick()
     buildChart()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -26,13 +26,18 @@ export default {
     return response.data;
   },
 
-  async fetchCategoryBreakdown() {
-    const response = await apiClient.get("/charts/category_breakdown");
+  async fetchCategoryBreakdown(params = {}) {
+    const response = await apiClient.get("/charts/category_breakdown", { params });
     return response.data;
   },
 
   async fetchDailyNet() {
     const response = await apiClient.get("/charts/daily_net");
+    return response.data;
+  },
+
+  async fetchCashFlow(params = {}) {
+    const response = await apiClient.get("/charts/cash_flow", { params });
     return response.data;
   },
 


### PR DESCRIPTION
## Summary
- route all chart API calls through `services/api.js`
- add `fetchCashFlow` function for cash flow charts

## Testing
- `pre-commit run --files frontend/src/services/api.js frontend/src/components/charts/DailyNetChart.vue frontend/src/components/charts/CategoryBreakdownChart.vue frontend/src/components/charts/AssetsBarTrended.vue frontend/src/components/charts/NetYearComparisonChart.vue frontend/src/components/charts/NetIncomeCharts.vue`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a23d09a3083299717f38cb7853093