### PR TITLE
[frontend] Integrate transaction API module

### DIFF
--- a/frontend/src/api/transactions.js
+++ b/frontend/src/api/transactions.js
@@ -1,19 +1,17 @@
-
-// src/api/charts.js
+/**
+ * Transaction API helpers.
+ *
+ * Provides functions for retrieving and updating transaction data from the
+ * backend. These utilities are consumed by composables and Vue components.
+ */
 import axios from 'axios'
 
-export const fetchCategoryBreakdown = async () => {
-  const response = await axios.get('/api/charts/category_breakdown')
+export const fetchTransactions = async (params = {}) => {
+  const response = await axios.get('/api/transactions/get_transactions', { params })
   return response.data
 }
 
-export const fetchDailyNet = async () => {
-  const response = await axios.get('/api/charts/daily_net')
+export const updateTransaction = async (transactionData) => {
+  const response = await axios.put('/api/transactions/update', transactionData)
   return response.data
 }
-
-export const fetchNetAssets = async () => {
-  const response = await axios.get('/api/charts/net_assets')
-  return response.data
-}
-

--- a/frontend/src/components/tables/MasterTxidTable.vue
+++ b/frontend/src/components/tables/MasterTxidTable.vue
@@ -106,6 +106,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
+import { updateTransaction } from '@/api/transactions'
 import { useToast } from 'vue-toastification'
 
 const toast = useToast()
@@ -151,7 +152,7 @@ function cancelEdit() {
 
 async function saveEdit(tx) {
   try {
-    await axios.put('/api/transactions/update', {
+    await updateTransaction({
       transaction_id: tx.transaction_id,
       ...editBuffer.value
     })

--- a/frontend/src/components/tables/UpdateTransactionsTable.vue
+++ b/frontend/src/components/tables/UpdateTransactionsTable.vue
@@ -139,6 +139,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
+import { updateTransaction } from '@/api/transactions'
 import { useToast } from 'vue-toastification'
 
 const toast = useToast()
@@ -183,7 +184,7 @@ function cancelEdit() {
 
 async function saveEdit(tx) {
   try {
-    await axios.put('/api/transactions/update', {
+    await updateTransaction({
       transaction_id: tx.transaction_id,
       ...editBuffer.value,
     })

--- a/frontend/src/composables/useTransactions.js
+++ b/frontend/src/composables/useTransactions.js
@@ -5,7 +5,7 @@
  * Handles pagination, search, and sort logic while fetching from the API.
  */
 import { ref, computed, onMounted } from "vue";
-import axios from "axios";
+import { fetchTransactions as fetchTransactionsApi } from "@/api/transactions";
 
 export function useTransactions(pageSize = 15) {
   const transactions = ref([]);
@@ -24,9 +24,10 @@ export function useTransactions(pageSize = 15) {
    */
   const fetchTransactions = async () => {
     try {
-      const res = await axios.get(
-        `/api/transactions/get_transactions?page=${currentPage.value}&page_size=${pageSize}`
-      );
+      const res = await fetchTransactionsApi({
+        page: currentPage.value,
+        page_size: pageSize,
+      });
 
       const payload =
         res.data.status === "success" ? res.data.data : res.data.data || res.data;

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -53,9 +53,9 @@ import AccountsTable from '@/components/tables/AccountsTable.vue'
 import TransactionsTable from '@/components/tables/TransactionsTable.vue'
 import TransactionModal from '@/components/modals/TransactionModal.vue'
 import AccountSnapshot from '@/components/widgets/AccountSnapshot.vue'
-import axios from 'axios'
 import { ref, computed, onMounted } from 'vue'
 import api from '@/services/api'
+import { fetchTransactions as fetchTransactionsApi } from '@/api/transactions'
 
 import { useTransactions } from '@/composables/useTransactions.js'
 
@@ -77,8 +77,10 @@ const netWorth = ref(0)
 
 async function openDayModal(date) {
   modalTitle.value = `Transactions for ${date}`
-  const res = await axios.get('/api/transactions/get_transactions', {
-    params: { start_date: date, end_date: date, page_size: 100 }
+  const res = await fetchTransactionsApi({
+    start_date: date,
+    end_date: date,
+    page_size: 100,
   })
   if (res.data.status === 'success') {
     modalTransactions.value = res.data.data.transactions
@@ -90,8 +92,9 @@ async function openDayModal(date) {
 
 async function openCategoryModal(category) {
   modalTitle.value = `Transactions for ${category}`
-  const res = await axios.get('/api/transactions/get_transactions', {
-    params: { category, page_size: 100 }
+  const res = await fetchTransactionsApi({
+    category,
+    page_size: 100,
   })
   if (res.data.status === 'success') {
     modalTransactions.value = res.data.data.transactions


### PR DESCRIPTION
## Summary
- add `src/api/transactions.js`
- update composable to use new API helpers
- use `fetchTransactions` in Dashboard modal
- wire updateTransaction in table components

## Testing
- `pre-commit run --files frontend/src/api/transactions.js frontend/src/composables/useTransactions.js frontend/src/views/Dashboard.vue frontend/src/components/tables/MasterTxidTable.vue frontend/src/components/tables/UpdateTransactionsTable.vue`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6868e98e763c83298e334025fe989184