### PR TITLE
[backend] Replace utcnow with timezone aware now

### DIFF
--- a/backend/app/helpers/account_refresh_dispatcher.py
+++ b/backend/app/helpers/account_refresh_dispatcher.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from app.config import logger  # uses app logger
 from app.models import Account, db
@@ -14,7 +14,7 @@ def is_due(last_synced, provider):
     """Returns True if the account should be refreshed."""
     if not last_synced:
         return True
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return now - last_synced >= SYNC_INTERVALS.get(provider, timedelta(days=1))
 
 
@@ -53,7 +53,7 @@ def refresh_all_accounts():
             )
             sync_service.sync_account(acct)
             if rel:
-                rel.last_refreshed = datetime.utcnow()
+                rel.last_refreshed = datetime.now(timezone.utc)
             db.session.commit()
             updated += 1
             logger.info(
@@ -65,6 +65,4 @@ def refresh_all_accounts():
                 f"❌ Sync failed for account {acct.id}: {str(e)}", exc_info=True
             )
 
-    logger.info(
-        f"🔚 Account refresh complete: {updated} updated, {skipped} skipped."
-    )
+    logger.info(f"🔚 Account refresh complete: {updated} updated, {skipped} skipped.")

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -1,6 +1,6 @@
 """Account management and refresh routes."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.config import logger
 from app.extensions import db
@@ -61,7 +61,7 @@ def refresh_all_accounts():
                     end_date=end_date,
                 )
                 if updated and account.plaid_account:
-                    account.plaid_account.last_refreshed = datetime.utcnow()
+                    account.plaid_account.last_refreshed = datetime.now(timezone.utc)
                     updated_accounts.append(account.name)
                     inst = account.institution_name or "Unknown"
                     refreshed_counts[inst] = refreshed_counts.get(inst, 0) + 1
@@ -89,7 +89,7 @@ def refresh_all_accounts():
                     end_date=end_date,
                 )
                 if updated and account.teller_account:
-                    account.teller_account.last_refreshed = datetime.utcnow()
+                    account.teller_account.last_refreshed = datetime.now(timezone.utc)
                     updated_accounts.append(account.name)
                     inst = account.institution_name or "Unknown"
                     refreshed_counts[inst] = refreshed_counts.get(inst, 0) + 1
@@ -147,7 +147,7 @@ def refresh_single_account(account_id):
             end_date=end_date,
         )
         if updated and account.plaid_account:
-            account.plaid_account.last_refreshed = datetime.utcnow()
+            account.plaid_account.last_refreshed = datetime.now(timezone.utc)
 
     elif account.link_type == "Teller":
         access_token = None
@@ -175,7 +175,7 @@ def refresh_single_account(account_id):
             end_date=end_date,
         )
         if updated and account.teller_account:
-            account.teller_account.last_refreshed = datetime.utcnow()
+            account.teller_account.last_refreshed = datetime.now(timezone.utc)
     else:
         return (
             jsonify({"status": "error", "message": "Unsupported link type"}),

--- a/backend/app/routes/plaid_transactions.py
+++ b/backend/app/routes/plaid_transactions.py
@@ -1,10 +1,9 @@
 # file: app/routes/plaid_transactions.py
-from datetime import datetime
+from datetime import datetime, timezone
 
-from app.config import PLAID_CLIENT_ID, PLAID_CLIENT_NAME, CLIENT_NAME, logger
+from app.config import CLIENT_NAME, PLAID_CLIENT_ID, logger
 from app.extensions import db
 from app.helpers.plaid_helpers import (
-    refresh_plaid_categories,
     exchange_public_token,
     generate_link_token,
     get_accounts,
@@ -106,7 +105,7 @@ def exchange_public_token_endpoint():
                 access_token=access_token,
                 item_id=item_id,
                 institution_id=institution_id,
-                last_refreshed=datetime.utcnow(),
+                last_refreshed=datetime.now(timezone.utc),
             )
             db.session.add(new_plaid_account)
 

--- a/backend/app/routes/teller.py
+++ b/backend/app/routes/teller.py
@@ -1,7 +1,7 @@
 """Routes for Teller account linking and data ingestion."""
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 from app.config import FILES, TELLER_APP_ID, logger
@@ -112,7 +112,7 @@ def link_account():
         rec = TellerAccount.query.filter_by(account_id=acct_id).first()
         if rec:
             rec.access_token = access_token
-            rec.updated_at = datetime.utcnow()
+            rec.updated_at = datetime.now(timezone.utc)
         else:
             db.session.add(TellerAccount(account_id=acct_id, access_token=access_token))
 

--- a/backend/app/routes/teller_transactions.py
+++ b/backend/app/routes/teller_transactions.py
@@ -1,8 +1,7 @@
 # teller_transactions.py
 import json
-import os
-from datetime import datetime
-import requests
+from datetime import datetime, timezone
+
 from app.config import FILES, TELLER_API_BASE_URL, logger
 from app.extensions import db
 from app.helpers.teller_helpers import load_tokens  # Use the shared helper
@@ -96,7 +95,7 @@ def teller_refresh_accounts():
             )
             if updated:
                 updated_accounts.append(account.name)
-                account.last_refreshed = datetime.utcnow()
+                account.last_refreshed = datetime.now(timezone.utc)
         db.session.commit()
         return (
             jsonify(

--- a/backend/app/routes/teller_webhook.py
+++ b/backend/app/routes/teller_webhook.py
@@ -1,14 +1,16 @@
 # teller_webhook.py
-import hmac
-import hashlib
 import base64
+import hashlib
+import hmac
 import json
-from flask import Blueprint, request, jsonify, current_app
+from datetime import datetime, timezone
+
 from app.config import FILES, logger
-from app.helpers.teller_helpers import load_tokens
-from app.sql import account_logic
 from app.extensions import db
+from app.helpers.teller_helpers import load_tokens
 from app.models import Account
+from app.sql import account_logic
+from flask import Blueprint, jsonify, request
 
 TELLER_WEBHOOK_SECRET = FILES.get("TELLER_WEBHOOK_SECRET")
 
@@ -89,7 +91,7 @@ def teller_webhook():
                 FILES["TELLER_API_BASE_URL"],
             )
             if updated:
-                account.last_refreshed = datetime.utcnow()
+                account.last_refreshed = datetime.now(timezone.utc)
                 db.session.commit()
 
         return jsonify({"status": "ok"}), 200

--- a/backend/app/services/forecast_engine.py
+++ b/backend/app/services/forecast_engine.py
@@ -1,9 +1,10 @@
 # forecast_engine.py
-from datetime import datetime, timedelta
-from typing import List
 from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from app.models import AccountHistory, RecurringTransaction
 from sqlalchemy.orm import Session
-from app.models import RecurringTransaction, AccountHistory
 
 
 class ForecastEngine:
@@ -74,7 +75,7 @@ class ForecastEngine:
 
         output = []
         for i in range(horizon_days):
-            day = (datetime.utcnow() + timedelta(days=i)).date()
+            day = (datetime.now(timezone.utc) + timedelta(days=i)).date()
             for acc_id in balances:
                 delta = daily_txns[day][acc_id]
                 balances[acc_id] += delta

--- a/backend/app/services/forecast_orchestrator.py
+++ b/backend/app/services/forecast_orchestrator.py
@@ -1,9 +1,11 @@
 # forecast_orchestrator.py
-from datetime import datetime, timedelta
-from sqlalchemy import func
-from .forecast_engine import ForecastEngine as ForecastEngineRuleBased
+from datetime import datetime, timedelta, timezone
+
 from app.models import Account, AccountHistory
 from app.sql import forecast_logic
+from sqlalchemy import func
+
+from .forecast_engine import ForecastEngine as ForecastEngineRuleBased
 
 try:  # Optional dependency
     from .forecast_stat_model import ForecastEngine as ForecastEngineStatModel
@@ -41,7 +43,7 @@ class ForecastOrchestrator:
     ):
         """Assemble forecast and actual lines with metadata."""
 
-        start = datetime.utcnow().date()
+        start = datetime.now(timezone.utc).date()
         horizon = 30 if view_type.lower() == "month" else 365
         end = start + timedelta(days=horizon - 1)
 

--- a/backend/app/sql/forecast_logic.py
+++ b/backend/app/sql/forecast_logic.py
@@ -1,11 +1,11 @@
 # backend/app/sql/forecast_logic.py
-from datetime import datetime, timedelta
-from sqlalchemy import func
-from sqlalchemy.dialects.sqlite import insert
+from datetime import datetime, timedelta, timezone
 
+from app.config import logger
 from app.extensions import db
 from app.models import Account, AccountHistory, RecurringTransaction, Transaction
-from app.config import logger
+from sqlalchemy import func
+from sqlalchemy.dialects.sqlite import insert
 
 
 def get_latest_balance_for_account(account_id: str, user_id: str) -> float:
@@ -27,8 +27,8 @@ def get_latest_balance_for_account(account_id: str, user_id: str) -> float:
 
 
 def update_account_history(account_id, user_id, balance, is_hidden=None):
-    today = datetime.utcnow().date()
-    now = datetime.utcnow()
+    today = datetime.now(timezone.utc).date()
+    now = datetime.now(timezone.utc)
 
     try:
         stmt = (

--- a/backend/app/sql/manual_import_logic.py
+++ b/backend/app/sql/manual_import_logic.py
@@ -1,5 +1,5 @@
 # manual_import_logic.py
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.extensions import db
 from app.models import Transaction
@@ -19,9 +19,9 @@ def upsert_imported_transactions(transactions, user_id=None, account_id=None):
             try:
                 parsed_date = datetime.fromisoformat(raw_date)
             except (TypeError, ValueError):
-                parsed_date = datetime.utcnow()
+                parsed_date = datetime.now(timezone.utc)
         else:
-            parsed_date = datetime.utcnow()
+            parsed_date = datetime.now(timezone.utc)
 
         txn = Transaction(
             transaction_id=tx.get("transaction_id"),

--- a/backend/load_transactions.py
+++ b/backend/load_transactions.py
@@ -1,7 +1,8 @@
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
 from app import create_app, db
-from app.models import Account, Transaction, Category
+from app.models import Account, Category, Transaction
 
 CATEGORIES = {
     "groceries": (-80, -150),
@@ -24,7 +25,7 @@ def get_or_create_category(name):
 
 def generate_transactions_for_account(account, months=6, start_date=None):
     if not start_date:
-        start_date = datetime.utcnow() - timedelta(days=30 * months)
+        start_date = datetime.now(timezone.utc) - timedelta(days=30 * months)
 
     transactions = []
     for month_offset in range(months):


### PR DESCRIPTION
## Summary
- use `datetime.now(timezone.utc)` across backend modules
- import `timezone` where needed for naive datetime fixes

## Testing
- `pre-commit run --files backend/app/sql/forecast_logic.py backend/app/sql/account_logic.py backend/app/sql/manual_import_logic.py backend/app/helpers/account_refresh_dispatcher.py backend/app/routes/accounts.py backend/app/routes/plaid_transactions.py backend/app/routes/teller_transactions.py backend/app/routes/teller_webhook.py backend/app/routes/teller.py backend/app/services/forecast_engine.py backend/app/services/forecast_orchestrator.py backend/load_transactions.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d4719952c8329b9232b4de4160242