### PR TITLE
[frontend] Update category chart styling

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -26,6 +26,11 @@
 </template>
 
 <script setup>
+/**
+ * CategoryBreakdownChart visualizes spending by parent category and
+ * allows filtering by top-level category groups. Emits `bar-click`
+ * with the selected category label.
+ */
 import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { debounce } from 'lodash-es'
 import { Chart } from 'chart.js/auto'
@@ -55,6 +60,13 @@ const groupColors = [
 ]
 function getGroupColor(idx) {
   return groupColors[idx % groupColors.length]
+}
+
+// Retrieve a CSS custom property value
+function getStyle(name) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim()
 }
 
 // ---- FIXED LOGIC ----
@@ -191,6 +203,7 @@ function renderChart() {
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      layout: { padding: { top: 20, bottom: 20 } },
       onClick: handleBarClick,
       plugins: {
         legend: { display: false },
@@ -203,17 +216,19 @@ function renderChart() {
       scales: {
         x: {
           ticks: {
-            color: '#c4b5fd',
-            font: { size: 14 },
+            color: getStyle('--color-text-muted'),
+            font: { family: "'Fira Code', monospace", size: 14 },
           },
+          grid: { color: getStyle('--divider') },
         },
         y: {
           beginAtZero: true,
           ticks: {
             callback: value => `$${value}`,
-            color: '#c4b5fd',
-            font: { size: 14 },
+            color: getStyle('--color-text-muted'),
+            font: { family: "'Fira Code', monospace", size: 14 },
           },
+          grid: { color: getStyle('--divider') },
         },
       },
     },


### PR DESCRIPTION
## Summary
- harmonize CategoryBreakdownChart with DailyNetChart
- add a getStyle helper for CSS variables
- apply consistent grid, tick and layout settings

## Testing
- `pre-commit run --files frontend/src/components/charts/CategoryBreakdownChart.vue` *(fails: Validate model fields)*
- `pytest` *(fails: missing dependencies such as flask_sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6868d6630d988329855a35be66067dbd