### PR TITLE
[frontend] Fix category breakdown spacing

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="category-breakdown-chart">
+  <div class="category-breakdown-chart pb-6">
     <div class="header-row">
       <h2 class="text-xl font-semibold mb-2">Spending by Category</h2>
       <input type="date" v-model="startDate" class="date-picker" />


### PR DESCRIPTION
## Summary
- adjust CategoryBreakdownChart container spacing

## Testing
- `pre-commit run --all-files` *(fails: missing docs and Bandit violations)*
- `pytest -q` *(fails: missing packages such as flask)*

------
https://chatgpt.com/codex/tasks/task_e_685a3c36b9cc83298d48f50fb7788a39