### PR TITLE
[frontend] fix root total spending

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -49,7 +49,7 @@ const startDate = ref(
   new Date(today.setDate(today.getDate() - 30)).toISOString().slice(0, 10)
 )
 
-const totalSpending = computed(() => sumAmounts(categoryTree.value))
+const totalSpending = computed(() => sumRootAmounts(categoryTree.value))
 
 const groupColors = [
   '#a78bfa', '#5db073', '#fbbf24', '#a43e5c', '#3b82f6',
@@ -83,11 +83,13 @@ async function fetchData() {
   }
 }
 
-function sumAmounts(nodes) {
-  return (nodes || []).reduce((sum, n) => {
-    const subtotal = n.amount + sumAmounts(n.children || [])
-    return sum + subtotal
-  }, 0)
+/**
+ * Sum only root-level amounts from the category tree.
+ * @param {Array<Object>} nodes - root nodes returned from the API
+ * @returns {number} aggregated spending total
+ */
+function sumRootAmounts(nodes) {
+  return (nodes || []).reduce((sum, n) => sum + (n.amount || 0), 0)
 }
 
 const categoryGroups = computed(() => {


### PR DESCRIPTION
## Summary
- compute total spending only from root-level amounts
- test category_breakdown_tree totals against backend

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue tests/test_api_charts.py` *(with pylint, bandit and model-field-validation skipped)*
- `pytest tests/test_api_charts.py`


------
https://chatgpt.com/codex/tasks/task_e_685fa551b30483298075c6f59ee90107