### PR TITLE
[backend] Display sign-adjusted transaction values

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -5,8 +5,12 @@ from datetime import datetime, timezone
 from app.config import logger
 from app.extensions import db
 from app.models import Account, RecurringTransaction
+from app.sql import account_logic
 from app.sql.forecast_logic import update_account_history
-from app.utils.finance_utils import normalize_account_balance
+from app.utils.finance_utils import (
+    display_transaction_amount,
+    normalize_account_balance,
+)
 from flask import Blueprint, jsonify, request
 
 # Blueprint for generic accounts routes
@@ -250,11 +254,12 @@ def get_recurring(account_id):
         ).all()
         data = []
         for tx in recurring_txs:
+            display_tx = getattr(tx, "transaction", tx)
             data.append(
                 {
                     "id": tx.id,
                     "description": tx.description,
-                    "amount": tx.amount,
+                    "amount": display_transaction_amount(display_tx),
                     "frequency": tx.frequency,
                     "next_due_date": (
                         tx.next_due_date.isoformat() if tx.next_due_date else None


### PR DESCRIPTION
## Summary
- use `display_transaction_amount` when serializing recurring transactions
- convert recurring route helpers to use helper for sign flip

## Testing
- `pre-commit run --files backend/app/routes/accounts.py backend/app/routes/recurring.py` *(fails: mypy, pylint, bandit)*

------
https://chatgpt.com/codex/tasks/task_e_687fe70839f4832997007b8dd99cb4c2