### PR TITLE
[frontend] Drop unused vars in AccountSnapshot

### DIFF
--- a/frontend/src/components/widgets/AccountSnapshot.vue
+++ b/frontend/src/components/widgets/AccountSnapshot.vue
@@ -74,7 +74,7 @@ import { ref, computed } from 'vue'
 import { useSnapshotAccounts } from '@/composables/useSnapshotAccounts.js'
 
 const hovered = ref(null)
-const { accounts, selectedAccounts, selectedIds, reminders } = useSnapshotAccounts()
+const { selectedAccounts, reminders } = useSnapshotAccounts()
 
 function formatAccounting(val) {
   const num = parseFloat(val || 0)


### PR DESCRIPTION
## Summary
- simplify AccountSnapshot composable usage

## Testing
- `npx eslint src/components/widgets/AccountSnapshot.vue --fix`
- `pre-commit run --all-files` *(fails: not found errors)*
- `pytest` *(fails: module 'app' has no attribute '__path__')*

------
https://chatgpt.com/codex/tasks/task_e_6868d87657c88329b556cf8d9cc155e6