### PR TITLE
[frontend] Add bar-click events to charts

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -26,11 +26,17 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
+/**
+ * CategoryBreakdownChart visualizes spending per category.
+ * Emits a `bar-click` event when a bar is clicked.
+ */
+import { ref, computed, onMounted, watch, nextTick, defineEmits } from 'vue'
 import { debounce } from 'lodash-es'
 import { Chart } from 'chart.js/auto'
 import { fetchCategoryBreakdownTree } from '@/api/charts'
 import GroupedCategoryDropdown from '@/components/ui/GroupedCategoryDropdown.vue'
+
+const emit = defineEmits(['bar-click'])
 
 const chartCanvas = ref(null)
 const chartInstance = ref(null)
@@ -152,6 +158,22 @@ function extractBars(tree, selectedIds = []) {
   return { labels, data, colors }
 }
 
+// Emit category label when a bar is clicked
+function handleBarClick(evt) {
+  if (!chartInstance.value) return
+  const points = chartInstance.value.getElementsAtEventForMode(
+    evt,
+    'nearest',
+    { intersect: true },
+    false,
+  )
+  if (points.length) {
+    const index = points[0].index
+    const label = chartInstance.value.data.labels[index]
+    emit('bar-click', label)
+  }
+}
+
 function renderChart() {
   const ctx = chartCanvas.value?.getContext('2d')
   if (!ctx) return
@@ -179,6 +201,7 @@ function renderChart() {
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      onClick: handleBarClick,
       plugins: {
         legend: { display: false },
         tooltip: {

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -22,9 +22,15 @@
 </template>
 
 <script setup>
+/**
+ * DailyNetChart displays daily income and expenses with a net line.
+ * Emits a `bar-click` event when a bar is clicked.
+ */
 import { fetchDailyNet } from '@/api/charts'
-import { ref, onMounted, onUnmounted, nextTick, computed, watch } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick, computed, watch, defineEmits } from 'vue'
 import { Chart } from 'chart.js/auto'
+
+const emit = defineEmits(['bar-click'])
 
 const chartInstance = ref(null)
 const chartCanvas = ref(null)
@@ -44,6 +50,22 @@ async function fetchData() {
 
 function toggleZoom() {
   zoomedOut.value = !zoomedOut.value
+}
+
+// Emit selected date when a bar is clicked
+function handleBarClick(evt) {
+  if (!chartInstance.value) return
+  const points = chartInstance.value.getElementsAtEventForMode(
+    evt,
+    'nearest',
+    { intersect: true },
+    false,
+  )
+  if (points.length) {
+    const index = points[0].index
+    const date = chartInstance.value.data.labels[index]
+    emit('bar-click', date)
+  }
 }
 
 watch([chartData, zoomedOut], async () => {
@@ -173,20 +195,7 @@ function renderChart() {
         },
         legend: { display: false },
       },
-      onClick: evt => {
-        if (!chartInstance.value) return
-        const points = chartInstance.value.getElementsAtEventForMode(
-          evt,
-          'nearest',
-          { intersect: true },
-          false,
-        )
-        if (points.length) {
-          const index = points[0].index
-          const date = filtered[index].date
-          // You can emit or handle the click event as needed
-        }
-      },
+      onClick: handleBarClick,
     },
   })
 }


### PR DESCRIPTION
## Summary
- emit `bar-click` events from `CategoryBreakdownChart` and `DailyNetChart`
- expose `handleBarClick` to send clicked bar data

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue frontend/src/components/charts/DailyNetChart.vue` *(fails: Validate model fields hook)*
- `PYTHONPATH=backend pytest -q` *(fails: ModuleNotFoundError: No module named 'app.config')*


------
https://chatgpt.com/codex/tasks/task_e_685f7537fcf08329b0c4bd6be18ee2f2