### PR TITLE
Add component test for AccountsReorderChart

### DIFF
--- a/frontend/src/components/charts/AccountsReorderChart.vue
+++ b/frontend/src/components/charts/AccountsReorderChart.vue
@@ -7,7 +7,11 @@
       <div v-for="account in positiveAccounts" :key="`p-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div
+            class="bar-fill"
+            :class="account.adjusted_balance >= 0 ? 'asset-bar' : 'liability-bar'"
+            :style="{ width: barWidth(account) }"
+          >
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -19,7 +23,11 @@
       <div v-for="account in negativeAccounts" :key="`n-${account.id}`" class="bar-row">
         <span class="bar-label">{{ account.name }}</span>
         <div class="bar-outer">
-          <div class="bar-fill" :style="{ width: barWidth(account) }">
+          <div
+            class="bar-fill"
+            :class="account.adjusted_balance >= 0 ? 'asset-bar' : 'liability-bar'"
+            :style="{ width: barWidth(account) }"
+          >
             <span class="bar-value">{{ format(account.adjusted_balance) }}</span>
           </div>
         </div>
@@ -43,21 +51,20 @@ const props = defineProps({
   },
 })
 
-const format = val => new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-}).format(val)
+const format = (val) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(val)
 
-const { positiveAccounts, negativeAccounts, allVisibleAccounts, fetchAccounts } =
-  useTopAccounts(toRef(props, 'accountSubtype'))
+const { positiveAccounts, negativeAccounts, allVisibleAccounts, fetchAccounts } = useTopAccounts(
+  toRef(props, 'accountSubtype'),
+)
 
 onMounted(fetchAccounts)
 
-const barWidth = account => {
-  const max = Math.max(
-    ...allVisibleAccounts.value.map(a => Math.abs(a.adjusted_balance)),
-    1
-  )
+const barWidth = (account) => {
+  const max = Math.max(...allVisibleAccounts.value.map((a) => Math.abs(a.adjusted_balance)), 1)
   return `${(Math.abs(account.adjusted_balance) / max) * 100}%`
 }
 
@@ -65,7 +72,6 @@ defineExpose({
   refresh: fetchAccounts,
 })
 </script>
-
 
 <style scoped>
 .chart-container {
@@ -108,10 +114,17 @@ defineExpose({
 
 .bar-fill {
   height: 100%;
-  background: linear-gradient(to right, #aad4ff, #78baff);
   border-radius: 6px;
   transition: width 0.6s ease-out;
   position: relative;
+}
+
+.asset-bar {
+  background: linear-gradient(to right, #aad4ff, #78baff);
+}
+
+.liability-bar {
+  background: linear-gradient(to right, #ffb3b3, #ff6868);
 }
 
 .bar-value {

--- a/frontend/src/components/charts/__tests__/AccountsReorderChart.cy.js
+++ b/frontend/src/components/charts/__tests__/AccountsReorderChart.cy.js
@@ -1,0 +1,42 @@
+import AccountsReorderChart from '../AccountsReorderChart.vue'
+
+describe('AccountsReorderChart', () => {
+  it('renders assets and liabilities with different classes and shows values on hover', () => {
+    cy.intercept('GET', '/api/accounts/get_accounts*', {
+      statusCode: 200,
+      body: {
+        status: 'success',
+        accounts: [
+          {
+            id: 1,
+            name: 'Checking',
+            subtype: 'checking',
+            balance: 500,
+            adjusted_balance: 500,
+            is_hidden: false,
+          },
+          {
+            id: 2,
+            name: 'Credit Card',
+            subtype: 'credit card',
+            balance: -250,
+            adjusted_balance: -250,
+            is_hidden: false,
+          },
+        ],
+      },
+    }).as('getAccounts')
+
+    cy.mount(AccountsReorderChart)
+    cy.wait('@getAccounts')
+
+    cy.get('.asset-bar').should('have.length', 1)
+    cy.get('.liability-bar').should('have.length', 1)
+
+    cy.get('.asset-bar').first().trigger('mouseover')
+    cy.get('.asset-bar .bar-value').first().should('contain', '$500.00')
+
+    cy.get('.liability-bar').first().trigger('mouseover')
+    cy.get('.liability-bar .bar-value').first().should('contain', '-$250.00')
+  })
+})


### PR DESCRIPTION
## Summary
- differentiate asset and liability bars with new classes and colors
- add Cypress component test for AccountsReorderChart

## Testing
- `npx eslint src/components/charts/AccountsReorderChart.vue src/components/charts/__tests__/AccountsReorderChart.cy.js --fix`
- `npx prettier src/components/charts/AccountsReorderChart.vue src/components/charts/__tests__/AccountsReorderChart.cy.js -w`
- `npm run test:unit` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ba87a65448329866003394b9c13d0