### PR TITLE
[frontend] Add category menu tree

### DIFF
--- a/frontend/src/api/categories.js
+++ b/frontend/src/api/categories.js
@@ -1,0 +1,12 @@
+// src/api/categories.js
+// API helpers for category menu data
+import axios from 'axios'
+
+/**
+ * Fetch hierarchical category tree for dropdown menus.
+ * @returns {Promise<Object>} API response
+ */
+export async function fetchCategoryTree() {
+  const response = await axios.get('/api/categories/tree')
+  return response.data
+}


### PR DESCRIPTION
## Summary
- create `fetchCategoryTree` API helper
- load category tree in `CategoryBreakdownChart`
- build dropdown groups from the new tree

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue frontend/src/api/categories.js` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685fa6f0d91c832984367f064ec18873