### PR TITLE
[frontend] Fix DailyNetChart context error

### DIFF
--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -18,8 +18,9 @@
 </template>
 
 <script>
+// Chart component visualizing daily net income trends
 import api from '@/services/api'
-import { ref, onMounted, nextTick, computed } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick, computed } from 'vue'
 import { Chart } from 'chart.js/auto'
 
 export default {
@@ -181,6 +182,12 @@ export default {
 
     onMounted(() => {
       fetchData()
+    })
+    onUnmounted(() => {
+      if (chartInstance.value) {
+        chartInstance.value.destroy()
+        chartInstance.value = null
+      }
     })
 
     return {


### PR DESCRIPTION
## Summary
- destroy DailyNetChart instance on component unmount to avoid null canvas context

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: missing docs and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858e882570c83299c28acaa9b22cea8