### PR TITLE
feat(frontend): improve top accounts fetching

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -211,6 +211,7 @@ def get_accounts():
                         "institution_name": a.institution_name,
                         "type": a.type,
                         "balance": normalized_balance,
+                        "adjusted_balance": normalized_balance,
                         "subtype": a.subtype,
                         "link_type": a.link_type,
                         "last_refreshed": last_refreshed,

--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup>
-import { toRef } from 'vue'
+import { toRef, onMounted } from 'vue'
 import { useTopAccounts } from '@/composables/useTopAccounts'
 
 const props = defineProps({
@@ -50,6 +50,8 @@ const format = val => new Intl.NumberFormat('en-US', {
 
 const { positiveAccounts, negativeAccounts, allVisibleAccounts, fetchAccounts } =
   useTopAccounts(toRef(props, 'accountSubtype'))
+
+onMounted(fetchAccounts)
 
 const barWidth = account => {
   const max = Math.max(

--- a/frontend/src/composables/__tests__/useTopAccounts.cy.js
+++ b/frontend/src/composables/__tests__/useTopAccounts.cy.js
@@ -1,0 +1,35 @@
+import { defineComponent } from 'vue'
+import { useTopAccounts } from '../useTopAccounts'
+
+const TestComponent = defineComponent({
+  template: '<div><div class="row" v-for="acc in positiveAccounts" :key="acc.id">{{ acc.name }}</div></div>',
+  setup() {
+    const { positiveAccounts } = useTopAccounts()
+    return { positiveAccounts }
+  },
+})
+
+describe('useTopAccounts', () => {
+  it('builds account data from API', () => {
+    cy.intercept('GET', '/api/accounts/get_accounts*', {
+      statusCode: 200,
+      body: {
+        status: 'success',
+        accounts: [
+          {
+            id: 1,
+            name: 'Checking',
+            subtype: 'checking',
+            balance: 100,
+            adjusted_balance: 100,
+            is_hidden: false,
+          },
+        ],
+      },
+    }).as('getAccounts')
+
+    cy.mount(TestComponent)
+    cy.wait('@getAccounts')
+    cy.get('.row').should('have.length', 1).and('contain', 'Checking')
+  })
+})

--- a/frontend/src/composables/useTopAccounts.js
+++ b/frontend/src/composables/useTopAccounts.js
@@ -33,7 +33,9 @@ export function useTopAccounts(subtype = '') {
   const fetchAccounts = async () => {
     loading.value = true
     try {
-      const { data } = await axios.get('/api/accounts/get_accounts')
+      const { data } = await axios.get(
+        '/api/accounts/get_accounts?include_hidden=true'
+      )
       if (data?.status === 'success') {
         accounts.value = data.accounts.map(acc => ({
           ...acc,
@@ -41,7 +43,7 @@ export function useTopAccounts(subtype = '') {
         }))
       }
     } catch (err) {
-      console.error('Failed to load accounts:', err)
+      console.error('Failed to load accounts in useTopAccounts:', err)
     } finally {
       loading.value = false
     }


### PR DESCRIPTION
## Summary
- pass include_hidden param when loading top accounts
- expose adjusted balance from backend
- ensure AccountsReorderChart triggers fetch on mount
- add Cypress test for useTopAccounts composable

## Testing
- `pre-commit run --files backend/app/routes/accounts.py` *(fails: ModuleNotFoundError: No module named 'app')*
- `pytest -q` *(fails: missing dependencies)*
- `npm run lint` *(fails: 7 errors)*
- `npm run test:unit` *(fails: dependency Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b31b2a4f08329a9c89111813c8883