### PR TITLE
[tests] Reinstate teller and forecast tests

### DIFF
--- a/tests/test_api_teller_link.py
+++ b/tests/test_api_teller_link.py
@@ -1,0 +1,145 @@
+"""Tests for Teller link-token and accounts endpoints."""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+# -------------------- PATH & MODULE STUBS --------------------
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+# --- Config stub ---
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+config_stub.FILES = {
+    "TELLER_DOT_KEY": "dummy",
+    "TELLER_DOT_CERT": "",
+    "TELLER_ACCOUNTS": "",
+}
+config_stub.TELLER_APP_ID = "app123"
+config_stub.TELLER_API_BASE_URL = "https://example.com"
+config_stub.FLASK_ENV = "test"
+sys.modules["app.config"] = config_stub
+
+# --- Helper stub ---
+helpers_pkg = types.ModuleType("app.helpers")
+helpers_pkg.teller_helpers = types.ModuleType("app.helpers.teller_helpers")
+helpers_pkg.teller_helpers.load_tokens = lambda: []
+helpers_pkg.teller_helpers.save_tokens = lambda tokens: None
+sys.modules["app.helpers"] = helpers_pkg
+sys.modules["app.helpers.teller_helpers"] = helpers_pkg.teller_helpers
+
+# --- Extensions stub ---
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace()
+sys.modules["app.extensions"] = extensions_stub
+
+# --- Models stub ---
+models_stub = types.ModuleType("app.models")
+models_stub.TellerAccount = type("TellerAccount", (), {})
+sys.modules["app.models"] = models_stub
+
+# --- Account Logic stub ---
+account_logic_stub = types.ModuleType("app.sql.account_logic")
+account_logic_stub.get_accounts_from_db = lambda: [{"account_id": "a1"}]
+sql_pkg = types.ModuleType("app.sql")
+sql_pkg.__path__ = []
+sql_pkg.account_logic = account_logic_stub
+sys.modules["app.sql"] = sql_pkg
+sys.modules["app.sql.account_logic"] = account_logic_stub
+
+# -------------------- LOAD ROUTE UNDER TEST --------------------
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "teller.py")
+spec = importlib.util.spec_from_file_location("app.routes.teller", ROUTE_PATH)
+teller_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(teller_module)  # type: ignore[union-attr]
+
+
+# -------------------- TESTS --------------------
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(teller_module.link_teller, url_prefix="/api/teller")
+    app.config["TESTING"] = True
+    app.secret_key = "test"
+    with app.test_client() as c:
+        yield c
+
+
+def test_generate_link_token_sends_user_id(client, monkeypatch):
+    captured = {}
+
+    class DummyResp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"link_token": "abc"}
+
+        text = "{}"
+
+    def fake_post(url, headers=None, json=None):
+        captured["payload"] = json
+        return DummyResp()
+
+    monkeypatch.setattr(teller_module.requests, "post", fake_post)
+
+    resp = client.post("/api/teller/link-token", json={"user_id": "u1"})
+    assert resp.status_code == 200
+    assert captured["payload"]["user_id"] == "u1"
+    data = resp.get_json()
+    assert data["link_token"] == "abc"
+
+
+def test_generate_link_token_uses_session(client, monkeypatch):
+    captured = {}
+
+    class DummyResp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"link_token": "xyz"}
+
+        text = "{}"
+
+    def fake_post(url, headers=None, json=None):
+        captured["payload"] = json
+        return DummyResp()
+
+    monkeypatch.setattr(teller_module.requests, "post", fake_post)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = "sess1"
+
+    resp = client.post("/api/teller/link-token")
+    assert resp.status_code == 200
+    assert captured["payload"]["user_id"] == "sess1"
+
+
+def test_get_accounts_returns_db_values(client, monkeypatch):
+    # Patch the account logic stub method (should already exist from sys.modules)
+    monkeypatch.setitem(
+        teller_module.__dict__,
+        "get_accounts_from_db",
+        lambda: [{"account_id": "a1"}],
+    )
+    monkeypatch.setattr(
+        teller_module.account_logic,
+        "get_accounts_from_db",
+        lambda: [{"account_id": "a1"}],
+    )
+    resp = client.get("/api/teller/accounts")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["data"]["accounts"][0]["account_id"] == "a1"

--- a/tests/test_forecast_route.py
+++ b/tests/test_forecast_route.py
@@ -1,3 +1,5 @@
+"""Unit tests for the forecast API route."""
+
 import os
 import sys
 import importlib.util
@@ -10,6 +12,8 @@ BASE_BACKEND = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "ba
 if BASE_BACKEND not in sys.path:
     sys.path.insert(0, BASE_BACKEND)
 sys.modules.pop("app", None)
+app_pkg = types.ModuleType("app")
+sys.modules["app"] = app_pkg
 
 # ---- app.config/environment/extensions stubs ----
 config_stub = types.ModuleType("app.config")

--- a/tests/test_model_field_validation.py
+++ b/tests/test_model_field_validation.py
@@ -1,0 +1,109 @@
+"""Validate model attribute usage in routes and helpers."""
+
+# pylint: disable=import-error
+
+import ast
+import importlib.util
+import os
+import sys
+import types
+
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.inspection import inspect as sa_inspect
+
+BASE_DIR = os.path.join(os.path.dirname(__file__), "..", "backend")
+
+
+def _load_models():
+    """Load backend models with minimal Flask-SQLAlchemy context."""
+    sys.modules.pop("app", None)
+    app_pkg = types.ModuleType("app")
+    extensions_stub = types.ModuleType("app.extensions")
+    extensions_stub.db = SQLAlchemy()
+    app_pkg.extensions = extensions_stub
+    sys.modules["app"] = app_pkg
+    sys.modules["app.extensions"] = extensions_stub
+
+    module_path = os.path.join(BASE_DIR, "app", "models.py")
+    spec = importlib.util.spec_from_file_location("app.models", module_path)
+    models = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(models)
+    return models
+
+
+def _collect_model_fields(models):
+    fields = {}
+    for name in dir(models):
+        obj = getattr(models, name)
+        if isinstance(obj, type) and getattr(obj, "__tablename__", None):
+            attrs = {prop.key for prop in sa_inspect(obj).attrs}
+            attrs.update({"query", "query_class"})
+            fields[name] = attrs
+    return fields
+
+
+def _parse_import_aliases(tree, valid):
+    alias_map = {}
+    alias_pkg = {}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "app.models":
+            for alias in node.names:
+                if alias.name in valid:
+                    alias_map[alias.asname or alias.name] = alias.name
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "app.models":
+                    alias_pkg[alias.asname or alias.name] = alias.name
+    return alias_map, alias_pkg
+
+
+def _find_invalid_accesses(path, valid):
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=path)
+    alias_map, alias_pkg = _parse_import_aliases(tree, valid)
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name):
+                base = node.value.id
+                model_name = alias_map.get(base)
+                if model_name and node.attr not in valid.get(model_name, set()):
+                    violations.append(f"{path}:{node.lineno} {model_name}.{node.attr}")
+            elif isinstance(node.value, ast.Attribute):
+                inner = node.value
+                if isinstance(inner.value, ast.Name):
+                    pkg = alias_pkg.get(inner.value.id)
+                    model_name = inner.attr
+                    if (
+                        pkg
+                        and model_name in valid
+                        and node.attr not in valid[model_name]
+                    ):
+                        violations.append(
+                            f"{path}:{node.lineno} {model_name}.{node.attr}"
+                        )
+    return violations
+
+
+def _collect_py_files():
+    targets = [
+        os.path.join(BASE_DIR, "app", "routes"),
+        os.path.join(BASE_DIR, "app", "helpers"),
+    ]
+    files = []
+    for target in targets:
+        for root, _, filenames in os.walk(target):
+            for name in filenames:
+                if name.endswith(".py") and not name.startswith("__"):
+                    files.append(os.path.join(root, name))
+    return files
+
+
+def test_model_fields_are_valid():
+    """Ensure all model attributes referenced in code actually exist."""
+    models = _load_models()
+    valid = _collect_model_fields(models)
+    violations = []
+    for file in _collect_py_files():
+        violations.extend(_find_invalid_accesses(file, valid))
+    assert not violations, "Invalid model field access found:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- restore `test_api_teller_link.py` using helper stubs
- stub root `app` package in `test_forecast_route.py`
- add previously deleted `test_model_field_validation.py`

## Testing
- `pytest tests/test_api_teller_link.py tests/test_forecast_route.py tests/test_model_field_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b5ad31e08329a8d0cd813692a791