### PR TITLE
[backend] Fix import dir path

### DIFF
--- a/backend/app/config/paths.py
+++ b/backend/app/config/paths.py
@@ -1,12 +1,18 @@
-# backend/app/config/paths.py
+"""Define and create backend directory structure.
+
+This module exposes common paths used by the backend. Each directory is created
+on import so other modules can read and write files safely.
+"""
 
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Directories used across the application. Paths are created automatically so
+# helpers do not need to check for existence.
 DIRECTORIES = {
     "DATA_DIR": BASE_DIR / "data",
-    "IMPORT_DIR": BASE_DIR / "data" / "imports`",
+    "IMPORT_DIR": BASE_DIR / "data" / "imports",
     "CERTS_DIR": BASE_DIR / "certs",
     "TEMP_DIR": BASE_DIR / "temp",
     "LOGS_DIR": BASE_DIR / "logs",

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,28 @@
+"""Tests for backend path configuration."""
+
+import importlib.util
+import os
+from pathlib import Path
+
+MODULE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "backend", "app", "config", "paths.py"
+)
+
+
+def test_directories_created(tmp_path):
+    """Ensure directories are created when the module is imported."""
+    # Prepare a temp copy of the module with BASE_DIR pointing to tmp_path
+    module_text = Path(MODULE_PATH).read_text(encoding="utf-8")
+    replacement = f"BASE_DIR = Path('{tmp_path}')"
+    module_text = module_text.replace(
+        "BASE_DIR = Path(__file__).resolve().parent.parent", replacement
+    )
+    temp_module = tmp_path / "paths_temp.py"
+    temp_module.write_text(module_text, encoding="utf-8")
+
+    spec = importlib.util.spec_from_file_location("paths_temp", temp_module)
+    paths = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(paths)
+
+    for path in paths.DIRECTORIES.values():
+        assert path.exists() and path.is_dir()


### PR DESCRIPTION
## Summary
- fix typo in `IMPORT_DIR` path
- ensure directories are created when module is imported
- add test verifying paths module creates directories

## Testing
- `pre-commit run --files backend/app/config/paths.py tests/test_paths.py` *(fails: mypy, bandit, model-field-validation)*
- `pytest tests/test_paths.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac87ddc388329aece55769cfde969