### PR TITLE
[frontend] Fix Category Chart spacing

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="category-breakdown-chart pb-6">
+  <div class="category-breakdown-chart p-4 pb-6">
     <div class="header-row">
       <h2 class="text-xl font-semibold mb-2">Spending by Category</h2>
       <input type="date" v-model="startDate" class="date-picker" />
@@ -170,7 +170,6 @@ onMounted(fetchData)
 .category-breakdown-chart {
   margin: 1rem;
   background-color: var(--color-bg-sec);
-  padding: 1rem;
   border-radius: 12px;
   box-shadow:
     0 4px 16px var(--shadow),


### PR DESCRIPTION
## Summary
- tweak chart container classes to give bottom padding via Tailwind

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue tests/test_model_field_validation.py` *(fails: bandit issues)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685aaa09f89c8329a619efc97cb5216b