### PR TITLE
[investments] Add Plaid investments linking

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -23,6 +23,7 @@ def create_app():
     from app.routes.forecast import forecast
     from app.routes.frontend import frontend
     from app.routes.institutions import institutions
+    from app.routes.investments import investments
     from app.routes.manual_io import manual_up
     from app.routes.plaid import plaid_routes
     from app.routes.plaid_investments import plaid_investments
@@ -47,6 +48,7 @@ def create_app():
     app.register_blueprint(plaid_routes, url_prefix="/api/plaid")
     app.register_blueprint(plaid_transactions, url_prefix="/api/plaid/transactions")
     app.register_blueprint(plaid_investments, url_prefix="/api/plaid/investments")
+    app.register_blueprint(investments, url_prefix="/api/investments")
     app.register_blueprint(link_teller, url_prefix="/api/teller")
     app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
     app.register_blueprint(institutions, url_prefix="/api/institutions")

--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -1,0 +1,13 @@
+"""Endpoints for retrieving investment account information."""
+
+from app.sql import investments_logic
+from flask import Blueprint, jsonify
+
+investments = Blueprint("investments", __name__)
+
+
+@investments.route("/accounts", methods=["GET"])
+def list_investment_accounts():
+    """Return all accounts linked with the Plaid investments product."""
+    accounts = investments_logic.get_investment_accounts()
+    return jsonify({"status": "success", "data": accounts}), 200

--- a/backend/app/sql/investments_logic.py
+++ b/backend/app/sql/investments_logic.py
@@ -1,0 +1,37 @@
+"""Helpers for storing and retrieving investment data."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from app.extensions import db
+from app.models import Account, PlaidAccount
+
+
+def get_investment_accounts() -> List[Dict[str, object]]:
+    """Return accounts linked for Plaid investments."""
+    query = Account.query.join(
+        PlaidAccount, Account.account_id == PlaidAccount.account_id
+    ).filter(PlaidAccount.product == "investments")
+    accounts = []
+    for acc in query.all():
+        accounts.append(
+            {
+                "account_id": acc.account_id,
+                "user_id": acc.user_id,
+                "name": acc.name,
+                "balance": acc.balance,
+                "institution_name": acc.institution_name,
+            }
+        )
+    return accounts
+
+
+def upsert_investments_from_plaid(user_id: str, access_token: str) -> dict:
+    """Placeholder for persisting Plaid investments data."""
+    from app.helpers.plaid_helpers import get_investments
+
+    holdings = get_investments(access_token)
+    # TODO: persist holdings to models when schema is defined
+    db.session.commit()
+    return holdings

--- a/frontend/src/api/accounts_link.js
+++ b/frontend/src/api/accounts_link.js
@@ -11,7 +11,11 @@ export default {
   async generateLinkToken(provider, payload = {}) {
     let url = ""
     if (provider === "plaid") {
-      url = "/plaid/transactions/generate_link_token"
+      const products = payload.products || []
+      const isInvestments = products.length === 1 && products[0] === "investments"
+      url = isInvestments
+        ? "/plaid/investments/generate_link_token"
+        : "/plaid/transactions/generate_link_token"
     } else if (provider === "teller") {
       url = "/teller/transactions/generate_link_token"
     }
@@ -29,7 +33,14 @@ export default {
       console.warn("Teller does not use public token exchange.")
       return { error: "Not supported for Teller" }
     }
-    const response = await apiClient.post(`/${provider}/transactions/exchange_public_token`, payload)
+    let url = `/${provider}/transactions/exchange_public_token`
+    if (provider === "plaid") {
+      const products = payload.products || []
+      if (products.length === 1 && products[0] === "investments") {
+        url = "/plaid/investments/exchange_public_token"
+      }
+    }
+    const response = await apiClient.post(url, payload)
     return response.data
   },
 

--- a/frontend/src/components/forms/LinkProviderLauncher.vue
+++ b/frontend/src/components/forms/LinkProviderLauncher.vue
@@ -73,6 +73,7 @@ const linkPlaid = async () => {
         await accountLinkApi.exchangePublicToken('plaid', {
           public_token,
           user_id: props.userId,
+          products: props.selectedProducts,
         })
         emit('refresh')
       },

--- a/tests/test_investments_logic.py
+++ b/tests/test_investments_logic.py
@@ -1,0 +1,69 @@
+import importlib.util
+import os
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def setup_app(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    extensions = load_module(
+        "app.extensions", os.path.join(BASE_BACKEND, "app", "extensions.py")
+    )
+    extensions.db.init_app(app)
+    return app, extensions
+
+
+@pytest.fixture()
+def db_ctx(tmp_path):
+    app, extensions = setup_app(tmp_path)
+    with app.app_context():
+        models = load_module(
+            "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+        )
+        import sys
+        sys.modules["app.models"] = models
+        logic = load_module(
+            "app.sql.investments_logic",
+            os.path.join(BASE_BACKEND, "app", "sql", "investments_logic.py"),
+        )
+        extensions.db.create_all()
+        yield extensions.db, models, logic
+        extensions.db.drop_all()
+
+
+def test_get_investment_accounts(db_ctx):
+    db, models, logic = db_ctx
+
+    acc = models.Account(
+        account_id="acct1",
+        user_id="u1",
+        name="Invest",
+        type="brokerage",
+    )
+    db.session.add(acc)
+    db.session.commit()
+    pa = models.PlaidAccount(
+        account_id="acct1",
+        access_token="tok",
+        item_id="it1",
+        product="investments",
+    )
+    db.session.add(pa)
+    db.session.commit()
+
+    accounts = logic.get_investment_accounts()
+    assert len(accounts) == 1
+    assert accounts[0]["account_id"] == "acct1"


### PR DESCRIPTION
## Summary
- enable investments link token generation in the frontend
- expose `/api/investments/accounts` for Plaid-linked investment accounts
- add minimal investments SQL logic and unit test

## Testing
- `pre-commit run --files backend/app/__init__.py backend/app/routes/investments.py backend/app/sql/investments_logic.py frontend/src/api/accounts_link.js frontend/src/components/forms/LinkProviderLauncher.vue tests/test_investments_logic.py` *(fails: ModuleNotFoundError: flask_cors)*
- `pytest tests/test_investments_logic.py` *(fails: sqlite OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_68817e2fc8588329baf760d4508c574c