### PR TITLE
[docs] Add dashboard modal guide

### DIFF
--- a/docs/frontend/DASHBOARD_MODAL_GUIDE.md
+++ b/docs/frontend/DASHBOARD_MODAL_GUIDE.md
@@ -1,0 +1,53 @@
+# Dashboard Chart Modal Logic
+
+> **Purpose:** Document the event flow and modal behavior for `Dashboard.vue`. This logic is vital for reviewing transactions directly from charts and must not be removed.
+
+## Charts Emitting Click Events
+
+Both `DailyNetChart.vue` and `CategoryBreakdownChart.vue` emit a `bar-click` event whenever a user clicks on a bar. The event payload represents either the date (daily net chart) or the category label (breakdown chart).
+
+```vue
+<!-- example usage -->
+<DailyNetChart @bar-click="openModalByDate" />
+<CategoryBreakdownChart @bar-click="openModalByCategory" />
+```
+
+## Handling Clicks in `Dashboard.vue`
+
+`Dashboard.vue` listens for these events to fetch the matching transactions and display them in `TransactionModal.vue`:
+
+```ts
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalTransactions = ref([])
+
+async function openModalByDate(date: string) {
+  modalTitle.value = `Transactions for ${date}`
+  const res = await fetchTransactions({ date })
+  modalTransactions.value = res.data.transactions || []
+  showModal.value = true
+}
+
+async function openModalByCategory(label: string) {
+  modalTitle.value = `Transactions in ${label}`
+  const res = await fetchTransactions({ category: label })
+  modalTransactions.value = res.data.transactions || []
+  showModal.value = true
+}
+```
+
+The modal remains visible until the user triggers the `close` event.
+
+```vue
+<TransactionModal
+  v-if="showModal"
+  :title="modalTitle"
+  :transactions="modalTransactions"
+  @close="showModal = false" />
+```
+
+## Maintenance Notes
+
+- Do **not** strip the `bar-click` listeners or modal helpers when refactoring.
+- Keep the fetch helpers in sync with backend API changes.
+- Update this guide whenever the modal workflow changes.


### PR DESCRIPTION
## Summary
- document `Dashboard.vue` chart modal logic under docs/frontend

## Testing
- `pre-commit run --files docs/frontend/DASHBOARD_MODAL_GUIDE.md` *(fails: model-field-validation hook path issues)*
- `pre-commit run --all-files` *(fails: missing files in hooks)*
- `pytest` *(fails: missing dependencies such as flask)*

------
https://chatgpt.com/codex/tasks/task_e_6870a2da09fc8329aa17f134bd46574d