### PR TITLE
[frontend] Fix dropdown update recursion

### DIFF
--- a/frontend/src/components/ui/GroupedCategoryDropdown.vue
+++ b/frontend/src/components/ui/GroupedCategoryDropdown.vue
@@ -28,6 +28,8 @@
 </template>
 
 <script setup>
+// Multi-select dropdown for selecting categories grouped by parent.
+// Emits `update:modelValue` with the selected category IDs.
 import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
@@ -38,15 +40,29 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue'])
 const open = ref(false)
 const expanded = ref(new Set())
+// Local copy of selected ids; kept in sync with the parent via v-model
 const selectedIds = ref(new Set(props.modelValue))
+// Flag prevents prop updates from triggering a feedback loop
+const updatingFromProps = ref(false)
 
+// When parent updates the modelValue, sync our local set
 watch(
   () => props.modelValue,
-  val => (selectedIds.value = new Set(val))
+  val => {
+    updatingFromProps.value = true
+    selectedIds.value = new Set(val)
+  }
 )
+// Emit changes only when they originate from user interaction
 watch(
   selectedIds,
-  val => emit('update:modelValue', Array.from(val)),
+  val => {
+    if (updatingFromProps.value) {
+      updatingFromProps.value = false
+      return
+    }
+    emit('update:modelValue', Array.from(val))
+  },
   { deep: true }
 )
 


### PR DESCRIPTION
## Summary
- prevent feedback loop in `GroupedCategoryDropdown` watch handlers

## Testing
- `pre-commit run --files frontend/src/components/ui/GroupedCategoryDropdown.vue` *(fails: command not found)*
- `pytest -k test_api_charts.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867fb2d45948329a2bd80aacf41da79