### PR TITLE
[backend] Add Plaid investments model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -96,6 +96,25 @@ class PlaidAccount(db.Model, TimestampMixin):
     last_error = db.Column(db.Text, nullable=True)
 
 
+# --- PlaidItem Model ---
+
+
+class PlaidItem(db.Model, TimestampMixin):
+    """A linked Plaid item representing one or more accounts."""
+
+    __tablename__ = "plaid_items"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String(64), index=True, nullable=False)
+    item_id = db.Column(db.String(128), unique=True, index=True, nullable=False)
+    access_token = db.Column(db.String(256), nullable=False)
+    institution_name = db.Column(db.String(128), nullable=True)
+    product = db.Column(db.String(64), nullable=False)
+    last_refreshed = db.Column(db.DateTime, nullable=True)
+    is_active = db.Column(db.Boolean, default=True)
+    last_error = db.Column(db.Text, nullable=True)
+
+
 # --- PlaidWebhookLog Model ---
 
 

--- a/backend/app/routes/plaid_investments.py
+++ b/backend/app/routes/plaid_investments.py
@@ -4,6 +4,7 @@ from app.helpers.plaid_helpers import (
     generate_link_token,
     get_investments,
 )
+from app.models import PlaidItem
 from app.sql.account_logic import save_plaid_item
 from flask import Blueprint, jsonify, request
 
@@ -82,8 +83,6 @@ def refresh_investments_endpoint():
     if not user_id or not item_id:
         return jsonify({"error": "Missing user_id or item_id"}), 400
     try:
-        from app.models import PlaidItem
-
         item = PlaidItem.query.filter_by(
             item_id=item_id, user_id=user_id, product="investments"
         ).first()

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -11,7 +11,14 @@ from app.config import FILES, logger
 from app.extensions import db
 from app.helpers.normalize import normalize_amount
 from app.helpers.plaid_helpers import get_accounts, get_transactions
-from app.models import Account, AccountHistory, Category, PlaidAccount, Transaction
+from app.models import (
+    Account,
+    AccountHistory,
+    Category,
+    PlaidAccount,
+    PlaidItem,
+    Transaction,
+)
 from app.sql import transaction_rules_logic
 from app.sql.refresh_metadata import refresh_or_insert_plaid_metadata
 from sqlalchemy import func
@@ -65,13 +72,14 @@ def get_accounts_from_db(include_hidden: bool = False):
 
 
 def save_plaid_item(user_id, item_id, access_token, institution_name, product):
-    item = PlaidItem.query.filter_by(item_id=item_id).first()  # noqa: F821
+    """Insert or update a PlaidItem record."""
+    item = PlaidItem.query.filter_by(item_id=item_id).first()
     if item:
         item.access_token = access_token
         item.institution_name = institution_name
         item.updated_at = datetime.now(timezone.utc)
     else:
-        item = PlaidItem(  # noqa: F821
+        item = PlaidItem(
             user_id=user_id,
             item_id=item_id,
             access_token=access_token,

--- a/docs/backend/app/routes/index.md
+++ b/docs/backend/app/routes/index.md
@@ -13,7 +13,7 @@
 - [`frontend.py`](#frontend-route)
 - [`manual_io.py`](#manual-io-route)
 - [`plaid.py`](#plaid-integration-route)
-- [`plaid_investments.py`](#plaid-investments-route)
+- [`plaid_investments.py`](#plaid-investments-route) – see [Plaid Investments integration](../../integrations/plaid_investments.md)
 - [`plaid_transactions.py`](#plaid-transactions-route)
 - [`plaid_transfer.py`](#plaid-transfer-route)
 - [`product_transactions.py`](#product-transactions-route)

--- a/docs/dataflow/investment_sync_pipeline.md
+++ b/docs/dataflow/investment_sync_pipeline.md
@@ -1,0 +1,10 @@
+# 💹 Investment Sync Pipeline
+
+This document summarizes how investment data flows from Plaid into the database.
+
+1. A user links an account via the `/api/plaid/investments/generate_link_token` and `/exchange_public_token` endpoints.
+2. The exchanged token and item ID are stored in the `PlaidItem` table.
+3. `/api/plaid/investments/refresh` retrieves holdings using `get_investments(access_token)`.
+4. Holdings and securities can then be persisted or processed downstream (logic not yet implemented).
+
+This pipeline mirrors the transaction refresh flow but is scoped specifically to Plaid's investments product.

--- a/docs/integrations/plaid_investments.md
+++ b/docs/integrations/plaid_investments.md
@@ -1,0 +1,22 @@
+# 📈 Plaid Investments Integration
+
+This integration stores Plaid investment items and allows holdings to be refreshed.
+
+## Database Table
+
+`PlaidItem` records each linked item:
+
+- `user_id` – owner of the item
+- `item_id` – unique Plaid item identifier
+- `access_token` – token used for API calls
+- `institution_name` – optional display name
+- `product` – `investments`
+- `last_refreshed` – timestamp of last sync
+
+## Refresh Flow
+
+1. `/api/plaid/investments/generate_link_token` generates a Link token limited to the investments product.
+2. `/api/plaid/investments/exchange_public_token` exchanges the public token and saves a `PlaidItem` entry via `save_plaid_item`.
+3. `/api/plaid/investments/refresh` looks up the stored `PlaidItem` and calls `get_investments`.
+
+See [`docs/dataflow/investment_sync_pipeline.md`](../dataflow/investment_sync_pipeline.md) for the full sync pipeline.

--- a/tests/test_save_plaid_item.py
+++ b/tests/test_save_plaid_item.py
@@ -1,0 +1,69 @@
+import importlib.util
+import os
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def setup_app(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    extensions = load_module(
+        "app.extensions", os.path.join(BASE_BACKEND, "app", "extensions.py")
+    )
+    extensions.db.init_app(app)
+    return app, extensions
+
+
+@pytest.fixture()
+def db_ctx(tmp_path):
+    app, extensions = setup_app(tmp_path)
+    with app.app_context():
+        models = load_module(
+            "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+        )
+        logic = load_module(
+            "app.sql.account_logic",
+            os.path.join(BASE_BACKEND, "app", "sql", "account_logic.py"),
+        )
+        extensions.db.create_all()
+        yield extensions.db, models, logic
+        extensions.db.drop_all()
+
+
+def test_save_plaid_item_inserts_and_updates(db_ctx):
+    db, models, logic = db_ctx
+
+    # Insert
+    item = logic.save_plaid_item(
+        user_id="u1",
+        item_id="item123",
+        access_token="tok1",
+        institution_name="InvestCo",
+        product="investments",
+    )
+    assert item.id
+    assert db.session.query(models.PlaidItem).count() == 1
+
+    # Update
+    item2 = logic.save_plaid_item(
+        user_id="u1",
+        item_id="item123",
+        access_token="tok2",
+        institution_name="InvestCo",
+        product="investments",
+    )
+    assert item2.id == item.id
+    assert item2.access_token == "tok2"
+    assert db.session.query(models.PlaidItem).count() == 1


### PR DESCRIPTION
## Summary
- define `PlaidItem` ORM model
- use `PlaidItem` when exchanging tokens
- document Plaid investments integration and sync pipeline
- test `save_plaid_item` with a temporary database

## Testing
- `pre-commit run --files backend/app/models.py backend/app/sql/account_logic.py backend/app/routes/plaid_investments.py docs/integrations/plaid_investments.md docs/dataflow/investment_sync_pipeline.md docs/backend/app/routes/index.md tests/test_save_plaid_item.py` *(fails: mypy, pylint, bandit, model-field-validation)*
- `pytest` *(fails: missing dependencies such as flask)*

------
https://chatgpt.com/codex/tasks/task_e_68728085c53c8329b206a9a6c2c73fe7