### PR TITLE
[frontend] standardize dashboard currency formatting

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -390,6 +390,8 @@ def match_account_by_fields():
 def account_net_changes(account_id):
     """Return net income and expense totals for an account."""
     try:
+        from app.sql import account_logic
+
         start_date_str = request.args.get("start_date")
         end_date_str = request.args.get("end_date")
 

--- a/docs/frontend/CURRENCY_FORMAT_GUIDE.md
+++ b/docs/frontend/CURRENCY_FORMAT_GUIDE.md
@@ -1,0 +1,18 @@
+# Currency Formatting Style
+
+Transactions displayed on the dashboard use a consistent accounting style.
+
+- Positive amounts show the standard `$xx.xx` format.
+- Negative amounts are wrapped in parentheses and displayed in red.
+- Formatting is handled via `formatAmount` from `src/utils/format.js` using
+  `Intl.NumberFormat` for USD.
+
+Example:
+
+```js
+formatAmount(42.5)   // "$42.50"
+formatAmount(-20.1)  // "($20.10)"
+```
+
+Apply the `text-red-400` class to negative amounts to ensure visual emphasis.
+

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -55,7 +55,7 @@
             <!-- Amount -->
             <td class="px-4 py-2 font-mono text-right text-base font-semibold" :class="{
               'text-blue-300': tx.amount > 0,
-              'text-pink-400': tx.amount < 0,
+              'text-red-400': tx.amount < 0,
               'text-neutral-500': tx.amount === 0 || !tx.amount
             }">
               {{ formatAmount(tx.amount) }}
@@ -75,6 +75,7 @@
 <script>
 import { onMounted, ref, computed } from 'vue'
 import Chart from 'chart.js/auto'
+import { formatAmount as formatCurrency } from '@/utils/format'
 
 export default {
   name: "TransactionsTable",
@@ -165,14 +166,7 @@ export default {
       })
     }
     const formatAmount = amount => {
-      const number = parseFloat(amount)
-      if (isNaN(number)) return "N/A"
-      return number.toLocaleString('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      })
+      return formatCurrency(amount)
     }
     const formatAccount = tx => {
       let parts = []

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,10 +1,25 @@
 // src/utils/format.js
+/**
+ * Convert a numeric value into a consistent USD currency string.
+ *
+ * Negative values are wrapped in parentheses to match accounting
+ * style. Positive values render normally. Non-numeric input falls
+ * back to `$0.00`.
+ *
+ * @param {number|string} amount - The value to format.
+ * @returns {string} Formatted currency string.
+ */
 export function formatAmount(amount) {
-    const num = parseFloat(amount);
-    if (isNaN(num)) return "$0.00";
-    // If negative, wrap with parentheses; otherwise, display normally.
-    return num < 0 
-      ? `($${Math.abs(num).toLocaleString()})`
-      : `$${num.toLocaleString()}`;
-  }
+  const num = Number(amount || 0);
+  if (Number.isNaN(num)) return '$0.00';
+
+  const formatted = Math.abs(num).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return num < 0 ? `(${formatted})` : formatted;
+}
   

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -44,12 +44,24 @@
                 </button>
               </template>
               <template #summary>
-                <div>Income: <span class="font-bold text-[var(--color-accent-mint)]">${{
-                  netSummary.totalIncome?.toLocaleString() }}</span></div>
-                <div>Expenses: <span class="font-bold text-[var(--color-accent-red)]">${{
-                  netSummary.totalExpenses?.toLocaleString() }}</span></div>
-                <div class="font-bold text-lg text-[var(--color-accent-mint)]">Net Total: ${{
-                  netSummary.totalNet?.toLocaleString() }}</div>
+                <div>
+                  Income:
+                  <span class="font-bold text-[var(--color-accent-mint)]">
+                    {{ formatAmount(netSummary.totalIncome) }}
+                  </span>
+                </div>
+                <div>
+                  Expenses:
+                  <span class="font-bold text-red-400">
+                    {{ formatAmount(netSummary.totalExpenses) }}
+                  </span>
+                </div>
+                <div
+                  class="font-bold text-lg"
+                  :class="{ 'text-red-400': netSummary.totalNet < 0, 'text-[var(--color-accent-mint)]': netSummary.totalNet >= 0 }"
+                >
+                  Net Total: {{ formatAmount(netSummary.totalNet) }}
+                </div>
               </template>
             </ChartWidgetTopBar>
             <DailyNetChart :zoomed-out="zoomedOut" @summary-change="netSummary = $event" @bar-click="onNetBarClick" />
@@ -80,8 +92,9 @@
               </template>
               <template #summary>
                 <span class="text-sm">Total:</span>
-                <span class="font-bold text-lg text-[var(--color-accent-mint)]">${{ catSummary.total?.toLocaleString()
-                  }}</span>
+                <span class="font-bold text-lg text-[var(--color-accent-mint)]">
+                  {{ formatAmount(catSummary.total) }}
+                </span>
               </template>
             </ChartWidgetTopBar>
             <CategoryBreakdownChart :start-date="catRange.start" :end-date="catRange.end"
@@ -130,6 +143,7 @@ import TransactionsTable from '@/components/tables/TransactionsTable.vue'
 import PaginationControls from '@/components/tables/PaginationControls.vue'
 import TransactionModal from '@/components/modals/TransactionModal.vue'
 import GroupedCategoryDropdown from '@/components/ui/GroupedCategoryDropdown.vue'
+import { formatAmount } from '@/utils/format'
 import { ref, computed, onMounted, watch } from 'vue'
 import api from '@/services/api'
 import { useTransactions } from '@/composables/useTransactions.js'


### PR DESCRIPTION
## Summary
- update formatAmount utility for accounting style
- use formatAmount on Dashboard page summaries
- style negative amounts red in transactions table
- document currency styling in docs
- fix missing import in `account_net_changes`

## Testing
- `pre-commit run --all-files` *(fails: ImportError and other errors)*
- `pytest` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688004ac57408329814ab4c7a9abf0d7