### PR TITLE
[docs] Add transaction rule documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ backend directly (without the proxy), prepend the host and port, e.g.
   - `start_date` – optional `YYYY-MM-DD` start date
   - `end_date` – optional `YYYY-MM-DD` end date
 
+### Transaction Rules
+
+Transaction rules let you define patterns for merchant names or amounts and apply category changes automatically. Manage rules at `/api/rules`. See [docs/backend/features/transaction_rules.md](docs/backend/features/transaction_rules.md) for details.
+
 Plaid and Teller integrations handled in `/backend/app/helpers/`.
 
 ## Running Tests

--- a/docs/backend/app/routes/categories.md
+++ b/docs/backend/app/routes/categories.md
@@ -13,6 +13,10 @@ Manages transaction categorization logic and user-defined category updates. Supp
 - `POST /categories/update`: Update category metadata (e.g., label, emoji).
 - `POST /categories/apply`: Reassign category tags to transactions.
 - `GET /categories/tree`: Nested view of primary and detailed categories.
+- `GET /rules`: List saved transaction rules.
+- `POST /rules`: Create a new rule.
+- `PATCH /rules/<id>`: Modify or disable a rule.
+- `DELETE /rules/<id>`: Remove a rule.
 
 ## Inputs & Outputs
 
@@ -33,6 +37,16 @@ Manages transaction categorization logic and user-defined category updates. Supp
 - **POST /categories/apply**
   - **Input:** `{ transaction_ids: [str], category_id: str }`
   - **Output:** `{ success: boolean, updated: int }`
+- **GET /rules**
+  - **Output:** List of saved rules.
+- **POST /rules**
+  - **Input:** { match_criteria: {...}, action: {...} }
+  - **Output:** Newly created rule object.
+- **PATCH /rules/<id>**
+  - **Input:** Partial updates or { is_active: bool }
+  - **Output:** Updated rule object.
+- **DELETE /rules/<id>**
+  - **Output:** { success: boolean }
 
 ## Internal Dependencies
 

--- a/docs/backend/app/sql/index.md
+++ b/docs/backend/app/sql/index.md
@@ -9,6 +9,7 @@
 - [`account_logic.py`](../../backend/app/sql/account_logic.py): SQL-level account resolution and user validation.
 - [`transactions_logic.py`](../../backend/app/sql/transactions_logic.py): Filtering, batch updates, and transaction persistence.
 - [`category_logic.py`](../../backend/app/sql/category_logic.py): Category inference, overrides, and bulk reclassification.
+- [`transaction_rules_logic.py`](../../backend/app/sql/transaction_rules_logic.md): Apply user-defined transaction rules during sync.
 
 ### 🔁 Recurring Logic
 

--- a/docs/backend/app/sql/models/TransactionRule.md
+++ b/docs/backend/app/sql/models/TransactionRule.md
@@ -1,0 +1,36 @@
+# \U0001F4D6 `TransactionRule` Model
+
+```markdown
+# TransactionRule Model
+
+## Purpose
+
+Stores persistent mapping of match criteria to actions applied on transactions. Allows future imports to be auto-categorized or adjusted.
+
+## Fields
+
+- `id`: Primary key (UUID)
+- `user_id`: Foreign key to `User`
+- `match_criteria`: JSON document describing patterns (merchant, description regex, amount range)
+- `action`: JSON of updates (e.g., `category_id`, `merchant`)
+- `is_active`: Boolean flag to disable without deleting
+- `created_at`, `updated_at`: Audit timestamps
+
+## Relationships
+
+- Linked to `User`
+- Applied to `Transaction` objects during ingest
+
+## Behaviors
+
+- Rules are user scoped; no cross-user sharing
+- Manual edits may create new rules when confirmed
+
+## Related Logic
+
+- [`transaction_rules_logic.py`](../../backend/app/sql/transaction_rules_logic.md)
+
+## Related Docs
+
+- [`docs/backend/features/transaction_rules.md`](../../../features/transaction_rules.md)
+```

--- a/docs/backend/app/sql/transaction_rules_logic.md
+++ b/docs/backend/app/sql/transaction_rules_logic.md
@@ -1,0 +1,53 @@
+# backend/app/sql Documentation
+
+---
+
+## \U0001F4D6 `transaction_rules_logic.py`
+
+```markdown
+# Transaction Rules SQL Logic
+
+## Purpose
+
+Provides helper functions to store and apply `TransactionRule` entries. Handles pattern matching and updates during transaction ingestion.
+
+## Key Responsibilities
+
+- Persist rule definitions in the database
+- Query rules for a user during sync operations
+- Apply matched actions to transaction rows
+
+## Primary Functions
+
+- `create_rule(user_id, match_criteria, action)`
+  - Inserts a row into `transaction_rule` table
+- `get_applicable_rules(user_id)`
+  - Returns all active rules for the user
+- `apply_rules(user_id, transaction)`
+  - Mutates a transaction dict based on any matching rule
+
+## Inputs
+
+- `Transaction` metadata (merchant name, description, amount)
+- User-scope rule set
+
+## Outputs
+
+- Updated transaction structures
+- Logs of which rule was applied
+
+## Internal Dependencies
+
+- `models.TransactionRule`
+- `db_session`
+
+## Known Behaviors
+
+- Rules are evaluated in insertion order
+- Disabled rules are ignored
+- Supports partial criteria (only merchant match, for example)
+
+## Related Docs
+
+- [`docs/backend/features/transaction_rules.md`](../features/transaction_rules.md)
+```

--- a/docs/backend/features/transaction_rules.md
+++ b/docs/backend/features/transaction_rules.md
@@ -1,0 +1,38 @@
+# Transaction Rules Guide
+
+Transaction rules let users automatically modify transactions during sync based on pattern matching.
+
+## Overview
+
+- **Model**: `TransactionRule`
+- **Purpose**: Persist user-defined criteria that trigger updates on incoming transactions.
+- **Location**: `backend/app/models.py` and accompanying SQL helpers.
+
+## Rule Fields
+
+- `id` – Primary key
+- `user_id` – Owner of the rule
+- `match_criteria` – JSON object containing one or more of:
+  - `merchant_name`
+  - `description_pattern`
+  - `amount_min` / `amount_max`
+- `action` – JSON describing applied changes (e.g., `{ "category_id": "...", "merchant": "Starbucks" }`)
+- `created_at` / `updated_at` – Timestamps
+
+## Workflow
+
+1. **Create Rule** – User edits a transaction and chooses "Save as rule". The backend stores criteria and action in `TransactionRule`.
+2. **Apply Rule** – During transaction ingestion (`account_logic.get_paginated_transactions` or similar), rules matching the new transaction are loaded and executed before commit.
+3. **Manage Rule** – CRUD endpoints under `/api/rules` allow listing, updating, disabling, or deleting rules.
+
+When a rule updates a transaction, the record is marked with `updated_by_rule=true` so the UI can show the automated classification.
+
+## Endpoints Summary
+
+- `GET /rules` – List rules for the current user.
+- `POST /rules` – Create a rule from provided criteria and action.
+- `PATCH /rules/<id>` – Modify rule parameters or enable/disable it.
+- `DELETE /rules/<id>` – Remove a rule entirely.
+
+These endpoints complement the existing `/transactions/update` flow.
+


### PR DESCRIPTION
## Summary
- outline new TransactionRule feature
- describe rule endpoints in categories docs
- document SQL helpers for applying rules
- link rule docs from README and SQL index

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f3cf378dc8329afef74c9e1b1d8c3