### PR TITLE
Fix Chroma indexing hook

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo "[CHROMA] Running index update after commit..."
-python scripts/chroma_index.py
+# Indexing has been moved to post-merge to avoid multiple runs during git pull

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Runs once after a merge or pull to keep the Chroma index in sync
+
+echo "[CHROMA] Running index update after merge..."
+python scripts/chroma_index.py


### PR DESCRIPTION
## Summary
- avoid running Chroma index on every commit
- trigger indexing once after merges/pulls

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'save_tokens')*

------
https://chatgpt.com/codex/tasks/task_e_685194365f0083298e7763ebb6ee1114