### PR TITLE
[frontend] Fix chart category selection

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, watch, computed, nextTick } from 'vue'
 import { Chart } from 'chart.js/auto'
 import api from '@/services/api'
 
@@ -64,6 +64,7 @@ async function fetchData() {
         if (!isValid) console.warn('Skipping invalid entry:', entry)
         return isValid
       })
+      await nextTick()
       selectedCategories.value = availableCategories.value.slice()
       updateChart()
     }


### PR DESCRIPTION
## Summary
- ensure `CategoryBreakdownChart` waits for DOM updates before selecting categories

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: missing docs paths)*

------
https://chatgpt.com/codex/tasks/task_e_685906c2b3d48329a8c5a7a75c3bbc4f