### PR TITLE
[docs] Add migration guide for transaction rules

### DIFF
--- a/docs/backend/features/transaction_rules.md
+++ b/docs/backend/features/transaction_rules.md
@@ -36,3 +36,6 @@ When a rule updates a transaction, the record is marked with `updated_by_rule=tr
 
 These endpoints complement the existing `/transactions/update` flow.
 
+## Migration
+
+See [../temp_migrations/versions/transaction_rules_add_table.md](../temp_migrations/versions/transaction_rules_add_table.md) for Alembic instructions to create the table.

--- a/docs/backend/temp_migrations/versions/transaction_rules_add_table.md
+++ b/docs/backend/temp_migrations/versions/transaction_rules_add_table.md
@@ -1,0 +1,43 @@
+## 📘 `add_transaction_rules_table.py`
+```markdown
+# Migration: Add Transaction Rules Table
+
+This migration creates the `transaction_rules` table used for automatic transaction updates.
+
+1. **Generate the migration**
+
+```bash
+flask db migrate -m "add transaction rules table"
+```
+
+The command produces `backend/migrations/versions/<revision>_add_transaction_rules_table.py`.
+
+2. **Define the table**
+
+Edit the new file so `upgrade()` contains:
+
+```python
+op.create_table(
+    "transaction_rules",
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("user_id", sa.String(64), index=True),
+    sa.Column("match_criteria", sa.JSON(), nullable=False),
+    sa.Column("action", sa.JSON(), nullable=False),
+    sa.Column("is_active", sa.Boolean(), default=True),
+    sa.Column("created_at", sa.DateTime(), nullable=False),
+    sa.Column("updated_at", sa.DateTime(), nullable=False),
+)
+```
+
+Include a matching `downgrade()` that drops the table.
+
+3. **Apply the migration**
+
+```bash
+flask db upgrade
+```
+
+4. **Validate**
+
+Check the database schema to ensure `transaction_rules` exists before enabling the feature.
+```


### PR DESCRIPTION
## Summary
- document Alembic migration for `transaction_rules`
- link migration guide from the rules feature doc

## Testing
- `pre-commit run --all-files` *(fails: file not found)*
- `pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dae34dab88329a9f97f6bdb055640