### PR TITLE
fix: use relative API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cp example.env .env
 Edit `frontend/.env` with:
 
 ```dotenv
-VITE_APP_API_BASE_URL=http://localhost:5000/api
+VITE_APP_API_BASE_URL=/api
 # ... other VITE_ variables as needed
 ```
 

--- a/backend/app/static/assets_vs_liabilities.html
+++ b/backend/app/static/assets_vs_liabilities.html
@@ -17,7 +17,7 @@
 
   <script>
     async function renderNetAssets() {
-      const res = await fetch('http://localhost:5000/api/charts/net_assets');
+      const res = await fetch('/api/charts/net_assets');
       const { data, metadata } = await res.json();
 
       // Optional summary metadata display

--- a/backend/app/static/category_breakdown.html
+++ b/backend/app/static/category_breakdown.html
@@ -18,7 +18,7 @@
 
   <script>
     async function renderCategoryChart() {
-      const res = await fetch('http://localhost:5000/api/charts/category_breakdown');
+      const res = await fetch('/api/charts/category_breakdown');
       const { data } = await res.json();
 
       const top10 = data.sort((a, b) => b.amount - a.amount).slice(0, 10);

--- a/backend/app/static/mtd_net.html
+++ b/backend/app/static/mtd_net.html
@@ -63,10 +63,10 @@
     let transactions = [], currentTx = [], currentSort = 'amount', sortOrder = 1;
 
     async function renderNetChart() {
-      const res = await fetch('http://localhost:5000/api/charts/daily_net');
+      const res = await fetch('/api/charts/daily_net');
       const { data } = await res.json();
 
-      const txRes = await fetch('http://localhost:5000/api/teller/transactions/get_transactions');
+      const txRes = await fetch('/api/teller/transactions/get_transactions');
       const txJson = await txRes.json();
       transactions = txJson.data.transactions;
 

--- a/frontend/example.env
+++ b/frontend/example.env
@@ -1,8 +1,8 @@
 # Environment mode
 VITE_SESSION_MODE="development" # Options: "development", "production"
 
-# API base URL
-VITE_APP_API_BASE_URL=http://localhost:5000/api
+# API base URL (use relative path for flexibility)
+VITE_APP_API_BASE_URL=/api
 
 # Teller integration
 VITE_TELLER_APP_ID="your_teller_app_id" # Used by Vite

--- a/frontend/src/api/accounts_link.js
+++ b/frontend/src/api/accounts_link.js
@@ -1,7 +1,7 @@
 import axios from "axios"
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_APP_API_BASE_URL || "http://localhost:5000/api",
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL || "/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,7 +2,7 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_APP_API_BASE_URL || "http://localhost:5000/api",
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL || "/api",
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
## Summary
- fetch API via `/api` relative path instead of `localhost`
- update example.env and README to mirror new default
- fix static HTML to use relative paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f9ceed67483299f9d23f61419df99