### PR TITLE
[frontend] Apply unified oceanic color scheme

### DIFF
--- a/frontend/src/components/base/BaseTable.vue
+++ b/frontend/src/components/base/BaseTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-gray-200">
+    <table class="min-w-full divide-y divide-[var(--divider)]">
       <slot />
     </table>
   </div>

--- a/frontend/src/components/forecast/ForecastComponent.vue
+++ b/frontend/src/components/forecast/ForecastComponent.vue
@@ -4,7 +4,7 @@
     <!-- Header -->
     <header class="text-center">
       <h1 class="text-3xl font-bold">Financial Forecast</h1>
-      <p class="text-gray-500">Simulate your future net delta and balance shifts</p>
+      <p class="text-[var(--color-text-muted)]">Simulate your future net delta and balance shifts</p>
     </header>
 
     <!-- Top Grid: Summary + Chart -->
@@ -27,7 +27,7 @@
       </div>
 
       <!-- Forecast Chart Placeholder -->
-      <div class="card glass h-64 flex items-center justify-center text-gray-400">
+      <div class="card glass h-64 flex items-center justify-center text-[var(--color-text-muted)]">
         <span>[Chart will go here]</span>
       </div>
     </div>
@@ -69,7 +69,7 @@
             <option>One-Time</option>
           </select>
         </div>
-        <button type="button" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Add</button>
+        <button type="button" class="mt-2 px-4 py-2 bg-[var(--primary)] text-white rounded">Add</button>
       </form>
     </div>
 

--- a/frontend/src/components/forecast/ForecastLayout.vue
+++ b/frontend/src/components/forecast/ForecastLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="forecast-layout p-6 bg-gray-50 space-y-6">
+  <div class="forecast-layout p-6 bg-[var(--color-bg-secondary)] space-y-6">
     <ForecastSummaryPanel :current-balance="currentBalance" :manual-income="manualIncome"
       :liability-rate="liabilityRate" :view-type="viewType" @update:manualIncome="manualIncome = $event"
       @update:liabilityRate="liabilityRate = $event" />

--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -9,7 +9,7 @@
       <slot />
     </main>
     <footer class="glass border-t" style="border-color: var(--divider);">
-      <div class="container py-4 text-center text-gray-600 text-sm">
+      <div class="container py-4 text-center text-[var(--color-text-muted)] text-sm">
         <slot name="footer" />
       </div>
     </footer>

--- a/frontend/src/components/recurring/RecurringCalendar.vue
+++ b/frontend/src/components/recurring/RecurringCalendar.vue
@@ -9,7 +9,7 @@
             {{ tx.name }} - ${{ tx.amount }}
           </div>
         </div>
-        <div v-else class="text-xs text-gray-400">No events</div>
+        <div v-else class="text-xs text-[var(--color-text-muted)]">No events</div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/recurring/ScanResultsList.vue
+++ b/frontend/src/components/recurring/ScanResultsList.vue
@@ -4,7 +4,7 @@
       <span class="font-semibold">ID:</span> {{ action.recurring_id }} -
       <span class="italic">{{ action.status }}</span>
     </li>
-    <li v-if="!results.length" class="text-gray-500">No actions detected.</li>
+    <li v-if="!results.length" class="text-[var(--color-text-muted)]">No actions detected.</li>
   </ul>
 </template>
 

--- a/frontend/src/components/recurring/ScanResultsTable.vue
+++ b/frontend/src/components/recurring/ScanResultsTable.vue
@@ -1,18 +1,18 @@
 <template>
-  <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-100 text-gray-700 text-sm font-semibold">
+  <table class="min-w-full divide-y divide-[var(--divider)]">
+    <thead class="bg-[var(--color-bg)] text-[var(--theme-fg)] text-sm font-semibold">
       <tr>
         <th class="px-3 py-2">Recurring ID</th>
         <th class="px-3 py-2">Status</th>
       </tr>
     </thead>
     <tbody>
-      <tr v-for="(action, idx) in results" :key="idx" class="even:bg-gray-50">
+      <tr v-for="(action, idx) in results" :key="idx" class="even:bg-[var(--color-bg-secondary)]">
         <td class="px-3 py-2">{{ action.recurring_id }}</td>
         <td class="px-3 py-2">{{ action.status }}</td>
       </tr>
       <tr v-if="!results.length">
-        <td colspan="2" class="px-3 py-2 text-gray-500 text-center">No actions detected.</td>
+        <td colspan="2" class="px-3 py-2 text-[var(--color-text-muted)] text-center">No actions detected.</td>
       </tr>
     </tbody>
   </table>

--- a/frontend/src/components/tables/MasterTxidTable.vue
+++ b/frontend/src/components/tables/MasterTxidTable.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="transactions space-y-4 p-6 bg-gray-50 rounded-xl shadow">
+  <div class="transactions space-y-4 p-6 bg-[var(--color-bg-secondary)] rounded-xl shadow">
     <!-- Filter Row -->
-    <div class="flex gap-4 items-center text-sm text-gray-700">
+    <div class="flex gap-4 items-center text-sm text-[var(--theme-fg)]">
       <div>
         <label class="block mb-1 font-medium">Category Group</label>
         <select v-model="selectedPrimaryCategory" class="input">
@@ -22,8 +22,8 @@
         </select>
       </div>
     </div>
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-100 text-gray-700 text-sm font-semibold uppercase">
+    <table class="min-w-full divide-y divide-[var(--divider)]">
+      <thead class="bg-[var(--color-bg)] text-[var(--theme-fg)] text-sm font-semibold uppercase">
         <tr>
           <th class="px-3 py-2 cursor-pointer" @click="sortBy('date')">
             Date <span v-if="sortKey === 'date'">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
@@ -51,7 +51,7 @@
 
         <tr v-for="tx in paginatedTransactions" :key="tx.transaction_id">
 
-          :class="['text-sm', editingIndex === index ? 'bg-yellow-100' : 'hover:bg-gray-100']">
+          :class="['text-sm', editingIndex === index ? 'bg-yellow-100' : 'hover:bg-[var(--color-bg)]']">
           <td class="px-3 py-2">
             <input v-if="editingIndex === index" v-model="editBuffer.date" type="date" class="input" />
             <span v-else>{{ formatDate(tx.date) }}</span>
@@ -97,7 +97,7 @@
       </tbody>
     </table>
 
-    <div v-if="filteredTransactions.length === 0" class="text-gray-500 text-sm">
+    <div v-if="filteredTransactions.length === 0" class="text-[var(--color-text-muted)] text-sm">
       No transactions found.
     </div>
   </div>
@@ -242,14 +242,14 @@ onMounted(async () => {
 <style scoped>
 @reference "../../assets/css/main.css";
 .input {
-  @apply w-full px-2 py-1 rounded border border-gray-300 bg-white text-gray-800 text-sm;
+  @apply w-full px-2 py-1 rounded border border-[var(--divider)] bg-[var(--surface)] text-[var(--theme-fg)] text-sm;
 }
 
 .input:focus {
-  @apply outline-none ring-2 ring-blue-300;
+  @apply outline-none ring-2 ring-[var(--primary)];
 }
 
 .btn-sm {
-  @apply inline-flex items-center px-2 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700;
+  @apply inline-flex items-center px-2 py-1 bg-[var(--primary)] text-white text-xs rounded hover:bg-[var(--primary-dark)];
 }
 </style>

--- a/frontend/src/components/tables/PaginationControls.vue
+++ b/frontend/src/components/tables/PaginationControls.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="flex items-center justify-center gap-3 mt-4">
     <button
-      class="rounded-2xl px-4 py-1 shadow text-lg bg-gray-100 border border-gray-300 text-gray-700 transition hover:bg-accent-cyan hover:text-white focus:ring-2 focus:ring-cyan-500"
+      class="rounded-2xl px-4 py-1 shadow text-lg bg-[var(--color-bg)] border border-[var(--divider)] text-[var(--theme-fg)] transition hover:bg-accent-cyan hover:text-white focus:ring-2 focus:ring-cyan-500"
       :disabled="currentPage <= 1" @click="goToPrev">
       Previous
     </button>
     <span class="flex items-center gap-1 text-sm">
       Page
       <input type="number" min="1" :max="totalPages" v-model.number="editablePage" @keyup.enter="jumpToPage"
-        class="w-14 mx-1 text-center border border-gray-300 rounded px-1 py-0.5 focus:ring-2 focus:ring-accent-cyan outline-none" />
+        class="w-14 mx-1 text-center border border-[var(--divider)] rounded px-1 py-0.5 focus:ring-2 focus:ring-accent-cyan outline-none" />
       of <span class="font-bold">{{ totalPages }}</span>
     </span>
     <button
-      class="rounded-2xl px-4 py-1 shadow text-lg bg-gray-100 border border-gray-300 text-gray-700 transition hover:bg-accent-cyan hover:text-white focus:ring-2 focus:ring-cyan-500"
+      class="rounded-2xl px-4 py-1 shadow text-lg bg-[var(--color-bg)] border border-[var(--divider)] text-[var(--theme-fg)] transition hover:bg-accent-cyan hover:text-white focus:ring-2 focus:ring-cyan-500"
       :disabled="currentPage >= totalPages" @click="goToNext">
       Next
     </button>

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="card mt-6 font-mono space-y-4">
     <h3 class="heading-md text-left">Transactions</h3>
-    <div class="overflow-auto rounded-2xl border border-gray-200 shadow">
-      <table class="min-w-full divide-y divide-gray-200 rounded-2xl overflow-hidden">
-        <thead class="bg-gray-50">
+    <div class="overflow-auto rounded-2xl border border-[var(--divider)] shadow">
+      <table class="min-w-full divide-y divide-[var(--divider)] rounded-2xl overflow-hidden">
+        <thead class="bg-[var(--color-bg-secondary)]">
           <tr>
             <th v-for="col in columns" :key="col.key" @click="sortTable(col.key)"
               class="px-3 py-2 text-left select-none cursor-pointer font-bold uppercase text-xs tracking-wide transition"

--- a/frontend/src/components/tables/UpdateTransactionsTable.vue
+++ b/frontend/src/components/tables/UpdateTransactionsTable.vue
@@ -130,7 +130,7 @@
     </table>
 
     <!-- Empty State -->
-    <div v-if="filteredTransactions.length === 0" class="text-center text-gray-500">
+    <div v-if="filteredTransactions.length === 0" class="text-center text-[var(--color-text-muted)]">
       No transactions found.
     </div>
   </div>
@@ -270,11 +270,11 @@ onMounted(async () => {
 <style scoped>
 @reference "../../assets/css/main.css";
 .input {
-  @apply w-full px-2 py-1 rounded border border-gray-300 bg-white text-gray-800 text-sm;
+  @apply w-full px-2 py-1 rounded border border-[var(--divider)] bg-[var(--surface)] text-[var(--theme-fg)] text-sm;
 }
 
 .input:focus {
-  @apply outline-none ring-2 ring-blue-300;
+  @apply outline-none ring-2 ring-[var(--primary)];
 }
 
 .btn-sm {

--- a/frontend/src/components/ui/FuzzyDropdown.vue
+++ b/frontend/src/components/ui/FuzzyDropdown.vue
@@ -12,7 +12,7 @@
           :disabled="max > 0 && !localValue.includes(item.id) && localValue.length >= max" />
         <span>{{ item.name }}</span>
       </label>
-      <p v-if="!filtered.length" class="text-sm text-gray-500 py-2">No matches</p>
+      <p v-if="!filtered.length" class="text-sm text-[var(--color-text-muted)] py-2">No matches</p>
     </div>
   </div>
 </template>

--- a/frontend/src/components/ui/Modal.vue
+++ b/frontend/src/components/ui/Modal.vue
@@ -3,7 +3,7 @@
     <div v-if="true" class="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black bg-opacity-50 p-4" @click.self="emitClose">
       <div class="card glass max-w-2xl w-full relative mt-20 shadow-2xl">
         <!-- Close button -->
-        <button class="absolute top-2 right-2 text-gray-500 hover:text-black" @click="emitClose">
+        <button class="absolute top-2 right-2 text-[var(--color-text-muted)] hover:text-black" @click="emitClose">
           <span class="text-xl">&times;</span>
         </button>
 

--- a/frontend/src/components/widgets/AccountSnapshot.vue
+++ b/frontend/src/components/widgets/AccountSnapshot.vue
@@ -4,17 +4,17 @@
     <div class="mt-2 space-y-1">
       <table class="w-full text-sm">
         <thead>
-          <tr class="text-left text-xs text-gray-400">
+          <tr class="text-left text-xs text-[var(--color-text-muted)]">
             <th class="pb-1">Account</th>
-            <th class="pb-1">Balance / <span class="italic text-gray-400">Upcoming</span></th>
+            <th class="pb-1">Balance / <span class="italic text-[var(--color-text-muted)]">Upcoming</span></th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="acc in selectedAccounts" :key="acc.account_id" class="border-b border-gray-100 last:border-none">
+          <tr v-for="acc in selectedAccounts" :key="acc.account_id" class="border-b border-[var(--divider)] last:border-none">
             <td class="py-1">
               <span class="block font-semibold text-base truncate max-w-[170px] text-blue-950 dark:text-blue-100"
                 :title="acc.name">{{ acc.name }}</span>
-              <span class="block text-xs text-gray-500 font-medium mt-0.5 leading-tight">{{ acc.institution_name
+              <span class="block text-xs text-[var(--color-text-muted)] font-medium mt-0.5 leading-tight">{{ acc.institution_name
                 }}</span>
             </td>
             <td class="py-1 min-w-[180px] relative group">
@@ -30,13 +30,13 @@
                 {{ formatUpcoming(netUpcoming(acc)) }}
                 <!-- Tooltip on hover -->
                 <div v-if="hovered === acc.account_id && upcomingForAccount(acc).length"
-                  class="absolute left-1/2 z-10 min-w-[220px] -translate-x-1/2 mt-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-lg rounded-xl p-2 text-xs">
+                  class="absolute left-1/2 z-10 min-w-[220px] -translate-x-1/2 mt-2 bg-[var(--surface)] dark:bg-gray-900 border border-[var(--divider)] dark:border-gray-700 shadow-lg rounded-xl p-2 text-xs">
                   <div v-for="(tx, idx) in upcomingForAccount(acc)"
                     :key="tx.id || tx.description + tx.next_due_date + idx"
-                    class="flex justify-between gap-2 py-1 border-b border-gray-100 last:border-0">
+                    class="flex justify-between gap-2 py-1 border-b border-[var(--divider)] last:border-0">
                     <span>
                       <span class="font-semibold">{{ tx.description }}</span>
-                      <span v-if="tx.next_due_date" class="ml-1 text-gray-400">[{{ tx.next_due_date }}]</span>
+                      <span v-if="tx.next_due_date" class="ml-1 text-[var(--color-text-muted)]">[{{ tx.next_due_date }}]</span>
                     </span>
                     <span class="font-mono" :class="upcomingClass(tx.amount)">
                       {{ formatUpcoming(tx.amount) }}
@@ -47,11 +47,11 @@
             </td>
           </tr>
           <tr v-if="!selectedAccounts.length">
-            <td colspan="2" class="text-center text-gray-400 text-sm py-2">No selected accounts.</td>
+            <td colspan="2" class="text-center text-[var(--color-text-muted)] text-sm py-2">No selected accounts.</td>
           </tr>
         </tbody>
         <tfoot>
-          <tr class="font-bold border-t border-gray-200 dark:border-gray-800">
+          <tr class="font-bold border-t border-[var(--divider)] dark:border-gray-800">
             <td class="pt-2">Total</td>
             <td class="pt-2 min-w-[180px] relative">
               <span class="font-mono">
@@ -96,7 +96,7 @@ function upcomingClass(val) {
     'faded-upcoming',
     num > 0 ? 'text-green-700 dark:text-green-400' : '',
     num < 0 ? 'text-red-400' : '',
-    num === 0 ? 'text-gray-400' : '',
+    num === 0 ? 'text-[var(--color-text-muted)]' : '',
   ]
 }
 

--- a/frontend/src/styles/global-colors.css
+++ b/frontend/src/styles/global-colors.css
@@ -1,4 +1,4 @@
-@import './themes/dark-frost.css';
+@import './themes/oceanic.css';
 
 :root {
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.45);

--- a/frontend/src/styles/themes/oceanic.css
+++ b/frontend/src/styles/themes/oceanic.css
@@ -1,0 +1,45 @@
+:root {
+  --page-bg: #0d1b2a;
+  --background: var(--page-bg);
+  --color-bg: #1b263b;
+  --color-bg-dark: #0d1b2a;
+  --color-bg-secondary: #243447;
+  --themed-bg: rgba(36, 52, 71, 0.75);
+  --frosted-bg: var(--themed-bg);
+  --themed-border: rgba(255, 255, 255, 0.12);
+  --surface: #28354a;
+  --input-bg: #33465c;
+  --divider: #3f536a;
+  --color-border-secondary: #3a4c63;
+
+  --theme-fg: #e2e8f0;
+  --color-text-dark: #000000;
+  --color-text-light: #f1f5f9;
+  --color-text-muted: #94a3b8;
+
+  --primary: #14b8a6;
+  --primary-dark: #0d9488;
+
+  --neon-mint: #5eead4;
+  --neon-purple: #c084fc;
+  --color-accent-mint: var(--neon-mint);
+  --color-accent-yellow: #f9f871;
+  --color-accent-magenta: #ff2cb1;
+  --color-accent-ice: #2fd7ff;
+  --color-accent-purple-hover: #d8b4fe;
+  --color-accent: var(--neon-mint);
+
+  --hover-bg: rgba(255, 255, 255, 0.08);
+  --color-hover-light: rgba(255, 255, 255, 0.1);
+  --hover-glow: 0 0 8px rgba(20, 184, 166, 0.6);
+
+  --button-bg: #334155;
+  --link-hover-color: var(--neon-mint);
+
+  --asset-gradient-start: #60a5fa;
+  --asset-gradient-end: #3b82f6;
+  --liability-gradient-start: #fb7185;
+  --liability-gradient-end: #f43f5e;
+  --bar-gradient-end: #f472b6;
+  --accent-yellow-soft: rgba(249, 248, 113, 0.5);
+}

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -97,7 +97,7 @@
           <BaseCard>
             <div class="space-y-4">
               <input v-model="searchQuery" type="text" placeholder="Search transactions, account, institution..."
-                class="w-full p-2 border border-gray-200 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                class="w-full p-2 border border-[var(--divider)] rounded focus:outline-none focus:ring-2 focus:ring-[var(--primary)]" />
               <TransactionsTable :transactions="filteredTransactions" :sort-key="sortKey" :sort-order="sortOrder"
                 :search="searchQuery" @sort="setSort" :current-page="currentPage" :total-pages="totalPages"
                 @change-page="changePage" />

--- a/frontend/src/views/DashboardMock.vue
+++ b/frontend/src/views/DashboardMock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full bg-white shadow p-4 rounded-xl flex flex-col gap-6">
+  <div class="w-full bg-[var(--surface)] shadow p-4 rounded-xl flex flex-col gap-6">
     <!-- Daily Net Income Chart -->
     <div>
       <h2 class="text-lg font-semibold mb-2">Daily Net Income</h2>

--- a/frontend/src/views/Investments.vue
+++ b/frontend/src/views/Investments.vue
@@ -12,7 +12,7 @@
 
     <main class="max-w-[960px] mx-auto">
       <!-- Account Details Section -->
-      <section id="account-details" class="bg-white p-5 mb-5 rounded shadow">
+      <section id="account-details" class="bg-[var(--surface)] p-5 mb-5 rounded shadow">
         <h2 class="mt-0">Account Details</h2>
         <button @click="refreshInvestments"
           class="bg-[#3498db] text-white border-none py-[10px] px-[20px] rounded cursor-pointer">
@@ -33,7 +33,7 @@
       </section>
 
       <!-- Visual Selections Section -->
-      <section id="visuals" class="bg-white p-5 mb-5 rounded shadow">
+      <section id="visuals" class="bg-[var(--surface)] p-5 mb-5 rounded shadow">
         <h2 class="mt-0">Investment Visuals</h2>
         <!-- Investment Performance Chart -->
         <div id="performance-chart" class="text-center mt-5">

--- a/frontend/src/views/Mock/AccountToggle.vue
+++ b/frontend/src/views/Mock/AccountToggle.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex justify-between items-center p-4 shadow-md bg-white rounded-b-2xl">
+  <div class="flex justify-between items-center p-4 shadow-md bg-[var(--surface)] rounded-b-2xl">
     <!-- Left: Greeting + Date Selector -->
     <div class="flex flex-col gap-1">
-      <h1 class="text-xl font-semibold text-gray-800">Welcome back, Brayden 👋</h1>
+      <h1 class="text-xl font-semibold text-[var(--theme-fg)]">Welcome back, Brayden 👋</h1>
       <div class="flex items-center gap-2">
-        <label for="daterange" class="text-sm text-gray-600">Date Range:</label>
-        <select id="daterange" class="border rounded px-2 py-1 text-sm text-gray-700">
+        <label for="daterange" class="text-sm text-[var(--color-text-muted)]">Date Range:</label>
+        <select id="daterange" class="border rounded px-2 py-1 text-sm text-[var(--theme-fg)]">
           <option>Last 7 Days</option>
           <option>Last 30 Days</option>
           <option>This Month</option>
@@ -19,12 +19,12 @@
     <div class="flex items-center gap-4">
       <!-- Account Visibility Toggle -->
       <div class="flex gap-2 items-center">
-        <span class="text-sm text-gray-600">Accounts:</span>
-        <button class="bg-blue-100 hover:bg-blue-200 text-blue-800 text-xs px-2 py-1 rounded"
+        <span class="text-sm text-[var(--color-text-muted)]">Accounts:</span>
+        <button class="bg-[var(--hover-bg)] hover:bg-[var(--color-hover-light)] text-[var(--primary-dark)] text-xs px-2 py-1 rounded"
           @click="toggleAccount('Checking')">
           Checking
         </button>
-        <button class="bg-blue-100 hover:bg-blue-200 text-blue-800 text-xs px-2 py-1 rounded"
+        <button class="bg-[var(--hover-bg)] hover:bg-[var(--color-hover-light)] text-[var(--primary-dark)] text-xs px-2 py-1 rounded"
           @click="toggleAccount('Savings')">
           Savings
         </button>
@@ -32,9 +32,9 @@
 
       <!-- Mock Profile Dropdown -->
       <div class="relative">
-        <button class="flex items-center space-x-2 bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded">
+        <button class="flex items-center space-x-2 bg-[var(--color-bg)] hover:bg-gray-200 px-3 py-1 rounded">
           <img src="https://via.placeholder.com/32" class="w-6 h-6 rounded-full" alt="Profile" />
-          <span class="text-sm text-gray-700">Brayden</span>
+          <span class="text-sm text-[var(--theme-fg)]">Brayden</span>
         </button>
       </div>
     </div>

--- a/frontend/src/views/Mock/DashboardMockTransactions.vue
+++ b/frontend/src/views/Mock/DashboardMockTransactions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full bg-white shadow p-4 rounded-xl flex flex-col gap-6">
+  <div class="w-full bg-[var(--surface)] shadow p-4 rounded-xl flex flex-col gap-6">
     <!-- Daily Net Income Chart -->
     <div>
       <h2 class="text-lg font-semibold mb-2">Daily Net Income</h2>

--- a/frontend/src/views/Mock/TopBar.vue
+++ b/frontend/src/views/Mock/TopBar.vue
@@ -3,13 +3,13 @@
   <div class="dashboard-top-bar">
     <div class="left-section">
       <h1 class="text-2xl font-semibold">Dashboard</h1>
-      <span class="text-sm text-gray-500">Welcome back, Brayden</span>
+      <span class="text-sm text-[var(--color-text-muted)]">Welcome back, Brayden</span>
     </div>
 
     ```
     <div class="center-section">
       <div class="date-range-selector">
-        <label for="dateRange" class="mr-2 text-sm text-gray-600">Date Range:</label>
+        <label for="dateRange" class="mr-2 text-sm text-[var(--color-text-muted)]">Date Range:</label>
         <select v-model="selectedRange" id="dateRange" class="border rounded p-1">
           <option value="7">Last 7 Days</option>
           <option value="30">Last 30 Days</option>
@@ -20,7 +20,7 @@
 
     <div class="right-section flex items-center gap-4">
       <div class="account-toggle">
-        <label for="accountToggle" class="text-sm text-gray-600">Show All Accounts:</label>
+        <label for="accountToggle" class="text-sm text-[var(--color-text-muted)]">Show All Accounts:</label>
         <input type="checkbox" v-model="showAllAccounts" id="accountToggle" class="ml-2">
       </div>
 
@@ -29,10 +29,10 @@
           <img src="/mock-profile.jpg" alt="Profile" class="w-8 h-8 rounded-full">
           <span class="text-sm">Brayden</span>
         </button>
-        <div v-if="menuOpen" class="absolute right-0 mt-2 w-40 bg-white border rounded shadow-md z-10">
+        <div v-if="menuOpen" class="absolute right-0 mt-2 w-40 bg-[var(--surface)] border rounded shadow-md z-10">
           <ul class="text-sm">
-            <li class="px-4 py-2 hover:bg-gray-100 cursor-pointer">Settings</li>
-            <li class="px-4 py-2 hover:bg-gray-100 cursor-pointer">Logout</li>
+            <li class="px-4 py-2 hover:bg-[var(--color-bg)] cursor-pointer">Settings</li>
+            <li class="px-4 py-2 hover:bg-[var(--color-bg)] cursor-pointer">Logout</li>
           </ul>
         </div>
       </div>
@@ -63,7 +63,7 @@ export default {
 <style scoped>
 @reference "../../assets/css/main.css";
 .dashboard-top-bar {
-  @apply flex justify-between items-center bg-white shadow px-6 py-4 rounded-b-md;
+  @apply flex justify-between items-center bg-[var(--surface)] shadow px-6 py-4 rounded-b-md;
 }
 
 .left-section {

--- a/frontend/src/views/RecurringTX.vue
+++ b/frontend/src/views/RecurringTX.vue
@@ -5,7 +5,7 @@
       <h1 class="text-2xl font-bold text-primary">pyNance Dashboard</h1>
       <button
         @click="refreshData"
-        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+        class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-[var(--primary-dark)] transition"
       >
         Refresh
       </button>
@@ -13,26 +13,26 @@
 
     <!-- Summary Cards -->
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-      <div class="bg-white shadow rounded-lg p-4">
+      <div class="bg-[var(--surface)] shadow rounded-lg p-4">
         <p class="text-sm text-muted">Net Worth</p>
         <p class="text-xl font-semibold text-green-600">$24,893.22</p>
       </div>
-      <div class="bg-white shadow rounded-lg p-4">
+      <div class="bg-[var(--surface)] shadow rounded-lg p-4">
         <p class="text-sm text-muted">YTD Spending</p>
         <p class="text-xl font-semibold text-red-500">$9,340.12</p>
       </div>
-      <div class="bg-white shadow rounded-lg p-4">
+      <div class="bg-[var(--surface)] shadow rounded-lg p-4">
         <p class="text-sm text-muted">Total Accounts</p>
         <p class="text-xl font-semibold text-primary">6</p>
       </div>
-      <div class="bg-white shadow rounded-lg p-4">
+      <div class="bg-[var(--surface)] shadow rounded-lg p-4">
         <p class="text-sm text-muted">Upcoming Bills</p>
         <p class="text-xl font-semibold text-yellow-600">$1,203.55</p>
       </div>
     </div>
 
     <!-- Remote Webhook Command Trigger -->
-    <div class="bg-white shadow rounded p-6 space-y-4 max-w-md">
+    <div class="bg-[var(--surface)] shadow rounded p-6 space-y-4 max-w-md">
       <h2 class="text-lg font-bold text-primary">Remote Command Trigger</h2>
 
       <input
@@ -44,7 +44,7 @@
       <button
         @click="sendCommand"
         :disabled="loading"
-        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+        class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-[var(--primary-dark)] transition"
       >
         {{ loading ? 'Sending...' : 'Send Command' }}
       </button>


### PR DESCRIPTION
## Summary
- introduce new `oceanic` CSS theme
- import the new theme in `global-colors.css`
- replace hardcoded Tailwind colors with CSS variables across components and views

## Testing
- `pre-commit run --all-files` *(fails: not found paths)*
- `pytest` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_68798b30d1008329b1313bbe3473ed20