### PR TITLE
[docs] Fix backend map

### DIFF
--- a/docs/maps/backend_map.txt
+++ b/docs/maps/backend_map.txt
@@ -92,7 +92,6 @@ Directory Tree Mapping
 │   │   ├── teller.py
 │   │   ├── teller_transactions.py
 │   │   ├── teller_webhook.py
-│   │   ├── teller_webhoook_disabled.py
 │   │   └── transactions.py
 │   ├── run_api.py
 │   ├── sql


### PR DESCRIPTION
## Summary
- update backend map and drop reference to old webhook

## Testing
- `pre-commit run --files docs/maps/backend_map.txt` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e29f4da988329b2c57da65753e4b3