### PR TITLE
[docs] document categories tree endpoint

### DIFF
--- a/docs/backend/app/routes/categories.md
+++ b/docs/backend/app/routes/categories.md
@@ -12,12 +12,18 @@ Manages transaction categorization logic and user-defined category updates. Supp
 - `GET /categories`: Fetch default and user-defined categories.
 - `POST /categories/update`: Update category metadata (e.g., label, emoji).
 - `POST /categories/apply`: Reassign category tags to transactions.
+- `GET /categories/tree`: Nested view of primary and detailed categories.
 
 ## Inputs & Outputs
 
 - **GET /categories**
 
   - **Output:** List of all categories, including system and custom types.
+
+- **GET /categories/tree**
+
+  - **Output:** `{ status: 'success', data: [{ name: str, children: [{ id: int, name: str }] }] }`
+  - Useful for populating dropdown menus.
 
 - **POST /categories/update**
 

--- a/docs/backend/app/routes/index.md
+++ b/docs/backend/app/routes/index.md
@@ -6,6 +6,7 @@
 
 - [`accounts.py`](#accounts-route)
 - [`categories.py`](#categories-route)
+- [`GET /categories/tree`](categories.md)
 - [`charts.py`](#charts-route)
 - [`export.py`](#export-route)
 - [`forecast.py`](#forecast-route)


### PR DESCRIPTION
## Summary
- add new `/categories/tree` endpoint details
- link from routes index

## Testing
- `pre-commit run --files docs/backend/app/routes/categories.md docs/backend/app/routes/index.md` *(fails: model-field-validation)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f7577616483298fde50eb0ed5bc11