### PR TITLE
[backend] Add product tracking to PlaidAccount

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -75,6 +75,8 @@ class Account(db.Model, TimestampMixin):
 
 
 class PlaidAccount(db.Model, TimestampMixin):
+    """Plaid-linked account with access token and sync state."""
+
     __tablename__ = "plaid_accounts"
 
     id = db.Column(db.Integer, primary_key=True)
@@ -84,6 +86,7 @@ class PlaidAccount(db.Model, TimestampMixin):
     plaid_institution_id = db.Column(db.String(128), nullable=True)
     access_token = db.Column(db.String(256), nullable=False)
     item_id = db.Column(db.String(128), nullable=True)
+    product = db.Column(db.String(64), nullable=True)
     institution_id = db.Column(db.String(128), nullable=True)
     webhook = db.Column(db.String(256), nullable=True)
     last_refreshed = db.Column(db.DateTime, nullable=True)

--- a/backend/migrations/versions/9b0c5ac294b7_add_product_to_plaid_account.py
+++ b/backend/migrations/versions/9b0c5ac294b7_add_product_to_plaid_account.py
@@ -1,0 +1,24 @@
+"""Add product to PlaidAccount
+
+Revision ID: 9b0c5ac294b7
+Revises: 3434a52b5364
+Create Date: 2025-07-07 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9b0c5ac294b7"
+down_revision = "3434a52b5364"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("plaid_accounts", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("product", sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("plaid_accounts", schema=None) as batch_op:
+        batch_op.drop_column("product")

--- a/docs/dataflow/investment_sync_pipeline.md
+++ b/docs/dataflow/investment_sync_pipeline.md
@@ -3,7 +3,8 @@
 This document summarizes how investment data flows from Plaid into the database.
 
 1. A user links an account via the `/api/plaid/investments/generate_link_token` and `/exchange_public_token` endpoints.
-2. The exchanged token and item ID are stored in the `PlaidItem` table.
+2. The exchanged token and item ID are stored in the `PlaidAccount` table using
+   `save_plaid_account` for each returned account.
 3. `/api/plaid/investments/refresh` retrieves holdings using `get_investments(access_token)`.
 4. Holdings and securities can then be persisted or processed downstream (logic not yet implemented).
 

--- a/docs/integrations/plaid_investments.md
+++ b/docs/integrations/plaid_investments.md
@@ -4,19 +4,18 @@ This integration stores Plaid investment items and allows holdings to be refresh
 
 ## Database Table
 
-`PlaidItem` records each linked item:
+`PlaidAccount` tracks each investment account:
 
-- `user_id` – owner of the item
-- `item_id` – unique Plaid item identifier
+- `account_id` – Plaid account identifier
+- `item_id` – associated Plaid item
 - `access_token` – token used for API calls
-- `institution_name` – optional display name
 - `product` – `investments`
 - `last_refreshed` – timestamp of last sync
 
 ## Refresh Flow
 
 1. `/api/plaid/investments/generate_link_token` generates a Link token limited to the investments product.
-2. `/api/plaid/investments/exchange_public_token` exchanges the public token and saves a `PlaidItem` entry via `save_plaid_item`.
-3. `/api/plaid/investments/refresh` looks up the stored `PlaidItem` and calls `get_investments`.
+2. `/api/plaid/investments/exchange_public_token` exchanges the public token and saves `PlaidAccount` rows via `save_plaid_account`.
+3. `/api/plaid/investments/refresh` looks up the stored `PlaidAccount` and calls `get_investments`.
 
 See [`docs/dataflow/investment_sync_pipeline.md`](../dataflow/investment_sync_pipeline.md) for the full sync pipeline.

--- a/tests/test_save_plaid_account.py
+++ b/tests/test_save_plaid_account.py
@@ -42,28 +42,35 @@ def db_ctx(tmp_path):
         extensions.db.drop_all()
 
 
-def test_save_plaid_item_inserts_and_updates(db_ctx):
+def test_save_plaid_account_inserts_and_updates(db_ctx):
     db, models, logic = db_ctx
 
-    # Insert
-    item = logic.save_plaid_item(
+    # minimal account record to satisfy FK
+    acc = models.Account(
+        account_id="acct1",
         user_id="u1",
+        name="Test",
+        type="brokerage",
+    )
+    db.session.add(acc)
+    db.session.commit()
+
+    account = logic.save_plaid_account(
+        account_id="acct1",
         item_id="item123",
         access_token="tok1",
-        institution_name="InvestCo",
         product="investments",
     )
-    assert item.id
-    assert db.session.query(models.PlaidItem).count() == 1
+    assert account.id
+    assert account.product == "investments"
+    assert db.session.query(models.PlaidAccount).count() == 1
 
-    # Update
-    item2 = logic.save_plaid_item(
-        user_id="u1",
+    account2 = logic.save_plaid_account(
+        account_id="acct1",
         item_id="item123",
         access_token="tok2",
-        institution_name="InvestCo",
         product="investments",
     )
-    assert item2.id == item.id
-    assert item2.access_token == "tok2"
-    assert db.session.query(models.PlaidItem).count() == 1
+    assert account2.id == account.id
+    assert account2.access_token == "tok2"
+    assert db.session.query(models.PlaidAccount).count() == 1


### PR DESCRIPTION
## Summary
- add `product` field to `PlaidAccount`
- create Alembic migration for the new column
- store investment items via `save_plaid_account`
- update investment routes to use new helper
- document investment sync via `PlaidAccount`
- rename and update tests for `save_plaid_account`

## Testing
- `pre-commit run --files backend/app/models.py backend/migrations/versions/9b0c5ac294b7_add_product_to_plaid_account.py backend/app/sql/account_logic.py backend/app/routes/plaid_investments.py docs/dataflow/investment_sync_pipeline.md docs/integrations/plaid_investments.md tests/test_save_plaid_account.py` *(fails: mypy, pylint, bandit, model-field-validation)*
- `pytest tests/test_save_plaid_account.py` *(fails: ModuleNotFoundError: No module named 'plaid')*

------
https://chatgpt.com/codex/tasks/task_e_687abf29e0b08329b633d769691a4185