### PR TITLE
[docs] Correct @reference path example

### DIFF
--- a/docs/TAILWIND_VITE_STYLE_REFERENCE.md
+++ b/docs/TAILWIND_VITE_STYLE_REFERENCE.md
@@ -68,14 +68,15 @@ This has implications:
 
 ```vue
 <style>
-@reference "../../app.css";
+@reference "../assets/css/main.css";    /* if used inside /src/views */
+@reference "../../assets/css/main.css"; /* if used inside /src/components */
 .my-class {
   @apply text-red-500 font-bold;
 }
 </style>
 ```
 
-> 📌 `@reference` makes global utility classes available to CSS blocks without duplicating them in the bundle.
+> 📌 `@reference` makes global utility classes available to CSS blocks without duplicating them in the bundle. Views live directly under `/src`, while components are one directory deeper, requiring an extra `../` in the path.
 
 #### Option 2: CSS Variables (Preferred for Performance)
 


### PR DESCRIPTION
## Summary
- update Tailwind docs to show real `@reference` path
- explain difference between `/src/views` and `/src/components`

## Testing
- `pre-commit run --files docs/TAILWIND_VITE_STYLE_REFERENCE.md` *(fails: no tests ran)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ef36429608329b6ec50cb55d2298b