### PR TITLE
[backend] Fix CLI logger import

### DIFF
--- a/backend/app/cli/sync.py
+++ b/backend/app/cli/sync.py
@@ -1,5 +1,7 @@
-# cli.py
+"""Command line helpers for manual account synchronization."""
+
 import click
+from app.config import logger
 from app.helpers.account_refresh_dispatcher import refresh_all_accounts
 
 


### PR DESCRIPTION
## Summary
- fix `sync-accounts` CLI by importing logger

## Testing
- `flask sync-accounts`
- `pre-commit run --all-files` *(fails: file not found errors)*
- `pytest -q` *(fails: module `app` has no attribute `__path__`)*

------
https://chatgpt.com/codex/tasks/task_e_685d47019c688329941c4f7613ec0c67