### PR TITLE
[backend] Add Plaid token helpers

### DIFF
--- a/backend/app/helpers/plaid_helpers.py
+++ b/backend/app/helpers/plaid_helpers.py
@@ -1,10 +1,8 @@
+"""Helper utilities for interacting with the Plaid API."""
+
 import json
 
-from app.config import (
-    FILES,
-    PLAID_CLIENT_NAME,
-    plaid_client,
-)
+from app.config import FILES, PLAID_CLIENT_NAME, plaid_client
 from app.config.log_setup import setup_logger
 from app.extensions import db
 from app.models import Category
@@ -21,12 +19,43 @@ from plaid.model.link_token_create_request import LinkTokenCreateRequest
 from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
 from plaid.model.products import Products
 from plaid.model.transactions_get_request import TransactionsGetRequest
-from plaid.model.transactions_get_request_options import (
-    TransactionsGetRequestOptions,
-)
+from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
 
 logger = setup_logger()
 LAST_TRANSACTIONS = FILES["LAST_TX_REFRESH"]
+PLAID_TOKENS = FILES["PLAID_TOKENS"]
+
+
+def load_plaid_tokens():
+    """Load Plaid tokens from the designated JSON file."""
+    try:
+        logger.debug(f"Loading Plaid tokens from {PLAID_TOKENS}")
+        with open(PLAID_TOKENS, "r") as f:
+            tokens = json.load(f)
+        logger.debug(f"Loaded Plaid tokens: {tokens}")
+        return tokens
+    except FileNotFoundError:
+        logger.warning(
+            f"Tokens file not found at {PLAID_TOKENS}, returning empty list."
+        )
+        return []
+    except json.JSONDecodeError as e:
+        logger.error(
+            f"Error decoding tokens file at {PLAID_TOKENS}: {e}",
+            exc_info=True,
+        )
+        return []
+
+
+def save_plaid_tokens(tokens):
+    """Save Plaid tokens to the designated JSON file."""
+    try:
+        logger.debug(f"Saving Plaid tokens to {PLAID_TOKENS}: {tokens}")
+        with open(PLAID_TOKENS, "w") as f:
+            json.dump(tokens, f, indent=4)
+        logger.debug("Plaid tokens saved successfully.")
+    except Exception as e:
+        logger.error(f"Error saving tokens to {PLAID_TOKENS}: {e}", exc_info=True)
 
 
 def save_transactions_json(transactions):

--- a/tests/test_plaid_token_helpers.py
+++ b/tests/test_plaid_token_helpers.py
@@ -1,0 +1,92 @@
+import importlib.util
+import json
+import os
+import sys
+import types
+
+
+def load_plaid_helpers(tmp_path):
+    """Load plaid_helpers with stubs and return module and token path."""
+    config_stub = types.ModuleType("app.config")
+    token_path = os.path.join(tmp_path, "tokens.json")
+    config_stub.FILES = {
+        "PLAID_TOKENS": token_path,
+        "LAST_TX_REFRESH": os.path.join(tmp_path, "tx.json"),
+    }
+    config_stub.PLAID_CLIENT_NAME = "client"
+    config_stub.plaid_client = types.SimpleNamespace()
+    sys.modules["app.config"] = config_stub
+
+    log_setup_stub = types.ModuleType("app.config.log_setup")
+
+    class DummyLogger:
+        def debug(self, *a, **k):
+            pass
+
+        def info(self, *a, **k):
+            pass
+
+        def warning(self, *a, **k):
+            pass
+
+        def error(self, *a, **k):
+            pass
+
+    log_setup_stub.setup_logger = lambda: DummyLogger()
+    sys.modules["app.config.log_setup"] = log_setup_stub
+
+    sys.modules["app.extensions"] = types.ModuleType("app.extensions")
+    sys.modules["app.extensions"].db = types.SimpleNamespace()
+    sys.modules["app.models"] = types.ModuleType("app.models")
+    sys.modules["app.models"].Category = type("Category", (), {})
+    forecast_stub = types.ModuleType("app.sql.forecast_logic")
+    forecast_stub.update_account_history = lambda *a, **k: None
+    sys.modules["app.sql.forecast_logic"] = forecast_stub
+
+    # Stub plaid model classes
+    model_pkg = types.ModuleType("plaid.model")
+    sys.modules["plaid"] = types.ModuleType("plaid")
+    sys.modules["plaid.model"] = model_pkg
+    class_map = {
+        "accounts_get_request": "AccountsGetRequest",
+        "country_code": "CountryCode",
+        "institutions_get_by_id_request": "InstitutionsGetByIdRequest",
+        "investments_holdings_get_request": "InvestmentsHoldingsGetRequest",
+        "item_get_request": "ItemGetRequest",
+        "item_public_token_exchange_request": "ItemPublicTokenExchangeRequest",
+        "link_token_create_request": "LinkTokenCreateRequest",
+        "link_token_create_request_user": "LinkTokenCreateRequestUser",
+        "products": "Products",
+        "transactions_get_request": "TransactionsGetRequest",
+        "transactions_get_request_options": "TransactionsGetRequestOptions",
+    }
+    for mod_name, class_name in class_map.items():
+        mod = types.ModuleType(f"plaid.model.{mod_name}")
+        setattr(mod, class_name, type(class_name, (), {}))
+        setattr(model_pkg, mod_name, mod)
+        sys.modules[f"plaid.model.{mod_name}"] = mod
+
+    module_path = os.path.join(
+        os.path.dirname(__file__), "..", "backend", "app", "helpers", "plaid_helpers.py"
+    )
+    spec = importlib.util.spec_from_file_location("plaid_helpers", module_path)
+    plaid_helpers = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(plaid_helpers)  # type: ignore[attr-defined]
+    return plaid_helpers, token_path
+
+
+def test_load_tokens_returns_empty_when_missing(tmp_path):
+    plaid_helpers, _ = load_plaid_helpers(tmp_path)
+    assert plaid_helpers.load_plaid_tokens() == []
+
+
+def test_save_and_load_tokens(tmp_path):
+    plaid_helpers, path = load_plaid_helpers(tmp_path)
+    data = [
+        {"user_id": "u1", "access_token": "tok1"},
+        {"user_id": "u2", "access_token": "tok2"},
+    ]
+    plaid_helpers.save_plaid_tokens(data)
+    with open(path) as fh:
+        assert json.load(fh) == data
+    assert plaid_helpers.load_plaid_tokens() == data


### PR DESCRIPTION
## Summary
- provide functions to load and save Plaid tokens similar to Teller
- document module
- test JSON read/write for Plaid token helpers

## Testing
- `ruff check backend/app/helpers/plaid_helpers.py tests/test_plaid_token_helpers.py`
- `pytest tests/test_plaid_token_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac87bc8248329a83e0ca4d1eb28b0