### PR TITLE
[frontend] Fix or Add Replace Youtube embed import

### DIFF
--- a/frontend/src/components/unused/YoutubeEmbed.vue
+++ b/frontend/src/components/unused/YoutubeEmbed.vue
@@ -1,3 +1,4 @@
+<!-- Deprecated component: retained only for historical reference -->
 <template>
     <div class="video-container">
       <!-- The YouTube player will be embedded in this div -->
@@ -71,7 +72,7 @@
   
   <style scoped>
 @reference "../../assets/css/main.css";
-@import '@/styles/global-colors.css';
+@reference '@/styles/global-colors.css';
 
   .video-container {
     position: relative;


### PR DESCRIPTION
## Summary
- mark YoutubeEmbed.vue as deprecated and use `@reference`

## Testing
- `pre-commit run --all-files` *(fails: ERROR not found: ...)*
- `pytest` *(fails: ImportError: cannot import name 'Category'...)*

------
https://chatgpt.com/codex/tasks/task_e_6879686577f4832982fdc5215233259d