### PR TITLE
Use api.getAccounts for dropdowns

### DIFF
--- a/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
+++ b/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
@@ -1,0 +1,24 @@
+import RefreshPlaidControls from '../widgets/RefreshPlaidControls.vue'
+import { mount } from 'cypress/vue'
+
+describe('RefreshPlaidControls', () => {
+  it('loads accounts into dropdown', () => {
+    cy.intercept('GET', '/accounts/get_accounts*', {
+      statusCode: 200,
+      body: {
+        status: 'success',
+        accounts: [
+          { account_id: '1', name: 'Checking' },
+          { account_id: '2', name: 'Savings' }
+        ]
+      }
+    }).as('getAccounts')
+
+    mount(RefreshPlaidControls)
+    cy.wait('@getAccounts')
+    cy.contains('button', 'Select Accounts').click()
+    cy.get('.dropdown-menu label').should('have.length', 2)
+    cy.get('.dropdown-menu').contains('Checking')
+    cy.get('.dropdown-menu').contains('Savings')
+  })
+})

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -116,7 +116,6 @@
 
 
 <script>
-import axios from "axios";
 import api from "@/services/api";
 import accountLinkApi from "@/api/accounts_link";
 
@@ -188,11 +187,9 @@ export default {
       this.loading = true;
       this.error = "";
       try {
-        const response = await axios.get(
-          "/api/accounts/get_accounts?include_hidden=true"
-        );
-        if (response.data?.status === "success") {
-          this.accounts = response.data.accounts || [];
+        const response = await api.getAccounts({ include_hidden: true });
+        if (response.status === "success") {
+          this.accounts = response.accounts || [];
         } else {
           this.error = "Error fetching accounts.";
         }

--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import api from "@/services/api";
 export default {
   name: "RefreshPlaidControls",
   data() {
@@ -59,34 +59,38 @@ export default {
     },
     async loadAccounts() {
       try {
-        const resp = await axios.get("/api/accounts/get_accounts");
-        if (resp.data?.accounts) {
-          this.accounts = resp.data.accounts;
+        const resp = await api.getAccounts();
+        if (resp?.status === "success" && resp.accounts) {
+          this.accounts = resp.accounts;
         } else {
           this.accounts = [];
+          this.message = "Error fetching accounts.";
+          this.messageType = "error";
         }
       } catch (err) {
         console.error("Failed to load accounts", err);
+        this.message = "Failed to load accounts: " + err.message;
+        this.messageType = "error";
       }
     },
     async handlePlaidRefresh() {
       this.dropdownOpen = false;
       this.isRefreshing = true;
       try {
-        const response = await axios.post("/api/accounts/refresh_accounts", {
+        const response = await api.refreshAccounts({
           user_id: this.user_id,
           start_date: this.startDate,
           end_date: this.endDate,
           account_ids: this.selectedAccounts,
         });
-        if (response.data.status === "success") {
+        if (response.status === "success") {
           this.message =
             "Plaid accounts refreshed: " +
-            response.data.updated_accounts.join(", ");
+            (response.updated_accounts || []).join(", ");
           this.messageType = "success";
         } else {
           this.message =
-            "Error refreshing Plaid accounts: " + response.data.message;
+            "Error refreshing Plaid accounts: " + response.message;
           this.messageType = "error";
         }
       } catch (err) {

--- a/frontend/src/components/widgets/RefreshTellerControls.vue
+++ b/frontend/src/components/widgets/RefreshTellerControls.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import api from "@/services/api";
 export default {
   name: "RefreshTellerControls",
   data() {
@@ -48,27 +48,28 @@ export default {
     },
     async loadAccounts() {
       try {
-        const resp = await axios.get("/api/accounts/get_accounts");
-        if (resp.data?.accounts) {
-          this.accounts = resp.data.accounts;
+        const resp = await api.getAccounts();
+        if (resp?.status === "success" && resp.accounts) {
+          this.accounts = resp.accounts;
         }
       } catch (err) {
         console.error("Failed to load accounts", err);
+        alert("Failed to load accounts: " + err.message);
       }
     },
     async handleTellerRefresh() {
       this.isRefreshing = true;
       try {
-        const response = await axios.post("/api/accounts/refresh_accounts", {
+        const response = await api.refreshAccounts({
           start_date: this.startDate,
           end_date: this.endDate,
           account_ids: this.selectedAccounts,
         });
-        if (response.data.status === "success") {
-          const updated = response.data.updated_accounts;
+        if (response.status === "success") {
+          const updated = response.updated_accounts;
           alert("Teller accounts refreshed: " + updated.join(", "));
         } else {
-          alert("Error refreshing Teller accounts: " + response.data.message);
+          alert("Error refreshing Teller accounts: " + response.message);
         }
       } catch (err) {
         console.error("Error refreshing Teller accounts:", err);

--- a/frontend/src/composables/__tests__/useTopAccounts.cy.js
+++ b/frontend/src/composables/__tests__/useTopAccounts.cy.js
@@ -11,7 +11,7 @@ const TestComponent = defineComponent({
 
 describe('useTopAccounts', () => {
   it('builds account data from API', () => {
-    cy.intercept('GET', '/api/accounts/get_accounts*', {
+    cy.intercept('GET', '/accounts/get_accounts*', {
       statusCode: 200,
       body: {
         status: 'success',

--- a/frontend/src/composables/useSnapshotAccounts.js
+++ b/frontend/src/composables/useSnapshotAccounts.js
@@ -4,6 +4,7 @@
  * Fetches account data and upcoming recurring reminders.
  */
 import { ref, computed, watch, onMounted } from 'vue'
+import api from '@/services/api'
 import axios from 'axios'
 
 export function useSnapshotAccounts(maxSelection = 5) {
@@ -16,7 +17,7 @@ export function useSnapshotAccounts(maxSelection = 5) {
     if (stored) {
       try {
         selectedIds.value = JSON.parse(stored).slice(0, maxSelection)
-      } catch (e) {
+      } catch {
         selectedIds.value = []
       }
     } else if (accounts.value.length) {
@@ -26,9 +27,9 @@ export function useSnapshotAccounts(maxSelection = 5) {
 
   const loadAccounts = async () => {
     try {
-      const res = await axios.get('/api/accounts/get_accounts')
-      if (res.data.status === 'success') {
-        accounts.value = res.data.accounts
+      const res = await api.getAccounts()
+      if (res.status === 'success') {
+        accounts.value = res.accounts
         initSelection()
       }
     } catch (err) {

--- a/frontend/src/composables/useTopAccounts.js
+++ b/frontend/src/composables/useTopAccounts.js
@@ -1,5 +1,5 @@
 import { ref, computed, onMounted, isRef } from 'vue'
-import axios from 'axios'
+import api from '@/services/api'
 
 export function useTopAccounts(subtype = '') {
   const subtypeRef = isRef(subtype) ? subtype : ref(subtype)
@@ -33,9 +33,7 @@ export function useTopAccounts(subtype = '') {
   const fetchAccounts = async () => {
     loading.value = true
     try {
-      const { data } = await axios.get(
-        '/api/accounts/get_accounts?include_hidden=true'
-      )
+      const data = await api.getAccounts({ include_hidden: true })
       if (data?.status === 'success') {
         accounts.value = data.accounts.map(acc => ({
           ...acc,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -9,8 +9,8 @@ const apiClient = axios.create({
 });
 
 export default {
-  async getAccounts() {
-    const response = await apiClient.get(`/accounts/get_accounts`);
+  async getAccounts(params = {}) {
+    const response = await apiClient.get('/accounts/get_accounts', { params });
     return response.data;
   },
 


### PR DESCRIPTION
## Summary
- fetch accounts via centralized API service
- show error messages when loading accounts fails
- update intercept paths in unit tests
- add Cypress test for RefreshPlaidControls dropdown

## Testing
- `npx eslint src/components/widgets/RefreshPlaidControls.vue src/components/widgets/RefreshTellerControls.vue src/components/tables/AccountsTable.vue src/composables/useSnapshotAccounts.js src/composables/useTopAccounts.js src/composables/__tests__/useTopAccounts.cy.js src/components/__tests__/RefreshPlaidControls.cy.js --fix`
- `npm run test:unit -- --spec "src/composables/__tests__/useTopAccounts.cy.js,src/components/__tests__/RefreshPlaidControls.cy.js"` *(fails: Xvfb not installed)*
- `pytest -q` *(fails: missing Flask and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ba5de1ee08329bc4fded57b9e0821