### PR TITLE
[frontend] Fix total spending calc

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -49,7 +49,10 @@ const startDate = ref(
   new Date(today.setDate(today.getDate() - 30)).toISOString().slice(0, 10)
 )
 
-const totalSpending = computed(() => sumAmounts(categoryTree.value))
+// Compute total from root categories only to prevent double-counting
+const totalSpending = computed(() =>
+  (categoryTree.value || []).reduce((sum, n) => sum + (n.amount || 0), 0)
+)
 
 const groupColors = [
   '#a78bfa', '#5db073', '#fbbf24', '#a43e5c', '#3b82f6',
@@ -83,12 +86,6 @@ async function fetchData() {
   }
 }
 
-function sumAmounts(nodes) {
-  return (nodes || []).reduce((sum, n) => {
-    const subtotal = n.amount + sumAmounts(n.children || [])
-    return sum + subtotal
-  }, 0)
-}
 
 const categoryGroups = computed(() => {
   // [{id, label, children: [{id, label}]}]


### PR DESCRIPTION
## Summary
- fix total amount calculation in `CategoryBreakdownChart`

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue` *(fails: Validate model fields - ModuleNotFoundError: No module named 'flask')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685fa6f3ee7483298784360f5b9277af