### PR TITLE
[backend] Fix duplicate imports

### DIFF
--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -1,31 +1,51 @@
 # backend/app/config/__init__.py
 
-from .log_setup import setup_logger
-from .plaid_config import PLAID_BASE_URL, plaid_client
+"""Expose configuration constants and logger setup across the app."""
+
+from .constants import DATABASE_NAME, FILES, SQLALCHEMY_DATABASE_URI
 from .environment import (
     CLIENT_NAME,
     FLASK_ENV,
-    PLAID_CLIENT_NAME,
     PLAID_CLIENT_ID,
-    PLAID_SECRET,
+    PLAID_CLIENT_NAME,
     PLAID_ENV,
+    PLAID_SECRET,
+    PRODUCTS,
     TELLER_API_BASE_URL,
     TELLER_APP_ID,
     TELLER_CERTIFICATE,
     TELLER_PRIVATE_KEY,
     TELLER_WEBHOOK_SECRET,
-    VARIABLE_ENV_TOKEN,
     VARIABLE_ENV_ID,
-    PRODUCTS,
+    VARIABLE_ENV_TOKEN,
 )
-from .constants import (
-    FILES,
-    DATABASE_NAME,
-    SQLALCHEMY_DATABASE_URI,
-    FILES,
-    DIRECTORIES,
-)
+from .log_setup import setup_logger
 from .paths import DIRECTORIES
+from .plaid_config import PLAID_BASE_URL, plaid_client
+
+__all__ = [
+    "CLIENT_NAME",
+    "FLASK_ENV",
+    "PLAID_CLIENT_NAME",
+    "PLAID_CLIENT_ID",
+    "PLAID_SECRET",
+    "PLAID_ENV",
+    "TELLER_API_BASE_URL",
+    "TELLER_APP_ID",
+    "TELLER_CERTIFICATE",
+    "TELLER_PRIVATE_KEY",
+    "TELLER_WEBHOOK_SECRET",
+    "VARIABLE_ENV_TOKEN",
+    "VARIABLE_ENV_ID",
+    "PRODUCTS",
+    "FILES",
+    "DATABASE_NAME",
+    "SQLALCHEMY_DATABASE_URI",
+    "DIRECTORIES",
+    "plaid_client",
+    "PLAID_BASE_URL",
+    "logger",
+]
 
 env_check = PLAID_ENV.upper()
 


### PR DESCRIPTION
## Summary
- deduplicate FILES and DIRECTORIES imports in config
- expose config symbols with `__all__`

## Testing
- `pre-commit run --files backend/app/config/__init__.py` *(fails: mypy, pylint, bandit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.config')*

------
https://chatgpt.com/codex/tasks/task_e_685d471635448329980441f912791e5a