### PR TITLE
[frontend] Ensure CategoryBreakdownChart renders correctly

### DIFF
--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -160,8 +160,7 @@ async function fetchData() {
     const response = await fetchDailyNet()
     if (response.status === 'success') {
       chartData.value = response.data
-      updateSummary()
-      await renderChart()
+      // Summary and chart will update through the watch handler
     }
   } catch (error) {
     console.error('Error fetching daily net data:', error)


### PR DESCRIPTION
## Summary
- avoid rendering chart before the canvas exists in CategoryBreakdownChart

## Testing
- `pre-commit run --all-files` *(fails: ruff errors in unrelated files and missing files for mypy)*
- `pytest -q` *(fails: missing optional dependencies such as Flask and chromadb)*

------
https://chatgpt.com/codex/tasks/task_e_686af6cee57483298622214c57ee392b