### PR TITLE
[backend] Add arbitrage monitor

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -17,6 +17,7 @@ def create_app():
     Migrate(app, db)
     # Always register routes (for all environments)
     from app.routes.accounts import accounts
+    from app.routes.arbitrage import arbitrage
     from app.routes.categories import categories
     from app.routes.charts import charts
     from app.routes.export import export
@@ -43,6 +44,7 @@ def create_app():
     app.register_blueprint(rules_bp, url_prefix="/api/rules")
     app.register_blueprint(accounts, url_prefix="/api/accounts")
     app.register_blueprint(manual_up, url_prefix="/api/import")
+    app.register_blueprint(arbitrage, url_prefix="/api/arbitrage")
     app.register_blueprint(charts, url_prefix="/api/charts")
     app.register_blueprint(forecast, url_prefix="/api/forecast")
     app.register_blueprint(recurring, url_prefix="/api/recurring")

--- a/backend/app/config/constants.py
+++ b/backend/app/config/constants.py
@@ -34,3 +34,8 @@ DATABASE_NAME = os.getenv(
 )
 SQLALCHEMY_DATABASE_URI = f"sqlite:///{DIRECTORIES['DATA_DIR']}/{DATABASE_NAME}"
 TELEMETRY = {"enabled": True, "track_modifications": False}
+
+# Path to the R/S arbitrage dashboard data produced by the Discord bot.
+# The TUI script should write JSON snapshots to this file for consumption
+# by the web API.
+ARBITRAGE_FILE = DIRECTORIES["LOGS_DIR"] / "rs_arbitrage.json"

--- a/backend/app/routes/arbitrage.py
+++ b/backend/app/routes/arbitrage.py
@@ -1,0 +1,33 @@
+"""Arbitrage dashboard endpoints."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from app.config.constants import ARBITRAGE_FILE
+from flask import Blueprint, jsonify
+
+arbitrage = Blueprint("arbitrage", __name__)
+
+
+@arbitrage.route("/current", methods=["GET"])
+def get_current_arbitrage():
+    """Return the latest R/S arbitrage snapshot.
+
+    The Discord bot writes periodic updates to :data:`ARBITRAGE_FILE`.
+    If the file contains JSON, it is returned as-is. Otherwise the raw
+    text content is wrapped under the ``content`` key.
+    """
+
+    if os.path.exists(ARBITRAGE_FILE):
+        try:
+            with open(ARBITRAGE_FILE, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except json.JSONDecodeError:
+            with open(ARBITRAGE_FILE, "r", encoding="utf-8") as fh:
+                data = {"content": fh.read()}
+    else:
+        data = {"content": ""}
+
+    return jsonify(data), 200

--- a/docs/arbitrage_page.md
+++ b/docs/arbitrage_page.md
@@ -1,0 +1,10 @@
+# R/S Arbitrage Monitor
+
+A lightweight view that displays real time updates from the Discord bot.
+
+The bot writes JSON to `backend/app/logs/rs_arbitrage.json`. The new
+`/api/arbitrage/current` endpoint exposes the latest snapshot so the
+Vue page can poll for updates.
+
+Visit `/arbitrage` in the frontend to see the data refresh every few
+seconds.

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -24,6 +24,7 @@ This repo implements a dynamic forecast engine that models projected vs. actual 
 | [`01REF_Architecture_Design.md`](https://github.com/braydio/pyNance/blob/main/frontend/src/components/forecast/01REF_Architecture_Design.md) | Engine logic flow, component roles, data formats |
 | [`02REF_API_Integration.md`](https://github.com/braydio/pyNance/blob/main/frontend/src/components/forecast/02REF_API_Integration.md) | Backend route specs and implementation flow |
 | [`03REF_Development_Planning.md`](https://github.com/braydio/pyNance/blob/main/frontend/src/components/forecast/03REF_Development_Planning.md) | Live integration planning, auth, date handling, endpoint testing |
+| [`arbitrage_page.md`](../arbitrage_page.md) | R/S arbitrage monitor overview |
 
 ---
 

--- a/frontend/src/api/arbitrage.js
+++ b/frontend/src/api/arbitrage.js
@@ -1,0 +1,9 @@
+/**
+ * Arbitrage monitoring API helpers.
+ */
+import axios from 'axios'
+
+export const fetchArbitrageData = async () => {
+  const response = await axios.get('/api/arbitrage/current')
+  return response.data
+}

--- a/frontend/src/views/ArbitrageLive.vue
+++ b/frontend/src/views/ArbitrageLive.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="p-6 space-y-4">
+    <h1 class="text-2xl font-bold text-[var(--color-accent-yellow)]">
+      R/S Arbitrage Monitor
+    </h1>
+    <pre
+      v-if="content"
+      class="bg-gray-800 text-white p-4 rounded whitespace-pre-wrap"
+    >{{ content }}</pre>
+    <div v-else>Loading...</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { fetchArbitrageData } from '@/api/arbitrage'
+
+const content = ref('')
+
+const load = async () => {
+  try {
+    const data = await fetchArbitrageData()
+    content.value = data.content || JSON.stringify(data, null, 2)
+  } catch (err) {
+    console.error('Failed to load arbitrage data', err)
+  }
+}
+
+onMounted(() => {
+  load()
+  setInterval(load, 5000)
+})
+</script>

--- a/tests/test_api_arbitrage.py
+++ b/tests/test_api_arbitrage.py
@@ -1,0 +1,53 @@
+"""Tests for arbitrage API routes."""
+
+import importlib.util
+import json
+import os
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(info=lambda *a, **k: None)
+sys.modules["app.config"] = config_stub
+
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace()
+sys.modules["app.extensions"] = extensions_stub
+
+constants_path = os.path.join(BASE_BACKEND, "app", "config", "constants.py")
+constants_spec = importlib.util.spec_from_file_location(
+    "app.config.constants", constants_path
+)
+constants_module = importlib.util.module_from_spec(constants_spec)
+constants_spec.loader.exec_module(constants_module)  # type: ignore
+sys.modules["app.config.constants"] = constants_module
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "arbitrage.py")
+spec = importlib.util.spec_from_file_location("app.routes.arbitrage", ROUTE_PATH)
+arbitrage_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(arbitrage_module)  # type: ignore
+
+
+@pytest.fixture
+def client(tmp_path):
+    test_file = tmp_path / "arbitrage.json"
+    constants_module.ARBITRAGE_FILE = str(test_file)
+    test_file.write_text(json.dumps({"value": 5}))
+    app = Flask(__name__)
+    app.register_blueprint(arbitrage_module.arbitrage, url_prefix="/api/arbitrage")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_get_current_arbitrage(client):
+    resp = client.get("/api/arbitrage/current")
+    assert resp.status_code == 200
+    assert resp.get_json()["value"] == 5


### PR DESCRIPTION
## Summary
- expose `/api/arbitrage/current` endpoint
- register blueprint in Flask factory
- add simple Vue page polling the endpoint
- document arbitrage monitor
- add unit test for the new route

## Testing
- `pre-commit run --files backend/app/__init__.py backend/app/config/constants.py backend/app/routes/arbitrage.py docs/arbitrage_page.md docs/index/INDEX.md frontend/src/api/arbitrage.js frontend/src/views/ArbitrageLive.vue tests/test_api_arbitrage.py` *(fails: mypy, pylint, bandit, model-field-validation)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889e1633b448329ac0d865549d6f253