### PR TITLE
Update AccountsTable filter UI

### DIFF
--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -1,3 +1,7 @@
+<!--
+  Displays user accounts in a sortable table with search and type filtering.
+  Type filtering uses a dynamic multi-select derived from account data.
+-->
 <template>
   <div class="accounts-section">
     <div class="accounts-table">
@@ -35,13 +39,14 @@
 
       <!-- Type Filter Slide -->
       <div class="type-filter-row" :class="{ 'slide-in': showTypeFilter }">
-        <select v-model="selectedType" class="filter-input">
-          <option value="">All Types</option>
-          <option value="checking">Checking</option>
-          <option value="savings">Savings</option>
-          <option value="credit">Credit</option>
-          <option value="loan">Loan</option>
-          <option value="investment">Investment</option>
+        <select multiple v-model="typeFilters" class="filter-input">
+          <option
+            v-for="type in uniqueTypes"
+            :key="type"
+            :value="type"
+          >
+            {{ formatType(type) }}
+          </option>
         </select>
       </div>
 
@@ -134,7 +139,6 @@ export default {
       sortOrder: 1,
       showDeleteButtons: false,
       showTypeFilter: false,
-      selectedType: "",
       typeFilters: [],
       showHidden: false,
       controlsVisible: false,
@@ -155,9 +159,6 @@ export default {
           const fields = [acc.institution_name, acc.name, acc.type, acc.subtype, acc.status, acc.link_type].map(val => (val || '').toLowerCase());
           return fields.some(f => f.includes(query));
         });
-      }
-      if (this.selectedType) {
-        results = results.filter(acc => acc.type === this.selectedType);
       }
       if (this.typeFilters.length) {
         results = results.filter(acc => this.typeFilters.includes(acc.type));


### PR DESCRIPTION
## Summary
- enable multi-select filter for account types in `AccountsTable`

## Testing
- `pre-commit run --files frontend/src/components/tables/AccountsTable.vue`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run lint` *(fails: 7 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684a97bd5328832989efa5ce58faa959