### PR TITLE
[backend] Flip displayed transaction amounts

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -12,6 +12,7 @@ from app.config import logger
 from app.extensions import db
 from app.models import Account, Transaction
 from app.sql import account_logic, transaction_rules_logic
+from app.utils.finance_utils import display_transaction_amount
 from flask import Blueprint, jsonify, request
 
 transactions = Blueprint("transactions", __name__)
@@ -220,6 +221,7 @@ def get_account_transactions(account_id):
 
 @transactions.route("/manual", methods=["GET"])
 def get_manual_transactions():
+    """Return all transactions from manually managed accounts."""
     try:
         manual_txns = (
             db.session.query(Transaction)
@@ -235,7 +237,7 @@ def get_manual_transactions():
                 "transaction_id": t.transaction_id,
                 "date": t.date.isoformat(),
                 "name": t.description,
-                "amount": t.amount,
+                "amount": display_transaction_amount(t),
                 "type": t.merchant_type,
                 "provider": t.account.link_type if t.account else None,
                 "account_id": t.account_id,

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -14,6 +14,7 @@ from app.helpers.plaid_helpers import get_accounts, get_transactions
 from app.models import Account, AccountHistory, Category, PlaidAccount, Transaction
 from app.sql import transaction_rules_logic
 from app.sql.refresh_metadata import refresh_or_insert_plaid_metadata
+from app.utils.finance_utils import display_transaction_amount
 from sqlalchemy import func
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy.orm import aliased
@@ -462,7 +463,7 @@ def get_paginated_transactions(
             {
                 "transaction_id": txn.transaction_id,
                 "date": txn.date.isoformat() if txn.date else None,
-                "amount": txn.amount,
+                "amount": display_transaction_amount(txn),
                 "description": txn.description or txn.merchant_name or "N/A",
                 "category": txn.category or "Uncategorized",
                 "merchant_name": txn.merchant_name or "Unknown",


### PR DESCRIPTION
## Summary
- adjust serialization logic to display negative amounts for expenses
- use `display_transaction_amount` in manual transaction route

## Testing
- `pre-commit run --files backend/app/sql/account_logic.py backend/app/routes/transactions.py` *(fails: mypy missing stubs)*
- `pytest` *(fails: import errors during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68795ebdcdc88329b7a67f965be9bee1