### PR TITLE
[frontend] Add tailwind styles to chart headers

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="category-breakdown-chart">
     <div class="header-row">
-      <h2>Spending by Category</h2>
+      <h2 class="text-xl font-semibold mb-2">Spending by Category</h2>
       <input type="date" v-model="startDate" class="date-picker" />
       <input type="date" v-model="endDate" class="date-picker" />
       <div class="chart-summary">
@@ -177,8 +177,7 @@ onMounted(fetchData)
 }
 
 .header-row h2 {
-  margin: 0;
-  color: var(--neon-purple);
+  @apply text-xl font-semibold mb-2 mt-0 text-neon-purple;
 }
 
 .chart-summary {

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="daily-net-chart">
     <div class="header-row">
-      <h2>Daily Net Income</h2>
+      <h2 class="text-xl font-semibold mb-2">Daily Net Income</h2>
       <button class="zoom-toggle" @click="toggleZoom">
         {{ zoomedOut ? 'Zoom In' : 'Zoom Out' }}
       </button>
@@ -226,6 +226,10 @@ export default {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
+}
+
+.header-row h2 {
+  @apply text-xl font-semibold mb-2 mt-0 text-neon-purple;
 }
 
 .zoom-toggle {


### PR DESCRIPTION
## Summary
- enhance `<h2>` tags in DailyNetChart and CategoryBreakdownChart
- ensure header text uses Tailwind sizing and weight

## Testing
- `pre-commit run --all-files` *(fails: not found errors)*
- `pytest -q` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_685920cfb3dc8329bc73d449d7a24074