### PR TITLE
[frontend] Fix account snapshot with fuzzy dropdown

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.9",
         "chart.js": "^4.4.9",
         "date-fns": "^4.1.0",
+        "fuse.js": "^7.1.0",
         "papaparse": "^5.5.2",
         "vue": "^3.5.13",
         "vue-chartjs": "^5.3.2",
@@ -6872,6 +6873,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "vue-chartjs": "^5.3.2",
     "vue-router": "^4.5.0",
     "vue-toastification": "^2.0.0-rc.5",
-    "vuedraggable": "^4.1.0"
+    "vuedraggable": "^4.1.0",
+    "fuse.js": "^7.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/frontend/src/components/ui/FuzzyDropdown.vue
+++ b/frontend/src/components/ui/FuzzyDropdown.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="relative">
+    <input
+      v-model="query"
+      type="text"
+      placeholder="Search accounts..."
+      class="input w-full mb-2"
+      @focus="open = true"
+    />
+    <div v-show="open" class="dropdown-menu w-full">
+      <label
+        v-for="item in filtered"
+        :key="item.account_id"
+        class="flex items-center gap-2 py-1"
+      >
+        <input
+          type="checkbox"
+          :value="item.account_id"
+          v-model="localValue"
+          :disabled="!localValue.includes(item.account_id) && localValue.length >= max"
+        />
+        <span>{{ item.institution_name || item.name }}</span>
+      </label>
+      <p v-if="!filtered.length" class="text-sm text-gray-500 py-2">No matches</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Fuzzy search dropdown for selecting account ids.
+ * Options should be objects with `account_id`, `name`, and `institution_name` fields.
+ */
+import { ref, computed, watch } from 'vue'
+import Fuse from 'fuse.js'
+
+const props = defineProps({
+  options: { type: Array, default: () => [] },
+  modelValue: { type: Array, default: () => [] },
+  max: { type: Number, default: 5 },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const query = ref('')
+const open = ref(false)
+const localValue = ref([...props.modelValue])
+
+watch(
+  () => props.modelValue,
+  val => (localValue.value = [...val])
+)
+watch(
+  localValue,
+  val => emit('update:modelValue', val),
+  { deep: true }
+)
+
+const fuse = computed(
+  () =>
+    new Fuse(props.options, { keys: ['name', 'institution_name'], threshold: 0.3 })
+)
+
+const filtered = computed(() => {
+  if (!query.value) return props.options
+  return fuse.value.search(query.value).map(r => r.item)
+})
+</script>
+
+<style scoped>
+.dropdown-menu {
+  @apply absolute bg-[var(--themed-bg)] border border-[var(--divider)] p-2 flex flex-col gap-1 max-h-48 overflow-y-auto z-10;
+}
+</style>

--- a/frontend/src/components/widgets/AccountSnapshot.vue
+++ b/frontend/src/components/widgets/AccountSnapshot.vue
@@ -2,23 +2,18 @@
   <div class="card space-y-4">
     <div class="flex-between">
       <h2 class="text-xl font-semibold">Account Snapshot</h2>
-      <button class="btn btn-sm btn-outline" @click="showConfig = !showConfig">
+      <button class="btn btn-sm btn-outline" @click="toggleConfig">
         {{ showConfig ? 'Done' : 'Configure' }}
       </button>
     </div>
 
-    <div v-if="showConfig" class="space-y-2">
-      <p class="text-sm text-gray-400">Select up to 5 accounts</p>
-      <div v-for="acc in accounts" :key="acc.account_id" class="flex items-center gap-2">
-        <input
-          type="checkbox"
-          :id="acc.account_id"
-          v-model="selectedIds"
-          :value="acc.account_id"
-          :disabled="!selectedIds.includes(acc.account_id) && selectedIds.length >= 5"
-        />
-        <label :for="acc.account_id">{{ acc.institution_name || acc.name }}</label>
-      </div>
+    <div v-if="showConfig" class="relative">
+      <FuzzyDropdown
+        :options="accounts"
+        v-model="selectedIds"
+        :max="5"
+        class="w-64"
+      />
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -46,15 +41,27 @@
         <p v-else class="text-sm text-gray-500 mt-2 italic">No upcoming bills</p>
       </div>
     </div>
+    <div class="text-right font-semibold pt-2">
+      Total Balance: {{ formatCurrency(totalBalance) }}
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import FuzzyDropdown from '@/components/ui/FuzzyDropdown.vue'
 import { useSnapshotAccounts } from '@/composables/useSnapshotAccounts.js'
 
 const showConfig = ref(false)
 const { accounts, selectedAccounts, selectedIds, reminders } = useSnapshotAccounts()
+
+function toggleConfig() {
+  showConfig.value = !showConfig.value
+}
+
+const totalBalance = computed(() =>
+  selectedAccounts.value.reduce((sum, acc) => sum + parseFloat(acc.balance || 0), 0)
+)
 
 function formatCurrency(val) {
   const num = parseFloat(val || 0)
@@ -67,4 +74,7 @@ function formatCurrency(val) {
 </script>
 
 <style scoped>
+.card {
+  @apply bg-[var(--color-bg-secondary)] border border-[var(--divider)] p-4 rounded-lg shadow;
+}
 </style>


### PR DESCRIPTION
## Summary
- add `fuse.js` dependency for fuzzy searching
- create `FuzzyDropdown` UI component
- update `AccountSnapshot` widget to use fuzzy dropdown and show total balance

## Testing
- `pre-commit run --all-files` *(fails: not found errors)*
- `pytest` *(fails: ModuleNotFoundError: 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6858d3ba0f388329a3f8c00e74886a07