### PR TITLE
[frontend] Add username style to Dashboard

### DIFF
--- a/docs/frontend/THEMING_GUIDE.md
+++ b/docs/frontend/THEMING_GUIDE.md
@@ -69,8 +69,8 @@ all of them:
 | `--hover-bg` | hover background for buttons |
 | `--hover-glow` | drop shadow for hover effects |
 
-Additional variables such as `--color-accent-magenta`, `--bar-gradient-end`,
-`--asset-gradient-start`/`--asset-gradient-end`, and
+Additional variables such as `--color-accent-magenta`, `--color-accent-ice`,
+`--bar-gradient-end`, `--asset-gradient-start`/`--asset-gradient-end`, and
 `--liability-gradient-start`/`--liability-gradient-end` are used by specific
 charts and widgets. Review the default theme for the full list.
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -3,12 +3,12 @@
   <AppLayout>
     <template #header>
       <div class="text-center space-y-1 py-4">
-        <h1 class="text-4xl font-extrabold tracking-wide text-neon-purple">
+        <h1 class="text-4xl md:text-5xl font-extrabold tracking-wide text-neon-purple">
           Welcome,
-          <span class="text-neon-mint">{{ userName }}</span>!
+          <span class="username">{{ userName }}</span>!
         </h1>
-        <p class="text-sm text-muted">Today is {{ currentDate }}</p>
-        <p class="italic text-muted">and things are looking quite bleak.</p>
+        <p class="text-base text-muted">Today is {{ currentDate }}</p>
+        <p class="italic text-sm text-muted">and things are looking quite bleak.</p>
       </div>
     </template>
 
@@ -105,3 +105,10 @@ const currentDate = new Date().toLocaleDateString(undefined, {
   year: 'numeric',
 })
 </script>
+
+<style scoped>
+.username {
+  @apply text-[var(--color-accent-ice)] text-lg;
+  text-shadow: 2px 6px 8px var(--bar-gradient-end);
+}
+</style>


### PR DESCRIPTION
## Summary
- style Dashboard greeting to match Accounts view
- document `--color-accent-ice` variable in theming guide

## Testing
- `pre-commit run --all-files` *(fails: file not found errors)*
- `pytest -q` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_685acb1a98b48329ace2cfdeb5817bef