### PR TITLE
[dashboard] Add category icons to transactions table

### DIFF
--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -439,9 +439,11 @@ def get_paginated_transactions(
     recent=False,
     limit=None,
 ):
+    """Return paginated transaction rows with account and category info."""
     query = (
-        db.session.query(Transaction, Account)
+        db.session.query(Transaction, Account, Category)
         .join(Account, Transaction.account_id == Account.account_id)
+        .outerjoin(Category, Transaction.category_id == Category.id)
         .filter(Account.is_hidden.is_(False))
         .order_by(Transaction.date.desc())
     )
@@ -466,7 +468,7 @@ def get_paginated_transactions(
 
     # Unpack and serialize
     serialized = []
-    for txn, acc in results:
+    for txn, acc, cat in results:
         serialized.append(
             {
                 "transaction_id": txn.transaction_id,
@@ -474,6 +476,7 @@ def get_paginated_transactions(
                 "amount": display_transaction_amount(txn),
                 "description": txn.description or txn.merchant_name or "N/A",
                 "category": txn.category or "Uncategorized",
+                "category_icon_url": getattr(cat, "pfc_icon_url", None),
                 "merchant_name": txn.merchant_name or "Unknown",
                 "account_name": acc.name or "Unnamed Account",
                 "institution_name": acc.institution_name or "Unknown",

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -34,8 +34,10 @@
             <!-- Date -->
             <td class="px-4 py-2 font-mono text-xs text-neutral-400">{{ formatDate(tx.date) }}</td>
             <!-- Category -->
-            <td class="px-4 py-2">
-              <span
+            <td class="px-4 py-2 text-center">
+              <img v-if="tx.category_icon_url" :src="tx.category_icon_url" alt="category icon"
+                class="h-5 w-5 mx-auto" loading="lazy" />
+              <span v-else
                 class="inline-block rounded-xl border border-blue-800 bg-gradient-to-r from-neutral-900 to-blue-950 px-3 py-1 text-xs font-semibold text-blue-200 tracking-wide shadow-sm">
                 {{ formatCategory(tx) }}
               </span>

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -67,13 +67,13 @@ def test_get_transactions_returns_data(client, monkeypatch):
     monkeypatch.setattr(
         transactions_module.account_logic,
         "get_paginated_transactions",
-        lambda *a, **k: ([{"txn": 1}], 1),
+        lambda *a, **k: ([{"txn": 1, "category_icon_url": "url"}], 1),
     )
     resp = client.get("/api/transactions/get_transactions")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["status"] == "success"
-    assert data["data"]["transactions"] == [{"txn": 1}]
+    assert data["data"]["transactions"] == [{"txn": 1, "category_icon_url": "url"}]
     assert data["data"]["total"] == 1
 
 


### PR DESCRIPTION
## Summary
- include category icon URL when fetching transactions
- display category icon in Dashboard transactions table
- adjust tests for the extra field

## Testing
- `pre-commit run --files backend/app/sql/account_logic.py frontend/src/components/tables/TransactionsTable.vue tests/test_api_transactions.py` *(fails: mypy/pylint missing deps)*
- `pytest -q` *(fails: missing Flask and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_688003cbc008832996a9f06314140567