### PR TITLE
Update charts route docs

### DIFF
--- a/docs/backend/app/routes/charts.md
+++ b/docs/backend/app/routes/charts.md
@@ -9,23 +9,42 @@ Provides data for visualizing user financial trends over time, including categor
 
 ## Key Endpoints
 
-- `GET /charts/breakdown`: Category spending summary over a time range.
-- `GET /charts/history`: Historical transaction totals (e.g., month-over-month).
-- `GET /charts/balance`: Account balance time series.
+- `GET /charts/category_breakdown` – Category spending summary.
+- `GET /charts/daily_net` – Net income/expense per day.
+- `GET /charts/cash_flow` – Aggregated income and expenses (daily or monthly).
+- `GET /charts/net_assets` – Net assets, assets, and liabilities over time.
+- `GET /charts/accounts-snapshot` – Current visible account balances.
+- `GET|POST /charts/forecast` – Forecast vs actual balance line.
 
 ## Inputs & Outputs
 
-- **GET /charts/breakdown**
+- **GET /charts/category_breakdown**
 
-  - **Params:** `start_date`, `end_date`, `group_by` (e.g., month)
-  - **Output:** `{ categories: [{ name: str, total: float }], total: float }`
+  - **Params:** `start_date`, `end_date`
+  - **Output:** `{ status: 'success', data: [{ category: str, amount: float, date: str }] }`
 
-- **GET /charts/history**
+- **GET /charts/daily_net**
 
-  - **Output:** `{ series: [{ date: str, total: float }], range: { start: str, end: str } }`
+  - **Output:** `{ status: 'success', data: [{ date: str, net: float, income: float, expenses: float, transaction_count: int }] }`
 
-- **GET /charts/balance**
-  - **Output:** `{ balances: [{ date: str, total: float }] }`
+- **GET /charts/cash_flow**
+
+  - **Params:** `granularity` (`daily` or `monthly`), optional `start_date`, `end_date`
+  - **Output:** `{ status: 'success', data: [{ date: str, income: float, expenses: float }], metadata: { total_income: float, total_expenses: float, total_transactions: int } }`
+
+- **GET /charts/net_assets**
+
+  - **Output:** `{ status: 'success', data: [{ date: str, net_assets: float, assets: float, liabilities: float }] }`
+
+- **GET /charts/accounts-snapshot**
+
+  - **Params:** `user_id`
+  - **Output:** `[ { account_id: str, name: str, institution_name: str, balance: float, type: str, subtype: str } ]`
+
+- **GET|POST /charts/forecast**
+
+  - **Params:** `view_type` (`Month` or `Year`), optional `manual_income`, `liability_rate`
+  - **Output:** `{ labels: [str], forecast: [float], actuals: [float], metadata: { ... } }`
 
 ## Internal Dependencies
 


### PR DESCRIPTION
## Summary
- update docs for charts route to list actual endpoints
- document input/output fields for each chart endpoint

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'save_tokens')*

------
https://chatgpt.com/codex/tasks/task_e_68516a289dc08329a72ae4386072c702