### PR TITLE
[frontend] Increase Category Breakdown Chart tick font size

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -119,7 +119,7 @@ function updateChart() {
         x: {
           ticks: {
             color: '#c4b5fd',
-            font: { size: 12 },
+            font: { size: 14 },
           },
         },
         y: {
@@ -127,7 +127,7 @@ function updateChart() {
           ticks: {
             callback: (value) => `$${value}`,
             color: '#c4b5fd',
-            font: { size: 12 },
+            font: { size: 14 },
           },
         },
       },


### PR DESCRIPTION
## Summary
- enlarge tick font size for CategoryBreakdownChart so labels are easier to read

## Testing
- `npm run lint` *(fails: 8 errors)*
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue` *(fails: model-field-validation)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68591e96a3dc8329a98df93ffe3dc92b