### PR TITLE
Fix chart layout on accounts page

### DIFF
--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -105,4 +105,10 @@
   .env-banner-dev {
     @import bg-red-100 text-red-800 text-center font-bold p-2 border-b-2 border-red-500 uppercase shadow;
   }
+
+  .heading-md {
+    @import text-center text-xl font-bold mb-3;
+    color: var(--neon-mint);
+    text-shadow: 0 0 6px var(--neon-purple);
+  }
 }

--- a/frontend/src/components/charts/AssetsBarTrended.vue
+++ b/frontend/src/components/charts/AssetsBarTrended.vue
@@ -112,10 +112,8 @@ onMounted(fetchData)
 
 <style scoped>
 .chart-container {
-  flex: 1 1 48%;
+  width: 100%;
   padding: 0.75rem;
-  max-width: 48%;
-  min-width: 300px;
   background-color: var(--color-bg-secondary);
   border-radius: 12px;
   box-shadow: 0 2px 16px rgba(0, 0, 0, 0.15);
@@ -137,10 +135,5 @@ canvas {
   height: 100% !important;
 }
 
-@media (max-width: 768px) {
-  .chart-container {
-    flex-basis: 100%;
-    max-width: 100%;
-  }
-}
+
 </style>

--- a/frontend/src/components/charts/NetYearComparisonChart.vue
+++ b/frontend/src/components/charts/NetYearComparisonChart.vue
@@ -144,10 +144,8 @@ onMounted(fetchData)
 
 <style scoped>
 .chart-container {
-  flex: 1 1 48%;
+  width: 100%;
   padding: 0.75rem;
-  max-width: 48%;
-  min-width: 300px;
   background-color: var(--color-bg-secondary);
   border-radius: 12px;
   box-shadow: 0 2px 12px var(--shadow);
@@ -176,11 +174,6 @@ canvas {
   height: 100% !important;
 }
 
-@media (max-width: 768px) {
-  .chart-container {
-    flex-basis: 100%;
-    max-width: 100%;
-  }
-}
+
 </style>
 

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -25,7 +25,7 @@
     <!-- Charts -->
     <section class="flex flex-col gap-6">
       <div class="flex flex-wrap gap-2 justify-between items-start">
-        <div class="p-4 bg-[var(--color-bg-secondary)] rounded-lg shadow-md">
+        <div class="flex-1 shrink basis-[48%] max-w-[48%] min-w-[300px] p-4 bg-[var(--color-bg-secondary)] rounded-lg shadow-md">
           <NetYearComparisonChart />
         </div>
         <div class="flex-1 shrink basis-[48%] max-w-[48%] min-w-[300px] bg-[var(--color-bg-secondary)] rounded-lg shadow-md p-3">
@@ -215,5 +215,6 @@ function toggleManualTokenMode() {
   font-size: 0.9rem;
   border-top: 1px solid var(--themed-border);
   padding-top: 1rem;
+  text-shadow: 0 0 4px var(--neon-purple);
 }
 </style>


### PR DESCRIPTION
## Summary
- allow charts to fill container width
- center titles with neon accent
- adjust accounts page layout and footer style

## Testing
- `pre-commit run --hook-stage manual`

------
https://chatgpt.com/codex/tasks/task_e_685092ff5d108329a563309a6eb9a58f