### PR TITLE
[backend] Add IDs to category tree

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -64,10 +64,14 @@ const parentCategories = computed(() => fullCategoryTree.value || [])
 
 // For the dropdown
 const categoryGroups = computed(() =>
-  parentCategories.value
+  (parentCategories.value || [])
     .map(root => ({
       id: root.id,
       label: root.label,
+      children: (root.children || []).map(c => ({
+        id: c.id,
+        label: c.label ?? c.name,
+      })),
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 )


### PR DESCRIPTION
## Summary
- provide unique IDs and `label` fields for root categories
- consume new tree shape in `CategoryBreakdownChart`
- cover category tree shape in tests

## Testing
- `pre-commit run --files backend/app/routes/categories.py frontend/src/components/charts/CategoryBreakdownChart.vue tests/test_api_charts.py` *(fails: mypy, pylint, bandit, model-field-validation)*
- `pytest -q` *(fails: import errors for flask and other libs)*

------
https://chatgpt.com/codex/tasks/task_e_6868d662646c8329a2c4bcb60f1187c9