### PR TITLE
Add Teller documentation for sync and webhook flows

### DIFF
--- a/docs/backend/app/routes/teller.md
+++ b/docs/backend/app/routes/teller.md
@@ -76,7 +76,7 @@ Manages authentication and data ingestion from the Teller API. Facilitates linki
 
 ## Related Docs
 
-- [`docs/dataflow/teller_sync.md`](../../dataflow/teller_sync.md)
+ - [`docs/dataflow/teller_transaction_sync.md`](../../dataflow/teller_transaction_sync.md)
 - [`docs/integrations/teller_config.md`](../../integrations/teller_config.md)
 ````
 

--- a/docs/dataflow/teller_transaction_sync.md
+++ b/docs/dataflow/teller_transaction_sync.md
@@ -1,0 +1,24 @@
+# 📨 Teller Transaction Sync
+
+**Module:** `app.sql.account_logic.refresh_data_for_teller_account`
+**Purpose:** Fetch balances and transactions from Teller and persist them.
+
+---
+
+## 🔄 Flow Overview
+
+1. Tokens are loaded via `helpers.teller_helpers.load_tokens`.
+2. For each account token, the service requests:
+   - `GET /accounts/<id>/balances`
+   - `GET /accounts/<id>/transactions`
+   using the certificate pair in `backend/app/certs/`.
+3. Balances update `Account.balance` and create an `AccountHistory` record for the current day.
+4. Transactions are inserted or updated in the `Transaction` table. Records modified by users are preserved.
+5. Called by refresh routes and the Teller webhook to keep data current.
+
+## 🗄️ Storage Details
+
+- **Balances:** stored on `Account` and mirrored in `AccountHistory`.
+- **Transactions:** stored in `Transaction` with amount, date, description and merchant info.
+
+This sync routine ensures the database reflects the latest Teller data.

--- a/docs/dataflow/teller_webhook.md
+++ b/docs/dataflow/teller_webhook.md
@@ -1,0 +1,16 @@
+# 📣 Teller Webhook Processing
+
+**Module:** `app.routes.teller_webhook`
+**Purpose:** React to Teller events and trigger account refresh.
+
+---
+
+## 🔔 Workflow
+
+1. `verify_signature` checks the `Teller-Signature` header using `TELLER_WEBHOOK_SECRET`.
+2. Payload is parsed for `event` and `account_id`.
+3. The matching `Account` and access token are looked up via `teller_helpers.load_tokens`.
+4. `account_logic.refresh_data_for_teller_account` fetches the latest balances and transactions.
+5. On success, `account.last_refreshed` is updated and a simple `{"status": "ok"}` is returned.
+
+Webhook events keep Teller data in sync without manual intervention.

--- a/docs/integrations/teller_config.md
+++ b/docs/integrations/teller_config.md
@@ -1,0 +1,22 @@
+# 🔧 Teller Configuration
+
+This integration relies on a few environment variables and TLS certificates.
+
+## Environment Variables
+
+- `TELLER_APP_ID` – your Teller application ID used when initiating Teller Link.
+- `TELLER_WEBHOOK_SECRET` – secret for verifying webhook signatures.
+
+These are loaded in `app.config.environment` and typically defined in `backend/.env`.
+
+## Certificates
+
+Place your client certificate and private key in `backend/app/certs/`:
+
+```
+backend/app/certs/
+  ├── certificate.pem
+  └── private_key.pem
+```
+
+The sync logic and webhook routes reference these paths when making HTTPS requests to Teller.


### PR DESCRIPTION
## Summary
- document how Teller transactions are synchronized and webhooks handled
- explain Teller environment variables and certificate placement
- update route docs to link to new references

## Testing
- `pre-commit run --files docs/dataflow/teller_transaction_sync.md docs/dataflow/teller_webhook.md docs/integrations/teller_config.md docs/backend/app/routes/teller.md docs/backend/app/routes/teller_transactions.md docs/backend/app/routes/teller_webhook.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a955786cc8329a72b5e166693b3f4