### PR TITLE
[scripts] Add slim setup flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ bash scripts/setup.sh [--slim]
 ```
 
 This command creates the virtual environment, installs Python and Node dependencies,
-links pre-commit hooks and copies the example `.env` files if needed.
+links pre-commit hooks and copies the example `.env` files if needed. Passing
+`--slim` installs only the core packages from `requirements-slim.txt` and skips
+the heavier development dependencies. Running without the flag installs the full
+set from `requirements.txt`.
 
 ### 4. Run Backend
 


### PR DESCRIPTION
## Summary
- update setup.sh to parse optional `--slim` flag
- skip dev deps and use requirements-slim.txt when flag set
- document slim option in README

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: ruff found undefined names in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686cb0a2da808329b535b0d3685576a0