### PR TITLE
Add institution grouping and refresh

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,7 +3,7 @@
 from flask import Flask
 from flask_cors import CORS
 from flask_migrate import Migrate
-from app.config import logger, plaid_client, FLASK_ENV
+from app.config import logger, FLASK_ENV
 from app.extensions import db
 from app.config.environment import TELLER_WEBHOOK_SECRET
 from app.cli.sync import sync_accounts
@@ -29,6 +29,7 @@ def create_app():
     from app.routes.plaid_investments import plaid_investments
     from app.routes.plaid_transactions import plaid_transactions
     from app.routes.teller_transactions import teller_transactions
+    from app.routes.institutions import institutions
     from app.routes.teller_webhook import webhooks, disabled_webhooks
 
     app.register_blueprint(frontend, url_prefix="/")
@@ -44,6 +45,7 @@ def create_app():
     app.register_blueprint(plaid_transactions, url_prefix="/api/plaid/transactions")
     app.register_blueprint(plaid_investments, url_prefix="/api/plaid/investments")
     app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
+    app.register_blueprint(institutions, url_prefix="/api/institutions")
 
     if TELLER_WEBHOOK_SECRET:
         app.register_blueprint(webhooks, url_prefix="/api/webhooks")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,7 @@
+"""SQLAlchemy ORM models for the pyNance backend."""
+
 from datetime import datetime, timezone
+
 from app.extensions import db
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -12,6 +15,19 @@ class TimestampMixin:
     )
 
 
+class Institution(db.Model, TimestampMixin):
+    """Grouping of accounts under the same financial provider."""
+
+    __tablename__ = "institutions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    provider = db.Column(db.String(64), nullable=False)
+    last_refreshed = db.Column(db.DateTime, nullable=True)
+
+    accounts = db.relationship("Account", back_populates="institution")
+
+
 class Account(db.Model, TimestampMixin):
     __tablename__ = "accounts"
 
@@ -22,6 +38,7 @@ class Account(db.Model, TimestampMixin):
     type = db.Column(db.String(64), nullable=True)
     subtype = db.Column(db.String(64), nullable=True)
     institution_name = db.Column(db.String(128), nullable=True)
+    institution_id = db.Column(db.Integer, db.ForeignKey("institutions.id"))
     status = db.Column(db.String(64), default="active")
     is_hidden = db.Column(db.Boolean, default=False)
     balance = db.Column(db.Float, default=0)
@@ -29,6 +46,7 @@ class Account(db.Model, TimestampMixin):
 
     plaid_account = db.relationship("PlaidAccount", backref="account", uselist=False)
     teller_account = db.relationship("TellerAccount", backref="account", uselist=False)
+    institution = db.relationship("Institution", back_populates="accounts")
 
     @hybrid_property
     def is_visible(self):

--- a/backend/app/routes/institutions.py
+++ b/backend/app/routes/institutions.py
@@ -1,0 +1,120 @@
+"""Institution grouping and refresh endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.config import FILES, TELLER_API_BASE_URL
+from app.models import Institution
+from app.helpers.teller_helpers import load_tokens
+from app.sql import account_logic
+from app.utils.finance_utils import normalize_account_balance
+
+institutions = Blueprint("institutions", __name__)
+
+
+@institutions.route("/", methods=["GET"])
+def list_institutions():
+    """Return institutions with aggregated account info."""
+    data = []
+    for inst in Institution.query.all():
+        accounts = []
+        last_refreshed = None
+        for acc in inst.accounts:
+            refreshed = None
+            if acc.plaid_account and acc.plaid_account.last_refreshed:
+                refreshed = acc.plaid_account.last_refreshed
+            elif acc.teller_account and acc.teller_account.last_refreshed:
+                refreshed = acc.teller_account.last_refreshed
+            if refreshed and (last_refreshed is None or refreshed > last_refreshed):
+                last_refreshed = refreshed
+            accounts.append(
+                {
+                    "account_id": acc.account_id,
+                    "name": acc.name,
+                    "type": acc.type,
+                    "subtype": acc.subtype,
+                    "balance": normalize_account_balance(acc.balance, acc.type),
+                    "link_type": acc.link_type,
+                }
+            )
+        data.append(
+            {
+                "id": inst.id,
+                "name": inst.name,
+                "provider": inst.provider,
+                "last_refreshed": last_refreshed,
+                "accounts": accounts,
+            }
+        )
+    return jsonify({"status": "success", "institutions": data})
+
+
+@institutions.route("/<int:institution_id>/refresh", methods=["POST"])
+def refresh_institution(institution_id: int):
+    """Refresh all accounts for the given institution."""
+    inst = Institution.query.get_or_404(institution_id)
+    data = request.get_json() or {}
+    start_date = data.get("start_date")
+    end_date = data.get("end_date")
+
+    updated_accounts = []
+    refreshed_counts: dict[str, int] = {}
+    tokens = load_tokens()
+
+    for account in inst.accounts:
+        updated = False
+        if account.link_type == "Plaid":
+            token = getattr(account.plaid_account, "access_token", None)
+            if not token:
+                continue
+            updated = account_logic.refresh_data_for_plaid_account(
+                token,
+                account.account_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            if updated and account.plaid_account:
+                account.plaid_account.last_refreshed = datetime.utcnow()
+        elif account.link_type == "Teller":
+            access_token = None
+            for t in tokens:
+                if t.get("user_id") == account.user_id:
+                    access_token = t.get("access_token")
+                    break
+            if not access_token and account.teller_account:
+                access_token = account.teller_account.access_token
+            if not access_token:
+                continue
+            updated = account_logic.refresh_data_for_teller_account(
+                account,
+                access_token,
+                FILES["TELLER_DOT_CERT"],
+                FILES["TELLER_DOT_KEY"],
+                TELLER_API_BASE_URL,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            if updated and account.teller_account:
+                account.teller_account.last_refreshed = datetime.utcnow()
+        if updated:
+            updated_accounts.append(account.name)
+            refreshed_counts[inst.name] = refreshed_counts.get(inst.name, 0) + 1
+    if updated_accounts:
+        inst.last_refreshed = datetime.utcnow()
+        db.session.commit()
+    else:
+        db.session.rollback()
+    return (
+        jsonify(
+            {
+                "status": "success",
+                "updated_accounts": updated_accounts,
+                "refreshed_counts": refreshed_counts,
+            }
+        ),
+        200,
+    )

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -23,7 +23,17 @@
 GET    /api/transactions/get_transactions
 GET    /api/accounts/get_accounts
 POST   /api/accounts/refresh_accounts
+GET    /api/institutions
+POST   /api/institutions/<id>/refresh
 ```
+
+**GET /api/institutions**
+
+Returns a list of institutions with their linked accounts and the most recent refresh timestamp.
+
+**POST /api/institutions/<id>/refresh**
+
+Refreshes all accounts under the specified institution. Accepts the same optional `start_date` and `end_date` parameters as `/api/accounts/refresh_accounts`.
 
 **POST /api/accounts/refresh_accounts**
 

--- a/frontend/src/components/tables/InstitutionTable.vue
+++ b/frontend/src/components/tables/InstitutionTable.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="p-4 bg-[var(--color-bg-secondary)] rounded-lg shadow-md">
+    <table class="min-w-full divide-y divide-[var(--divider)]">
+      <thead>
+        <tr>
+          <th class="text-left">Institution</th>
+          <th class="text-left">Provider</th>
+          <th class="text-left">Last Refresh</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="inst in institutions" :key="inst.id">
+          <tr class="cursor-pointer" @click="toggle(inst.id)">
+            <td>{{ inst.name }}</td>
+            <td>{{ inst.provider }}</td>
+            <td>{{ formatDate(inst.last_refreshed) }}</td>
+            <td>
+              <button class="btn btn-sm" @click.stop="refresh(inst.id)">Refresh</button>
+            </td>
+          </tr>
+          <tr v-if="expanded[inst.id]">
+            <td colspan="4" class="p-0">
+              <table class="w-full text-sm divide-y divide-[var(--divider)]">
+                <thead>
+                  <tr>
+                    <th class="text-left">Account</th>
+                    <th class="text-left">Type</th>
+                    <th class="text-right">Balance</th>
+                    <th class="text-left">Link</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="acc in inst.accounts" :key="acc.account_id">
+                    <td>{{ acc.name }}</td>
+                    <td>{{ acc.subtype || acc.type }}</td>
+                    <td class="text-right">{{ formatBalance(acc.balance) }}</td>
+                    <td>{{ acc.link_type }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import api from '@/services/api';
+export default {
+  name: 'InstitutionTable',
+  data() {
+    return { institutions: [], expanded: {}, loading: true };
+  },
+  methods: {
+    toggle(id) {
+      this.$set(this.expanded, id, !this.expanded[id]);
+    },
+    formatDate(d) {
+      if (!d) return 'N/A';
+      return new Date(d).toLocaleString();
+    },
+    formatBalance(b) {
+      const num = parseFloat(b || 0);
+      return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(num);
+    },
+    async refresh(id) {
+      await api.refreshInstitution(id);
+      this.fetch();
+    },
+    async fetch() {
+      const res = await api.getInstitutions();
+      if (res.status === 'success') {
+        this.institutions = res.institutions;
+      }
+      this.loading = false;
+    }
+  },
+  mounted() {
+    this.fetch();
+  }
+};
+</script>
+
+<style scoped>
+th, td { @apply p-2; }
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -19,6 +19,16 @@ export default {
     return response.data;
   },
 
+  async getInstitutions() {
+    const response = await apiClient.get('/institutions');
+    return response.data;
+  },
+
+  async refreshInstitution(id, payload = {}) {
+    const response = await apiClient.post(`/institutions/${id}/refresh`, payload);
+    return response.data;
+  },
+
   async fetchTransactions(page = 1, pageSize = 50) {
     const response = await apiClient.get(
       `/transactions/get_transactions?page=${page}&page_size=${pageSize}`

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -42,21 +42,10 @@
     </section>
 
     <!-- Accounts Table -->
-    <transition name="slide-horizontal" mode="out-in">
-      <div class="card section-container" :key="activeAccountGroup">
-        <AccountsTable :accountGroup="activeAccountGroup" @refresh="refreshCharts" />
-      </div>
-    </transition>
+    <div class="card section-container">
+      <InstitutionTable @refresh="refreshCharts" />
+    </div>
 
-    <!-- Account Tabs -->
-    <section class="section-container">
-      <div class="account-tabs">
-        <button v-for="group in accountGroups" :key="group" class="btn btn-pill"
-          :class="{ 'active-tab': activeAccountGroup === group }" @click="activeAccountGroup = group">
-          {{ group }}
-        </button>
-      </div>
-    </section>
 
     <!-- Footer -->
     <footer class="accounts-footer">
@@ -72,7 +61,7 @@ import { ref } from 'vue'
 const selectedProducts = ref([])
 
 import LinkAccount from '@/components/forms/LinkAccount.vue'
-import AccountsTable from '@/components/tables/AccountsTable.vue'
+import InstitutionTable from '@/components/tables/InstitutionTable.vue'
 import NetYearComparisonChart from '@/components/charts/NetYearComparisonChart.vue'
 import AssetsBarTrended from '@/components/charts/AssetsBarTrended.vue'
 import AccountsReorderChart from '@/components/charts/AccountsReorderChart.vue'
@@ -91,8 +80,6 @@ function refreshCharts() {
 // Meta & State
 const userName = import.meta.env.VITE_USER_ID_PLAID || ''
 
-const activeAccountGroup = ref('Checking')
-const accountGroups = ['Checking', 'Savings', 'Credit']
 const showTokenForm = ref(false)
 
 function toggleManualTokenMode() {

--- a/scripts/generate_example_db.py
+++ b/scripts/generate_example_db.py
@@ -37,6 +37,7 @@ sys.modules["app.models"] = models
 Account = models.Account
 Category = models.Category
 Transaction = models.Transaction
+Institution = models.Institution
 
 ah_path = BACKEND_DIR / "app" / "helpers" / "account_history_helper.py"
 ah_spec = importlib.util.spec_from_file_location(
@@ -59,12 +60,16 @@ def create_app(db_uri: str) -> Flask:
 
 def seed_data() -> None:
     """Populate the database with 12 months of mock records."""
+    example_bank = Institution(name="Example Bank", provider="manual")
+    db.session.add(example_bank)
+
     checking = Account(
         account_id="acc_checking",
         name="Checking Account",
         type="checking",
         subtype="checking",
         institution_name="Example Bank",
+        institution=example_bank,
         balance=1000,
         link_type="manual",
     )
@@ -74,6 +79,7 @@ def seed_data() -> None:
         type="credit",
         subtype="credit card",
         institution_name="Example Bank",
+        institution=example_bank,
         balance=-500,
         link_type="manual",
     )

--- a/tests/test_api_institutions.py
+++ b/tests/test_api_institutions.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import importlib.util
+import types
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+app_pkg = types.ModuleType("app")
+sys.modules["app"] = app_pkg
+
+# Config stub
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+config_stub.FILES = {"TELLER_DOT_CERT": "cert", "TELLER_DOT_KEY": "key"}
+config_stub.TELLER_API_BASE_URL = "https://example.com"
+config_stub.FLASK_ENV = "test"
+sys.modules["app.config"] = config_stub
+
+# Extensions stub
+extensions_stub = types.ModuleType("app.extensions")
+session_ns = types.SimpleNamespace(commit=lambda: None, rollback=lambda: None)
+extensions_stub.db = types.SimpleNamespace(session=session_ns, commit=lambda: None, rollback=lambda: None)
+sys.modules["app.extensions"] = extensions_stub
+
+# Helpers stub
+helpers_pkg = types.ModuleType("app.helpers")
+teller_helpers_stub = types.ModuleType("app.helpers.teller_helpers")
+teller_helpers_stub.load_tokens = lambda: [{"user_id": "u1", "access_token": "tok"}]
+helpers_pkg.teller_helpers = teller_helpers_stub
+sys.modules["app.helpers"] = helpers_pkg
+sys.modules["app.helpers.teller_helpers"] = teller_helpers_stub
+
+# Utils stub
+utils_pkg = types.ModuleType("app.utils")
+finance_utils_stub = types.ModuleType("app.utils.finance_utils")
+finance_utils_stub.normalize_account_balance = lambda bal, t: bal
+utils_pkg.finance_utils = finance_utils_stub
+sys.modules["app.utils"] = utils_pkg
+sys.modules["app.utils.finance_utils"] = finance_utils_stub
+
+# SQL stub
+sql_pkg = types.ModuleType("app.sql")
+account_logic_stub = types.ModuleType("app.sql.account_logic")
+account_logic_stub.refresh_data_for_plaid_account = lambda *a, **k: True
+account_logic_stub.refresh_data_for_teller_account = lambda *a, **k: True
+sys.modules["app.sql"] = sql_pkg
+sys.modules["app.sql.account_logic"] = account_logic_stub
+sql_pkg.account_logic = account_logic_stub
+
+# Models stub
+models_stub = types.ModuleType("app.models")
+
+
+class DummyAccount:
+    def __init__(self, aid, link_type="Plaid"):
+        self.account_id = aid
+        self.name = aid
+        self.type = "checking"
+        self.subtype = "checking"
+        self.balance = 0
+        self.link_type = link_type
+        self.user_id = "u1"
+        self.plaid_account = types.SimpleNamespace(access_token="tok", last_refreshed=None) if link_type == "Plaid" else None
+        self.teller_account = types.SimpleNamespace(access_token="tok", last_refreshed=None) if link_type == "Teller" else None
+
+
+class DummyInstitution:
+    def __init__(self, iid, accounts):
+        self.id = iid
+        self.name = f"Inst {iid}"
+        self.provider = "manual"
+        self.accounts = accounts
+        self.last_refreshed = None
+
+
+class InstQuery:
+    def __init__(self, insts):
+        self.insts = {i.id: i for i in insts}
+
+    def all(self):
+        return list(self.insts.values())
+
+    def get_or_404(self, iid):
+        return self.insts[iid]
+
+
+models_stub.Institution = DummyInstitution
+sys.modules["app.models"] = models_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "institutions.py")
+spec = importlib.util.spec_from_file_location("app.routes.institutions", ROUTE_PATH)
+inst_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(inst_module)
+
+
+@pytest.fixture
+def client():
+    inst1 = DummyInstitution(1, [DummyAccount("a1"), DummyAccount("a2", "Teller")])
+    inst2 = DummyInstitution(2, [DummyAccount("a3")])
+    inst_module.Institution.query = InstQuery([inst1, inst2])
+
+    app = Flask(__name__)
+    app.register_blueprint(inst_module.institutions, url_prefix="/api/institutions")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_get_institutions(client):
+    resp = client.get("/api/institutions/")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "success"
+    assert len(data["institutions"]) == 2
+
+
+def test_refresh_institution(client):
+    resp = client.post("/api/institutions/1/refresh", json={})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["updated_accounts"] == ["a1", "a2"]


### PR DESCRIPTION
## Summary
- introduce Institution model and relationships
- expose `/api/institutions` and `/api/institutions/<id>/refresh`
- add Vue InstitutionTable and service helpers
- document new endpoints
- test institution API

## Testing
- `pytest tests/test_api_institutions.py -q`
- `pytest -q` *(fails: accounts refresh & model field validation)*

------
https://chatgpt.com/codex/tasks/task_e_684e52288fe48329a2c053290d98d603