### PR TITLE
[frontend] Add recent activity summary to dashboard

### DIFF
--- a/frontend/src/composables/useAccountActivity.js
+++ b/frontend/src/composables/useAccountActivity.js
@@ -1,0 +1,49 @@
+// src/composables/useAccountActivity.js
+/**
+ * Fetch net change summary and recent transactions for an account.
+ *
+ * @param {Ref<string>|string|null} accountId - Account identifier
+ * @returns {Object} reactive state and loader
+ */
+import { ref, watch, onMounted, isRef } from 'vue'
+import { fetchNetChanges, fetchRecentTransactions } from '@/api/transactions'
+
+export function useAccountActivity(accountId, limit = 5) {
+  const accountIdRef = isRef(accountId) ? accountId : ref(accountId)
+  const loading = ref(false)
+  const error = ref(null)
+  const summary = ref({ income: 0, expense: 0, net: 0 })
+  const transactions = ref([])
+
+  async function loadActivity() {
+    if (!accountIdRef.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const [netRes, txRes] = await Promise.all([
+        fetchNetChanges(accountIdRef.value),
+        fetchRecentTransactions(accountIdRef.value, limit)
+      ])
+      if (netRes.status === 'success') {
+        summary.value = netRes.data || { income: 0, expense: 0, net: 0 }
+      }
+      if (txRes.status === 'success') {
+        const data = txRes.data || {}
+        transactions.value = data.transactions || data
+      }
+    } catch (e) {
+      console.error('Failed to load account activity:', e)
+      error.value = 'Failed to load activity'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  watch(accountIdRef, () => {
+    loadActivity()
+  })
+
+  onMounted(loadActivity)
+
+  return { accountId: accountIdRef, loading, error, summary, transactions, loadActivity }
+}

--- a/frontend/src/views/__tests__/DashboardRecentActivity.cy.js
+++ b/frontend/src/views/__tests__/DashboardRecentActivity.cy.js
@@ -1,0 +1,54 @@
+import Dashboard from '../Dashboard.vue'
+
+function mountDashboard() {
+  cy.intercept('GET', '/api/charts/net_assets', {
+    statusCode: 200,
+    body: { status: 'success', data: [{ date: '2024-01-01', net_assets: 0 }] },
+  })
+  cy.intercept('GET', '/api/accounts/get_accounts*', {
+    statusCode: 200,
+    body: { status: 'success', accounts: [{ account_id: '1', name: 'Checking' }] },
+  })
+  cy.intercept('GET', '/api/accounts/1/net_changes*', {
+    statusCode: 200,
+    body: { status: 'success', data: { income: 100, expense: -40, net: 60 } },
+  }).as('getNetChanges')
+  cy.intercept('GET', '/api/transactions/1/transactions*', {
+    statusCode: 200,
+    body: {
+      status: 'success',
+      data: {
+        transactions: [
+          { transaction_id: 't1', date: '2024-01-01', description: 'Paycheck', amount: 100 },
+        ],
+      },
+    },
+  }).as('getRecent')
+
+  cy.mount(Dashboard, {
+    global: {
+      stubs: {
+        AppLayout: true,
+        BaseCard: true,
+        PaginationControls: true,
+        DailyNetChart: true,
+        CategoryBreakdownChart: true,
+        AccountsTable: true,
+        TransactionsTable: true,
+        TransactionModal: true,
+        AccountSnapshot: true,
+      },
+    },
+  })
+  cy.wait(['@getNetChanges', '@getRecent'])
+}
+
+describe('Dashboard recent activity', () => {
+  it('displays summary and transactions', () => {
+    mountDashboard()
+    cy.contains('Income').next().should('contain', '$100.00')
+    cy.contains('Expenses').next().should('contain', '-$40.00')
+    cy.contains('Net').next().should('contain', '$60.00')
+    cy.get('table tbody tr').should('have.length', 1)
+  })
+})


### PR DESCRIPTION
## Summary
- fetch net change totals and latest transactions on dashboard load
- display recent activity summary block
- expose `useAccountActivity` composable
- add component test for the new dashboard section

## Testing
- `npm run lint` *(fails: 2 errors)*
- `npm run test:unit` *(fails: missing `Xvfb`)*
- `pre-commit run --all-files` *(fails: many missing files)*
- `pytest` *(fails: missing dependencies like `chromadb`)*

------
https://chatgpt.com/codex/tasks/task_e_68724782b6708329a602207b483dad3b