### PR TITLE
Accept user_id from request body or session

### DIFF
--- a/backend/app/routes/teller.py
+++ b/backend/app/routes/teller.py
@@ -5,7 +5,7 @@ import json
 import requests
 from app.config import FILES, TELLER_APP_ID, logger
 from app.helpers.teller_helpers import load_tokens  # Import helper
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, session
 
 # File paths and API endpoints
 TELLER_DOT_KEY = FILES["TELLER_DOT_KEY"]
@@ -31,11 +31,14 @@ def generate_link_token():
     """Generate a Teller link token for the provided ``user_id``."""
     try:
         logger.debug("Generating Teller link token.")
-        data = request.get_json() or {}
-        user_id = data.get("user_id")
+        data = request.get_json(silent=True) or {}
+        user_id = data.get("user_id") or session.get("user_id")
         if not user_id:
-            logger.warning("Missing user_id in request body")
-            return jsonify({"status": "error", "message": "user_id is required"}), 400
+            logger.warning("Missing user_id in request body or session")
+            return (
+                jsonify({"status": "error", "message": "user_id is required"}),
+                400,
+            )
 
         url = f"{TELLER_API_BASE_URL}/link_tokens"
         headers = {

--- a/docs/backend/app/routes/teller.md
+++ b/docs/backend/app/routes/teller.md
@@ -28,6 +28,7 @@ Manages authentication and data ingestion from the Teller API. Facilitates linki
       "user_id": "user123"
     }
     ```
+    - `user_id` *(string, required)* – omitted will fall back to session
   - **Output:** `{ link_token: str }`
 
 - **POST /teller/link**

--- a/tests/test_api_teller_link.py
+++ b/tests/test_api_teller_link.py
@@ -12,44 +12,46 @@ sys.modules.pop("app", None)
 
 # Config stub
 config_stub = types.ModuleType("app.config")
-config_stub.logger = types.SimpleNamespace(
+config_stub.logger = types.SimpleNamespace(  # type: ignore[attr-defined]
     info=lambda *a, **k: None,
     debug=lambda *a, **k: None,
     warning=lambda *a, **k: None,
     error=lambda *a, **k: None,
 )
-config_stub.FILES = {
+config_stub.FILES = {  # type: ignore[attr-defined]
     "TELLER_DOT_KEY": "dummy",
     "TELLER_DOT_CERT": "",
     "TELLER_ACCOUNTS": "",
 }
-config_stub.TELLER_APP_ID = "app123"
-config_stub.TELLER_API_BASE_URL = "https://example.com"
-config_stub.FLASK_ENV = "test"
+config_stub.TELLER_APP_ID = "app123"  # type: ignore[attr-defined]
+config_stub.TELLER_API_BASE_URL = "https://example.com"  # type: ignore[attr-defined]
+config_stub.FLASK_ENV = "test"  # type: ignore[attr-defined]
 sys.modules["app.config"] = config_stub
 
 # Helper stub
 helpers_pkg = types.ModuleType("app.helpers")
-helpers_pkg.teller_helpers = types.ModuleType("app.helpers.teller_helpers")
-helpers_pkg.teller_helpers.load_tokens = lambda: []
+helpers_pkg.teller_helpers = types.ModuleType("app.helpers.teller_helpers")  # type: ignore[attr-defined]
+helpers_pkg.teller_helpers.load_tokens = lambda: []  # type: ignore[attr-defined]
 sys.modules["app.helpers"] = helpers_pkg
 sys.modules["app.helpers.teller_helpers"] = helpers_pkg.teller_helpers
 
 # Extensions stub
 extensions_stub = types.ModuleType("app.extensions")
-extensions_stub.db = types.SimpleNamespace()
+extensions_stub.db = types.SimpleNamespace()  # type: ignore[attr-defined]
 sys.modules["app.extensions"] = extensions_stub
 
 ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "teller.py")
 spec = importlib.util.spec_from_file_location("app.routes.teller", ROUTE_PATH)
 teller_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(teller_module)
+spec.loader.exec_module(teller_module)  # type: ignore[union-attr]
+
 
 @pytest.fixture
 def client():
     app = Flask(__name__)
     app.register_blueprint(teller_module.link_teller, url_prefix="/api/teller")
     app.config["TESTING"] = True
+    app.secret_key = "test"
     with app.test_client() as c:
         yield c
 
@@ -77,3 +79,29 @@ def test_generate_link_token_sends_user_id(client, monkeypatch):
     assert captured["payload"]["user_id"] == "u1"
     data = resp.get_json()
     assert data["link_token"] == "abc"
+
+
+def test_generate_link_token_uses_session(client, monkeypatch):
+    captured = {}
+
+    class DummyResp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"link_token": "xyz"}
+
+        text = "{}"
+
+    def fake_post(url, headers=None, json=None):
+        captured["payload"] = json
+        return DummyResp()
+
+    monkeypatch.setattr(teller_module.requests, "post", fake_post)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = "sess1"
+
+    resp = client.post("/api/teller/generate_link_token")
+    assert resp.status_code == 200
+    assert captured["payload"]["user_id"] == "sess1"


### PR DESCRIPTION
## Summary
- allow Teller link token route to pull `user_id` from request body or session
- document `user_id` requirement
- expand teller link route tests to cover session-based fallback

## Testing
- `black backend/app/routes/teller.py tests/test_api_teller_link.py`
- `isort backend/app/routes/teller.py tests/test_api_teller_link.py`
- `ruff check backend/app/routes/teller.py tests/test_api_teller_link.py`
- `pytest -q tests/test_api_teller_link.py`

------
https://chatgpt.com/codex/tasks/task_e_684a955701c08329b706aa59a65ed6a2