### PR TITLE
Add asset/liability gradients for account chart

### DIFF
--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -1,3 +1,7 @@
+<!--
+  AccountsReorderChart.vue
+  Displays top accounts split by assets and liabilities using gradient bars.
+-->
 <template>
   <div class="chart-container card">
     <h2 class="heading-md">Top {{ accountSubtype }} Accounts</h2>
@@ -7,7 +11,7 @@
       <div v-for="account in positiveAccounts" :key="`p-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div class="bar-fill asset-fill" :style="{ width: barWidth(account) }">
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -19,7 +23,7 @@
       <div v-for="account in negativeAccounts" :key="`n-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div class="bar-fill liability-fill" :style="{ width: barWidth(account) }">
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -108,10 +112,25 @@ defineExpose({
 
 .bar-fill {
   height: 100%;
-  background: linear-gradient(to right, #aad4ff, #78baff);
   border-radius: 6px;
   transition: width 0.6s ease-out;
   position: relative;
+}
+
+.asset-fill {
+  background: linear-gradient(
+    to right,
+    var(--asset-gradient-start),
+    var(--asset-gradient-end)
+  );
+}
+
+.liability-fill {
+  background: linear-gradient(
+    to right,
+    var(--liability-gradient-start),
+    var(--liability-gradient-end)
+  );
 }
 
 .bar-value {

--- a/frontend/src/styles/themes/dark-frost.css
+++ b/frontend/src/styles/themes/dark-frost.css
@@ -37,4 +37,8 @@
   --link-hover-color: var(--neon-mint);
   --bar-gradient-end: #ff2cb1;
   --accent-yellow-soft: rgba(249, 248, 113, 0.5);
+  --asset-gradient-start: #aad4ff;
+  --asset-gradient-end: #78baff;
+  --liability-gradient-start: #fb4934;
+  --liability-gradient-end: #cc241d;
 }

--- a/frontend/src/styles/themes/neon-dark.css
+++ b/frontend/src/styles/themes/neon-dark.css
@@ -37,4 +37,8 @@
   --link-hover-color: var(--neon-mint);
   --bar-gradient-end: #ff2cb1;
   --accent-yellow-soft: rgba(249, 248, 113, 0.5);
+  --asset-gradient-start: #aad4ff;
+  --asset-gradient-end: #78baff;
+  --liability-gradient-start: #fb4934;
+  --liability-gradient-end: #cc241d;
 }


### PR DESCRIPTION
## Summary
- create asset/liability gradient vars for themes
- apply asset/liability gradient classes in `AccountsReorderChart.vue`

## Testing
- `pre-commit run`

------
https://chatgpt.com/codex/tasks/task_e_684ba870b9988329a68bf9f86fd4eb78