### PR TITLE
[api] Add net changes endpoint

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -384,3 +384,26 @@ def match_account_by_fields():
         )
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@accounts.route("/<account_id>/net_changes", methods=["GET"])
+def account_net_changes(account_id):
+    """Return net income and expense totals for an account."""
+    try:
+        start_date_str = request.args.get("start_date")
+        end_date_str = request.args.get("end_date")
+
+        start_date = (
+            datetime.strptime(start_date_str, "%Y-%m-%d").date()
+            if start_date_str
+            else None
+        )
+        end_date = (
+            datetime.strptime(end_date_str, "%Y-%m-%d").date() if end_date_str else None
+        )
+
+        data = account_logic.get_net_changes(account_id, start_date, end_date)
+        return jsonify({"status": "success", "data": data}), 200
+    except Exception as e:
+        logger.error(f"Error in account_net_changes: {e}", exc_info=True)
+        return jsonify({"status": "error", "message": str(e)}), 500

--- a/docs/latest/net_changes_feature.md
+++ b/docs/latest/net_changes_feature.md
@@ -1,0 +1,11 @@
+# Net Changes API
+
+The `/api/accounts/<account_id>/net_changes` endpoint reports income and expense totals for an account.
+
+## Logic Overview
+- `account_logic.get_net_changes` aggregates transactions within an optional date range using SQL sum functions.
+- The accounts route parses `start_date` and `end_date` query params and returns JSON `{income, expense, net}`.
+
+## Potential Issues
+- Missing transactions or incorrect date parsing can lead to inaccurate totals.
+- This endpoint currently relies on `Transaction.amount` signs to determine income vs expense.

--- a/docs/latest/recent_transactions_feature.md
+++ b/docs/latest/recent_transactions_feature.md
@@ -1,0 +1,12 @@
+# Recent Transactions API
+
+`GET /api/transactions/<account_id>/transactions?recent=true&limit=10`
+returns the newest transactions for an account.
+
+## Logic Overview
+- `get_paginated_transactions` now accepts `account_id`, `recent`, and `limit` arguments.
+- When `recent=true`, pagination is skipped and only the latest `limit` rows are returned.
+- The new route wraps this logic and supports standard filtering params.
+
+## Potential Issues
+- Sorting relies on `Transaction.date` which may not match insertion time if data was backfilled.


### PR DESCRIPTION
## Summary
- add module docstring for transactions blueprint
- expand account_logic with `get_net_changes` and extra params for recent transactions
- expose `/api/accounts/<account_id>/net_changes`
- add `/api/transactions/<account_id>/transactions` for recent transactions
- document logic under `docs/latest`

## Testing
- `pre-commit run --files backend/app/routes/transactions.py backend/app/routes/accounts.py backend/app/sql/account_logic.py` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_68648ca265ac832982ae02d0693eea0c