### PR TITLE
[backend] Delete accounts via Plaid item removal

### DIFF
--- a/backend/app/helpers/plaid_helpers.py
+++ b/backend/app/helpers/plaid_helpers.py
@@ -15,6 +15,7 @@ from plaid.model.item_get_request import ItemGetRequest
 from plaid.model.item_public_token_exchange_request import (
     ItemPublicTokenExchangeRequest,
 )
+from plaid.model.item_remove_request import ItemRemoveRequest
 from plaid.model.link_token_create_request import LinkTokenCreateRequest
 from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
 from plaid.model.products import Products
@@ -150,6 +151,16 @@ def exchange_public_token(public_token: str):
 
     except Exception as e:
         logger.error(f"Error exchanging public token: {e}", exc_info=True)
+        raise
+
+
+def remove_item(access_token: str) -> None:
+    """Remove a Plaid item associated with ``access_token``."""
+    try:
+        plaid_request = ItemRemoveRequest(access_token=access_token)
+        plaid_client.item_remove(plaid_request)
+    except Exception as e:
+        logger.error(f"Error removing Plaid item: {e}", exc_info=True)
         raise
 
 


### PR DESCRIPTION
## Summary
- integrate `/item/remove` call when deleting a Plaid account
- expose new `remove_item` helper
- test that the deletion route calls Plaid removal

## Testing
- `pre-commit run --files backend/app/helpers/plaid_helpers.py backend/app/routes/plaid_transactions.py tests/test_api_plaid_transactions.py` *(fails: mypy, pylint)*
- `pytest tests/test_api_plaid_transactions.py::test_delete_account_calls_remove_item -q`

------
https://chatgpt.com/codex/tasks/task_e_68870b5e2e2c83299143aab946c08219