### PR TITLE
[backend] Remove unused transactions sql helper

### DIFF
--- a/backend/app/sql/transactions_logic.py
+++ b/backend/app/sql/transactions_logic.py
@@ -1,3 +1,0 @@
-# transactions_logic.py
-# This module to be used for transactions business logic (sql db upserting / fetching)
-#

--- a/docs/backend/app/sql/index.md
+++ b/docs/backend/app/sql/index.md
@@ -7,7 +7,6 @@
 ### 🧮 Transaction & Account Operations
 
 - [`account_logic.py`](../../backend/app/sql/account_logic.py): SQL-level account resolution and user validation.
-- [`transactions_logic.py`](../../backend/app/sql/transactions_logic.py): Filtering, batch updates, and transaction persistence.
 - [`category_logic.py`](../../backend/app/sql/category_logic.py): Category inference, overrides, and bulk reclassification.
 - [`transaction_rules_logic.py`](../../backend/app/sql/transaction_rules_logic.md): Apply user-defined transaction rules during sync.
 
@@ -26,67 +25,5 @@
 
 ---
 
-## 📘 `transactions_logic.py`
-
-```markdown
-# Transactions Logic Module
-
-## Purpose
-
-Implements SQL-backed routines for managing transaction records. Handles inserts, updates, lookups, and rollups using direct SQL or ORM-based batch operations. Powers most of the backend workflows involving user transactions.
-
-## Key Responsibilities
-
-- Retrieve filtered transaction datasets
-- Insert or update records atomically
-- Support batch operations and scoped joins
-
-## Primary Functions
-
-- `get_user_transactions(user_id, filters)`
-
-  - Applies WHERE clauses on account, date, category, etc.
-
-- `insert_transaction(user_id, data)`
-
-  - Commits a new transaction row with relational validation
-
-- `bulk_update_categories(transaction_ids, category_id)`
-
-  - Updates category for multiple transactions at once
-
-- `delete_transaction(transaction_id)`
-  - Marks a transaction deleted or removes it entirely
-
-## Inputs
-
-- `user_id`, filter parameters, payload dicts
-- Transaction metadata: description, amount, date, tags
-
-## Outputs
-
-- Transaction records or summaries
-- Count of affected rows for bulk ops
-- Post-update signals (budget refresh, tag rebuild)
-
-## Internal Dependencies
-
-- `models.Transaction`, `models.Category`, `models.Account`
-- SQLAlchemy query builders
-- `utils.transaction_filters`
-
-## Known Behaviors
-
-- Inserts trigger post-hooks to forecast + recurring modules
-- Date coercion applied automatically during insert
-- Filter logic reused in `/transactions` route and dashboard exports
-
-## Related Docs
-
-- [`docs/dataflow/transaction_lifecycle.md`](../../dataflow/transaction_lifecycle.md)
-- [`docs/frontend/pages/TransactionsPage.md`](../../frontend/pages/TransactionsPage.md)
-```
-
----
 
 All core SQL logic modules documented. Ready to continue with `models/` layer?

--- a/docs/backend/app/sql/models/Category.md
+++ b/docs/backend/app/sql/models/Category.md
@@ -33,7 +33,6 @@ Represents a labeled classification used to group transactions. Can be system-de
 
 - [`category_logic.py`](../../backend/app/sql/category_logic.py)
 - [`forecast_stat_model.py`](../../backend/app/services/forecast_stat_model.py)
-- [`transactions_logic.py`](../../backend/app/sql/transactions_logic.py)
 
 ## Related Docs
 

--- a/docs/backend/app/sql/models/Transactions.md
+++ b/docs/backend/app/sql/models/Transactions.md
@@ -37,7 +37,6 @@ Captures a single financial transaction made by a user. This can be a synced tra
 
 ## Related Logic
 
-- [`transactions_logic.py`](../../backend/app/sql/transactions_logic.py)
 - [`category_logic.py`](../../backend/app/sql/category_logic.py)
 - [`recurring_bridge.py`](../../backend/app/services/recurring_bridge.py)
 

--- a/docs/backend/app/sql/models/User.md
+++ b/docs/backend/app/sql/models/User.md
@@ -32,7 +32,7 @@ Represents an authenticated user in the system. Each user is the owner of a full
 ## Related Logic
 
 - Auth, token management, and user-scoped filters
-- `account_logic.py`, `transactions_logic.py`
+ - `account_logic.py`
 - Admin tools for impersonation or override
 
 ## Related Docs


### PR DESCRIPTION
## Summary
- delete unused `transactions_logic.py` helper and doc file
- clean references to the module in SQL docs

## Testing
- `pre-commit run --all-files` *(fails: ERROR not found messages)*
- `pytest -q` *(fails: missing Flask & chromadb deps)*

------
https://chatgpt.com/codex/tasks/task_e_68724789f11883298c89bef1338e10f4