### PR TITLE
[frontend] Use category API helper

### DIFF
--- a/frontend/src/components/tables/MasterTxidTable.vue
+++ b/frontend/src/components/tables/MasterTxidTable.vue
@@ -106,6 +106,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
+import { fetchCategoryTree } from '@/api/categories'
 import { useToast } from 'vue-toastification'
 
 const toast = useToast()
@@ -228,9 +229,9 @@ const filteredTransactions = computed(() => {
 
 onMounted(async () => {
   try {
-    const res = await axios.get('/api/categories/tree')
-    if (res.data?.status === 'success') {
-      categoryTree.value = res.data.data
+    const res = await fetchCategoryTree()
+    if (res?.status === 'success') {
+      categoryTree.value = res.data
     }
   } catch (e) {
     console.error('Failed to load category tree:', e)

--- a/frontend/src/components/tables/UpdateTransactionsTable.vue
+++ b/frontend/src/components/tables/UpdateTransactionsTable.vue
@@ -139,6 +139,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
+import { fetchCategoryTree } from '@/api/categories'
 import { useToast } from 'vue-toastification'
 
 const toast = useToast()
@@ -256,9 +257,9 @@ const filteredTransactions = computed(() => {
 
 onMounted(async () => {
   try {
-    const res = await axios.get('/api/categories/tree')
-    if (res.data?.status === 'success') {
-      categoryTree.value = res.data.data
+    const res = await fetchCategoryTree()
+    if (res?.status === 'success') {
+      categoryTree.value = res.data
     }
   } catch (e) {
     console.error('Failed to load category tree:', e)


### PR DESCRIPTION
## Summary
- centralize category fetches through `fetchCategoryTree`
- update transaction tables to use the new helper

## Testing
- `pre-commit run --files tests/test_model_field_validation.py` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68604cbe849c8329a7dcadc10bedc0e4