### PR TITLE
[frontend] Fix API imports for net charts

### DIFF
--- a/frontend/src/components/charts/NetIncomeCharts.vue
+++ b/frontend/src/components/charts/NetIncomeCharts.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import { fetchDailyNet } from '@/api/charts'
+import api from '@/services/api.js'
 import { ref, onMounted, nextTick, computed } from "vue";
 import { Chart } from "chart.jsauto";
 

--- a/frontend/src/components/charts/NetYearComparisonChart.vue
+++ b/frontend/src/components/charts/NetYearComparisonChart.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import { fetchDailyNet } from '@/api/charts'
+import api from '@/services/api.js'
 import { ref, onMounted, nextTick } from 'vue'
 import { Chart } from 'chart.js/auto'
 


### PR DESCRIPTION
## Summary
- update API service import in NetIncomeCharts
- update API service import in NetYearComparisonChart

## Testing
- `npx eslint src/components/charts/NetIncomeCharts.vue src/components/charts/NetYearComparisonChart.vue`
- `pre-commit run --all-files` *(fails: missing docs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6868d874a2d88329b9db503d0cd05f51