### PR TITLE
Implement Teller linking endpoints

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -28,6 +28,7 @@ def create_app():
     from app.routes.plaid import plaid_routes
     from app.routes.plaid_investments import plaid_investments
     from app.routes.plaid_transactions import plaid_transactions
+    from app.routes.teller import link_teller
     from app.routes.teller_transactions import teller_transactions
     from app.routes.institutions import institutions
     from app.routes.teller_webhook import webhooks, disabled_webhooks
@@ -44,6 +45,7 @@ def create_app():
     app.register_blueprint(plaid_routes, url_prefix="/api/plaid")
     app.register_blueprint(plaid_transactions, url_prefix="/api/plaid/transactions")
     app.register_blueprint(plaid_investments, url_prefix="/api/plaid/investments")
+    app.register_blueprint(link_teller, url_prefix="/api/teller")
     app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
     app.register_blueprint(institutions, url_prefix="/api/institutions")
 

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -1,4 +1,5 @@
-# account_logic.py
+"""Database persistence and refresh helpers for account data."""
+
 from tempfile import NamedTemporaryFile
 import json
 import time
@@ -47,6 +48,29 @@ def normalize_balance(amount, account_type):
             ),
         }
     )
+
+
+def get_accounts_from_db(include_hidden: bool = False):
+    """Return serialized account rows from the database."""
+    query = Account.query
+    if not include_hidden:
+        query = query.filter(Account.is_hidden.is_(False))
+
+    accounts = []
+    for acc in query.all():
+        accounts.append(
+            {
+                "account_id": acc.account_id,
+                "user_id": acc.user_id,
+                "name": acc.name,
+                "type": acc.type,
+                "subtype": acc.subtype,
+                "institution_name": acc.institution_name,
+                "balance": acc.balance,
+                "status": acc.status,
+            }
+        )
+    return accounts
 
 
 def save_plaid_item(user_id, item_id, access_token, institution_name, product):

--- a/tests/test_api_teller_link.py
+++ b/tests/test_api_teller_link.py
@@ -74,7 +74,7 @@ def test_generate_link_token_sends_user_id(client, monkeypatch):
 
     monkeypatch.setattr(teller_module.requests, "post", fake_post)
 
-    resp = client.post("/api/teller/generate_link_token", json={"user_id": "u1"})
+    resp = client.post("/api/teller/link-token", json={"user_id": "u1"})
     assert resp.status_code == 200
     assert captured["payload"]["user_id"] == "u1"
     data = resp.get_json()
@@ -102,6 +102,18 @@ def test_generate_link_token_uses_session(client, monkeypatch):
     with client.session_transaction() as sess:
         sess["user_id"] = "sess1"
 
-    resp = client.post("/api/teller/generate_link_token")
+    resp = client.post("/api/teller/link-token")
     assert resp.status_code == 200
     assert captured["payload"]["user_id"] == "sess1"
+
+
+def test_get_accounts_returns_db_values(client, monkeypatch):
+    monkeypatch.setattr(
+        teller_module.account_logic,
+        "get_accounts_from_db",
+        lambda: [{"account_id": "a1"}],
+    )
+    resp = client.get("/api/teller/accounts")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["data"]["accounts"][0]["account_id"] == "a1"


### PR DESCRIPTION
## Summary
- register Teller link blueprint
- add `/link-token`, `/link`, `/accounts`, and `/balances` routes
- expose helper `get_accounts_from_db`
- update tests for new Teller routes

## Testing
- `ruff check backend/app/sql/account_logic.py backend/app/routes/teller.py backend/app/__init__.py tests/test_api_teller_link.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684fff9380d48329ae1af759e078f7c6