### PR TITLE
[frontend] Clean unused defineEmits import

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -30,7 +30,7 @@
  * CategoryBreakdownChart visualizes spending per category.
  * Emits a `bar-click` event when a bar is clicked.
  */
-import { ref, computed, onMounted, watch, nextTick, defineEmits } from 'vue'
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { debounce } from 'lodash-es'
 import { Chart } from 'chart.js/auto'
 import { fetchCategoryBreakdownTree } from '@/api/charts'

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -27,7 +27,7 @@
  * Emits a `bar-click` event when a bar is clicked.
  */
 import { fetchDailyNet } from '@/api/charts'
-import { ref, onMounted, onUnmounted, nextTick, computed, watch, defineEmits } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick, computed, watch } from 'vue'
 import { Chart } from 'chart.js/auto'
 
 const emit = defineEmits(['bar-click'])


### PR DESCRIPTION
## Summary
- remove `defineEmits` from the `import` lines in CategoryBreakdownChart and DailyNetChart

## Testing
- `SKIP=model-field-validation pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue frontend/src/components/charts/DailyNetChart.vue`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.config')*

------
https://chatgpt.com/codex/tasks/task_e_685f8ad7f42883299485f699c310cab4