### PR TITLE
Add Teller sync and webhook docs

### DIFF
--- a/docs/backend/app/routes/teller.md
+++ b/docs/backend/app/routes/teller.md
@@ -65,7 +65,8 @@ Manages authentication and data ingestion from the Teller API. Facilitates linki
 
 ## Related Docs
 
-- [`docs/dataflow/teller_sync.md`](../../dataflow/teller_sync.md)
+- [`docs/dataflow/teller_transaction_sync.md`](../../dataflow/teller_transaction_sync.md)
+- [`docs/dataflow/teller_webhook.md`](../../dataflow/teller_webhook.md)
 - [`docs/integrations/teller_config.md`](../../integrations/teller_config.md)
 ````
 

--- a/docs/dataflow/teller_transaction_sync.md
+++ b/docs/dataflow/teller_transaction_sync.md
@@ -1,0 +1,20 @@
+# 📈 Teller Transaction Sync
+
+Describes how Teller transactions are retrieved and stored.
+
+## Flow Overview
+
+1. Routes in `teller_transactions.py` call `account_logic.refresh_data_for_teller_account`.
+2. `refresh_data_for_teller_account` uses `fetch_url_with_backoff` to request account balances and `/transactions` from the Teller API using the stored certificate pair and access token.
+3. Each returned transaction is inserted or updated in the `Transaction` table. User-modified fields are preserved.
+4. The latest balance for the account is recorded in both `Account` and `AccountHistory` tables.
+
+Raw responses may be dumped to a temporary file for inspection during debugging.
+
+## Key Modules
+
+- `backend/app/sql/account_logic.py`
+- `backend/app/routes/teller_transactions.py`
+- `backend/app/helpers/teller_helpers.py`
+
+These components coordinate to maintain an up‑to‑date ledger of Teller activity.

--- a/docs/dataflow/teller_webhook.md
+++ b/docs/dataflow/teller_webhook.md
@@ -1,0 +1,19 @@
+# 📢 Teller Webhook Processing
+
+This document outlines how incoming Teller webhook events are handled.
+
+## Processing Steps
+
+1. Webhooks arrive at `/api/webhooks/teller`.
+2. `teller_webhook.py` verifies the `Teller-Signature` header using `TELLER_WEBHOOK_SECRET`.
+3. The account is looked up and its stored access token is loaded.
+4. `refresh_data_for_teller_account` is invoked to pull the latest balances and transactions.
+5. If updates are made, the account's `last_refreshed` timestamp is saved.
+
+Unsupported events return a simple OK response so Teller considers them delivered.
+
+## Key Modules
+
+- `backend/app/routes/teller_webhook.py`
+- `backend/app/sql/account_logic.py`
+- `backend/app/helpers/teller_helpers.py`

--- a/docs/integrations/teller_config.md
+++ b/docs/integrations/teller_config.md
@@ -1,0 +1,23 @@
+# ⚙️ Teller Configuration
+
+This page summarizes the environment variables and certificate files required to enable Teller integration.
+
+## Environment Variables
+
+- `TELLER_APP_ID` – application ID registered with Teller. Used by the frontend when launching the link flow and passed to backend routes for API requests.
+- `TELLER_WEBHOOK_SECRET` – secret used to validate Teller webhook signatures. If not set, the webhook route is disabled.
+
+These variables are loaded by `backend/app/config/environment.py` from your `.env` file.
+
+## Certificate Placement
+
+Teller requests are authenticated with mutual TLS certificates. Place your certificate files inside `backend/app/certs/`:
+
+```
+backend/app/certs/
+  ├── certificate.pem
+  └── private_key.pem
+```
+
+The backend looks for these filenames when calling the Teller API.
+


### PR DESCRIPTION
## Summary
- document Teller transaction sync flow
- document Teller webhook processing
- explain Teller config env vars and certificate locations
- link Teller route docs to new pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a6ff6ea588329b12a2d3157871dfe