### PR TITLE
[frontend] Add account net change panel

### DIFF
--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -1,0 +1,18 @@
+/**
+ * Account-related API helpers.
+ *
+ * Provides functions for retrieving net change summaries and recent
+ * transactions for a single account.
+ */
+import axios from 'axios'
+
+export const fetchNetChanges = async (accountId, params = {}) => {
+  const response = await axios.get(`/api/accounts/${accountId}/net_changes`, { params })
+  return response.data
+}
+
+export const fetchRecentTransactions = async (accountId, limit = 10) => {
+  const params = { recent: true, limit }
+  const response = await axios.get(`/api/transactions/${accountId}/transactions`, { params })
+  return response.data
+}

--- a/frontend/src/views/__tests__/AccountsSummary.cy.js
+++ b/frontend/src/views/__tests__/AccountsSummary.cy.js
@@ -1,0 +1,63 @@
+import Accounts from '../Accounts.vue'
+
+function mountWithData() {
+  cy.intercept('GET', '/api/accounts/get_accounts', {
+    statusCode: 200,
+    body: { status: 'success', accounts: [{ account_id: 'acc1' }] },
+  }).as('getAccounts')
+
+  cy.intercept('GET', '/api/accounts/acc1/net_changes', {
+    statusCode: 200,
+    body: { status: 'success', data: { income: 100, expense: 50, net: 50 } },
+  }).as('getSummary')
+
+  cy.intercept('GET', '/api/transactions/acc1/transactions*', {
+    statusCode: 200,
+    body: {
+      status: 'success',
+      data: {
+        transactions: [
+          {
+            transaction_id: 'tx1',
+            date: '2024-01-01',
+            amount: -50,
+            description: 'Test',
+            category: 'misc',
+            institution_name: 'Bank',
+            account_name: 'Checking',
+            merchant_name: 'Store',
+            subtype: 'checking',
+          },
+        ],
+        total: 1,
+      },
+    },
+  }).as('getTx')
+
+  cy.mount(Accounts, {
+    global: {
+      stubs: {
+        LinkAccount: true,
+        RefreshPlaidControls: true,
+        RefreshTellerControls: true,
+        TokenUpload: true,
+        NetYearComparisonChart: true,
+        AssetsBarTrended: true,
+        AccountsReorderChart: true,
+        InstitutionTable: true,
+      },
+    },
+  })
+
+  cy.wait(['@getAccounts', '@getSummary', '@getTx'])
+}
+
+describe('Accounts summary view', () => {
+  it('shows summary and transactions', () => {
+    mountWithData()
+    cy.contains('Net Change Summary').should('exist')
+    cy.contains('Income').should('exist')
+    cy.contains('Recent Transactions').should('exist')
+    cy.get('table').should('exist')
+  })
+})


### PR DESCRIPTION
## Summary
- add new API helpers for account summaries
- load net change summary and recent transactions on Accounts page
- display results with loading/error states
- add Cypress test for Accounts view

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `npm run test:unit` *(fails: missing Xvfb for Cypress)*

------
https://chatgpt.com/codex/tasks/task_e_68723320f10083299d8ef02c16196e09