### PR TITLE
Add asset/liability gradients

### DIFF
--- a/docs/frontend/THEMING_GUIDE.md
+++ b/docs/frontend/THEMING_GUIDE.md
@@ -69,9 +69,10 @@ all of them:
 | `--hover-bg` | hover background for buttons |
 | `--hover-glow` | drop shadow for hover effects |
 
-Additional variables such as `--color-accent-magenta` or `--bar-gradient-end`
-are used by specific charts and widgets. Review the default theme for the full
-list.
+Additional variables such as `--color-accent-magenta`, `--bar-gradient-end`,
+`--asset-gradient-start`/`--asset-gradient-end`, and
+`--liability-gradient-start`/`--liability-gradient-end` are used by specific
+charts and widgets. Review the default theme for the full list.
 
 ## How the Theme Loads
 

--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -7,7 +7,7 @@
       <div v-for="account in positiveAccounts" :key="`p-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div class="bar-fill bar-fill-asset" :style="{ width: barWidth(account) }">
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -19,7 +19,7 @@
       <div v-for="account in negativeAccounts" :key="`n-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div class="bar-fill bar-fill-liability" :style="{ width: barWidth(account) }">
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -108,10 +108,25 @@ defineExpose({
 
 .bar-fill {
   height: 100%;
-  background: linear-gradient(to right, #aad4ff, #78baff);
   border-radius: 6px;
   transition: width 0.6s ease-out;
   position: relative;
+}
+
+.bar-fill-asset {
+  background: linear-gradient(
+    to right,
+    var(--asset-gradient-start),
+    var(--asset-gradient-end)
+  );
+}
+
+.bar-fill-liability {
+  background: linear-gradient(
+    to right,
+    var(--liability-gradient-start),
+    var(--liability-gradient-end)
+  );
 }
 
 .bar-value {

--- a/frontend/src/styles/themes/dark-frost.css
+++ b/frontend/src/styles/themes/dark-frost.css
@@ -35,6 +35,10 @@
 
   --button-bg: #2a303c;
   --link-hover-color: var(--neon-mint);
+  --asset-gradient-start: #aad4ff;
+  --asset-gradient-end: #78baff;
+  --liability-gradient-start: #ffc0cb;
+  --liability-gradient-end: #ff6a6a;
   --bar-gradient-end: #ff2cb1;
   --accent-yellow-soft: rgba(249, 248, 113, 0.5);
 }

--- a/frontend/src/styles/themes/neon-dark.css
+++ b/frontend/src/styles/themes/neon-dark.css
@@ -35,6 +35,10 @@
 
   --button-bg: #2a303c;
   --link-hover-color: var(--neon-mint);
+  --asset-gradient-start: #aad4ff;
+  --asset-gradient-end: #78baff;
+  --liability-gradient-start: #ffc0cb;
+  --liability-gradient-end: #ff6a6a;
   --bar-gradient-end: #ff2cb1;
   --accent-yellow-soft: rgba(249, 248, 113, 0.5);
 }


### PR DESCRIPTION
## Summary
- add asset and liability gradient CSS variables
- apply asset/liability classes to account bar fills
- document new theme variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ba69d5c4083299a99e304967b91f3