### PR TITLE
[frontend] unify currency formatting

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -390,6 +390,8 @@ def match_account_by_fields():
 def account_net_changes(account_id):
     """Return net income and expense totals for an account."""
     try:
+        from app.sql import account_logic
+
         start_date_str = request.args.get("start_date")
         end_date_str = request.args.get("end_date")
 

--- a/docs/frontend/CURRENCY_FORMAT_GUIDE.md
+++ b/docs/frontend/CURRENCY_FORMAT_GUIDE.md
@@ -1,0 +1,16 @@
+# Currency Formatting Style
+
+Transactions displayed on the dashboard use a consistent accounting style.
+
+- Positive amounts show the standard `$xx.xx` format.
+- Negative amounts are wrapped in parentheses and displayed in red.
+- Formatting is handled via `formatAmount` from `src/utils/format.js` using `Intl.NumberFormat` for USD.
+
+Example:
+
+```js
+formatAmount(42.5)   // "$42.50"
+formatAmount(-20.1)  // "($20.10)"
+```
+
+Apply the `text-red-400` class to negative amounts to ensure visual emphasis.

--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -10,6 +10,7 @@ import { ref, computed, watch, nextTick, onUnmounted } from 'vue'
 import { debounce } from 'lodash-es'
 import { Chart } from 'chart.js/auto'
 import { fetchCategoryBreakdownTree } from '@/api/charts'
+import { formatAmount } from "@/utils/format"
 
 const props = defineProps({
   startDate: { type: String, required: true },
@@ -122,10 +123,8 @@ async function renderChart() {
         tooltip: {
           callbacks: {
             label: context => {
-              const val = context.raw ?? 0
-              return val < 0
-                ? `($${Math.abs(val).toLocaleString()})`
-                : `$${val.toLocaleString()}`
+              const val = context.raw ?? 0;
+              return formatAmount(val);
             },
           },
           backgroundColor: getStyle('--theme-bg'),
@@ -149,9 +148,7 @@ async function renderChart() {
           beginAtZero: true,
           grid: { display: true, color: getStyle('--divider') },
           ticks: {
-            callback: value => value < 0
-              ? `($${Math.abs(value).toLocaleString()})`
-              : `$${value.toLocaleString()}`,
+            callback: value => formatAmount(value),
             color: getStyle('--color-text-muted'),
             font: { family: "'Fira Code', monospace", size: 14 },
           },

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -8,6 +8,7 @@
 import { fetchDailyNet } from '@/api/charts'
 import { ref, onMounted, onUnmounted, nextTick, computed, watch } from 'vue'
 import { Chart } from 'chart.js/auto'
+import { formatAmount } from "@/utils/format"
 
 const props = defineProps({
   zoomedOut: { type: Boolean, default: false }
@@ -117,7 +118,7 @@ async function renderChart() {
         tooltip: {
           callbacks: {
             label: (context) => {
-              return `${context.dataset.label}: $${context.parsed.y.toLocaleString()}`
+              return `${context.dataset.label}: ${formatAmount(context.parsed.y)}`
             },
           },
           backgroundColor: getStyle('--theme-bg'),
@@ -144,9 +145,7 @@ async function renderChart() {
           beginAtZero: true,
           grid: { display: true, color: getStyle('--divider') },
           ticks: {
-            callback: value => value < 0
-              ? `($${Math.abs(value).toLocaleString()})`
-              : `$${value.toLocaleString()}`,
+            callback: value => formatAmount(value),
             color: getStyle('--color-text-muted'),
             font: { family: "'Fira Code', monospace", size: 14 },
           },

--- a/frontend/src/components/charts/NetIncomeCharts.vue
+++ b/frontend/src/components/charts/NetIncomeCharts.vue
@@ -3,13 +3,13 @@
     <h2>{{ chartTitle }}</h2>
     <div class="chart-summary">
       <div class="summary-line income">
-        Income: ${{ summary.totalIncome.toLocaleString() }}
+        Income: ${{ formatAmount(summary.totalIncome) }}
       </div>
       <div class="summary-line expenses">
-        Expenses: ${{ summary.totalExpenses.toLocaleString() }}
+        Expenses: ${{ formatAmount(summary.totalExpenses) }}
       </div>
       <div class="summary-line net">
-        Net: ${{ summary.totalNet.toLocaleString() }}
+        Net: ${{ formatAmount(summary.totalNet) }}
       </div>
     </div>
 
@@ -27,6 +27,7 @@
 import api from '@/services/api.js'
 import { ref, onMounted, nextTick, computed } from "vue";
 import { Chart } from "chart.jsauto";
+import { formatAmount } from "@/utils/format"
 
 export default {
   name: "NetIncomeChart",
@@ -98,9 +99,9 @@ export default {
                   const index = context.dataIndex;
                   const dataPoint = chartData.value[index];
                   return [
-                    `Net: $${(dataPoint.income - dataPoint.expenses).toLocaleString()}`,
-                    `Income: $${dataPoint.income.toLocaleString()}`,
-                    `Expenses: $${dataPoint.expenses.toLocaleString()}`
+                    `Net: ${formatAmount(dataPoint.income - dataPoint.expenses)}`,
+                    `Income: ${formatAmount(dataPoint.income)}`,
+                    `Expenses: ${formatAmount(dataPoint.expenses)}`
                   ];
                 }
               },

--- a/frontend/src/components/recurring/RecurringTransactionSection.vue
+++ b/frontend/src/components/recurring/RecurringTransactionSection.vue
@@ -70,6 +70,7 @@ import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { scanRecurringTransactions } from '@/api/recurring'
 import axios from 'axios'
+import { formatAmount } from "@/utils/format"
 
 const route = useRoute()
 const accountId = route.params.accountId || '1'
@@ -155,11 +156,6 @@ async function saveRecurring() {
   }
 }
 
-const formatAmount = (val) => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-  }).format(parseFloat(val || 0))
 }
 
 onMounted(async () => {

--- a/frontend/src/components/tables/MasterTxidTable.vue
+++ b/frontend/src/components/tables/MasterTxidTable.vue
@@ -108,6 +108,7 @@ import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
 import { updateTransaction } from '@/api/transactions'
 import { useToast } from 'vue-toastification'
+import { formatAmount } from '@/utils/format'
 
 const toast = useToast()
 const emit = defineEmits(['editRecurringFromTransaction'])
@@ -187,16 +188,6 @@ function formatDate(dateStr) {
   })
 }
 
-function formatAmount(amount) {
-  const number = parseFloat(amount)
-  const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    currencySign: 'accounting',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
-  return formatter.format(number)
 }
 
 function sortBy(key) {

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -55,7 +55,7 @@
             <!-- Amount -->
             <td class="px-4 py-2 font-mono text-right text-base font-semibold" :class="{
               'text-blue-300': tx.amount > 0,
-              'text-pink-400': tx.amount < 0,
+              'text-red-400': tx.amount < 0,
               'text-neutral-500': tx.amount === 0 || !tx.amount
             }">
               {{ formatAmount(tx.amount) }}
@@ -75,6 +75,7 @@
 <script>
 import { onMounted, ref, computed } from 'vue'
 import Chart from 'chart.js/auto'
+import { formatAmount as formatCurrency } from '@/utils/format'
 
 export default {
   name: "TransactionsTable",
@@ -165,14 +166,7 @@ export default {
       })
     }
     const formatAmount = amount => {
-      const number = parseFloat(amount)
-      if (isNaN(number)) return "N/A"
-      return number.toLocaleString('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      })
+      return formatCurrency(amount)
     }
     const formatAccount = tx => {
       let parts = []

--- a/frontend/src/components/tables/UpdateTransactionsTable.vue
+++ b/frontend/src/components/tables/UpdateTransactionsTable.vue
@@ -142,6 +142,7 @@ import axios from 'axios'
 import { updateTransaction } from '@/api/transactions'
 import { useToast } from 'vue-toastification'
 
+import { formatAmount } from '@/utils/format'
 const toast = useToast()
 const emit = defineEmits(['editRecurringFromTransaction'])
 const props = defineProps({ transactions: Array })
@@ -219,16 +220,6 @@ function formatDate(dateStr) {
   })
 }
 
-function formatAmount(amount) {
-  const number = parseFloat(amount)
-  const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    currencySign: 'accounting',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
-  return formatter.format(number)
 }
 
 function sortBy(key) {

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,10 +1,24 @@
 // src/utils/format.js
+/**
+ * Convert a numeric value into a consistent USD currency string.
+ *
+ * Negative values are wrapped in parentheses to match accounting
+ * style. Positive values render normally. Non-numeric input falls
+ * back to `$0.00`.
+ *
+ * @param {number|string} amount - The value to format.
+ * @returns {string} Formatted currency string.
+ */
 export function formatAmount(amount) {
-    const num = parseFloat(amount);
-    if (isNaN(num)) return "$0.00";
-    // If negative, wrap with parentheses; otherwise, display normally.
-    return num < 0 
-      ? `($${Math.abs(num).toLocaleString()})`
-      : `$${num.toLocaleString()}`;
-  }
-  
+  const num = Number(amount || 0);
+  if (Number.isNaN(num)) return '$0.00';
+
+  const formatted = Math.abs(num).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return num < 0 ? `(${formatted})` : formatted;
+}

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -94,6 +94,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { fetchNetChanges, fetchRecentTransactions } from '@/api/accounts'
+import { formatAmount } from "@/utils/format"
 
 // State
 const selectedProducts = ref([])
@@ -132,9 +133,6 @@ function refreshCharts() {
   reorderChart.value?.refresh?.()
 }
 
-function formatAmount(val) {
-  const num = Number(val || 0)
-  return num.toLocaleString('en-US', { style: 'currency', currency: 'USD' })
 }
 
 onMounted(async () => {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -44,12 +44,24 @@
                 </button>
               </template>
               <template #summary>
-                <div>Income: <span class="font-bold text-[var(--color-accent-mint)]">${{
-                  netSummary.totalIncome?.toLocaleString() }}</span></div>
-                <div>Expenses: <span class="font-bold text-[var(--color-accent-red)]">${{
-                  netSummary.totalExpenses?.toLocaleString() }}</span></div>
-                <div class="font-bold text-lg text-[var(--color-accent-mint)]">Net Total: ${{
-                  netSummary.totalNet?.toLocaleString() }}</div>
+                <div>
+                  Income:
+                  <span class="font-bold text-[var(--color-accent-mint)]">
+                    {{ formatAmount(netSummary.totalIncome) }}
+                  </span>
+                </div>
+                <div>
+                  Expenses:
+                  <span class="font-bold text-red-400">
+                    {{ formatAmount(netSummary.totalExpenses) }}
+                  </span>
+                </div>
+                <div
+                  class="font-bold text-lg"
+                  :class="{ 'text-red-400': netSummary.totalNet < 0, 'text-[var(--color-accent-mint)]': netSummary.totalNet >= 0 }"
+                >
+                  Net Total: {{ formatAmount(netSummary.totalNet) }}
+                </div>
               </template>
             </ChartWidgetTopBar>
             <DailyNetChart :zoomed-out="zoomedOut" @summary-change="netSummary = $event" @bar-click="onNetBarClick" />
@@ -80,8 +92,9 @@
               </template>
               <template #summary>
                 <span class="text-sm">Total:</span>
-                <span class="font-bold text-lg text-[var(--color-accent-mint)]">${{ catSummary.total?.toLocaleString()
-                  }}</span>
+                <span class="font-bold text-lg text-[var(--color-accent-mint)]">
+                  {{ formatAmount(catSummary.total) }}
+                </span>
               </template>
             </ChartWidgetTopBar>
             <CategoryBreakdownChart :start-date="catRange.start" :end-date="catRange.end"
@@ -130,6 +143,7 @@ import TransactionsTable from '@/components/tables/TransactionsTable.vue'
 import PaginationControls from '@/components/tables/PaginationControls.vue'
 import TransactionModal from '@/components/modals/TransactionModal.vue'
 import GroupedCategoryDropdown from '@/components/ui/GroupedCategoryDropdown.vue'
+import { formatAmount } from '@/utils/format'
 import { ref, computed, onMounted, watch } from 'vue'
 import api from '@/services/api'
 import { useTransactions } from '@/composables/useTransactions.js'


### PR DESCRIPTION
## Summary
- fix docs with clean formatting guidance
- centralize currency formatting in all dashboard-related components
- remove duplicate formatter implementations

## Testing
- `pre-commit run --files docs/frontend/CURRENCY_FORMAT_GUIDE.md frontend/src/utils/format.js frontend/src/components/tables/UpdateTransactionsTable.vue frontend/src/components/tables/MasterTxidTable.vue frontend/src/components/recurring/RecurringTransactionSection.vue frontend/src/views/Accounts.vue frontend/src/components/charts/DailyNetChart.vue frontend/src/components/charts/CategoryBreakdownChart.vue frontend/src/components/charts/NetIncomeCharts.vue` *(fails: command not found)*
- `pytest -q` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688004ac57408329814ab4c7a9abf0d7