### PR TITLE
[frontend] Fix chart modal data fetching

### DIFF
--- a/frontend/src/api/transactions.js
+++ b/frontend/src/api/transactions.js
@@ -12,9 +12,15 @@
  */
 import axios from 'axios'
 
+/**
+ * Fetch transactions from the backend.
+ *
+ * @param {Object} params - Query parameters to send with the request.
+ * @returns {Promise<Object>} Result containing a transactions array.
+ */
 export const fetchTransactions = async (params = {}) => {
-  const response = await axios.get('/api/transactions/get_transactions', { params })
-  return response.data
+  const res = await axios.get('/api/transactions/get_transactions', { params })
+  return res.data?.status === 'success' ? res.data.data : { transactions: [] }
 }
 
 export const updateTransaction = async (transactionData) => {

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -5,14 +5,16 @@
 </template>
 
 <script setup>
+// DailyNetChart renders a stacked bar/line chart of income, expenses, and net values.
+// Emits "bar-click" when a bar is selected so the parent view can load transactions.
 import { fetchDailyNet } from '@/api/charts'
-import { fetchTransactions } from '@/api/transactions'
 import { ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { Chart } from 'chart.js/auto'
 import { formatAmount } from "@/utils/format"
 
 const props = defineProps({ zoomedOut: { type: Boolean, default: false } })
-const emit = defineEmits(['bar-click', 'summary-change', 'show-transactions'])
+// Emits "bar-click" when a bar is selected and "summary-change" when data totals change
+const emit = defineEmits(['bar-click', 'summary-change'])
 
 const chartInstance = ref(null)
 const chartCanvas = ref(null)
@@ -23,21 +25,14 @@ function getStyle(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
 }
 
-async function handleBarClick(evt) {
+// Emit the selected date when a bar is clicked
+function handleBarClick(evt) {
   if (!chartInstance.value) return
   const points = chartInstance.value.getElementsAtEventForMode(evt, 'nearest', { intersect: true }, false)
   if (points.length) {
     const index = points[0].index
     const date = chartInstance.value.data.labels[index]
     emit('bar-click', date)
-    try {
-      const response = await fetchTransactions({ date })
-      if (response.status === 'success') {
-        emit('show-transactions', response.data)
-      }
-    } catch (error) {
-      console.error('Error fetching transactions:', error)
-    }
   }
 }
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -140,7 +140,7 @@
         </transition>
       </div>
 
-      <<TransactionModal :show="showModal" :title="modalTitle" :transactions="modalTransactions"
+      <TransactionModal :show="showModal" :title="modalTitle" :transactions="modalTransactions"
         @close="showModal = false" />
     </div>
 
@@ -153,6 +153,7 @@
 
 
 <script setup>
+// Dashboard view showing financial charts and transaction tables.
 import AppLayout from '@/components/layout/AppLayout.vue'
 import BaseCard from '@/components/base/BaseCard.vue'
 import DailyNetChart from '@/components/charts/DailyNetChart.vue'
@@ -170,6 +171,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import api from '@/services/api'
 import { useTransactions } from '@/composables/useTransactions.js'
 import { fetchCategoryTree } from '@/api/categories'
+import { fetchTransactions } from '@/api/transactions'
 
 // Transactions and user
 const {
@@ -284,23 +286,22 @@ async function loadCategoryGroups() {
   }
 }
 
-function onNetBarClick(label) {
-  // Use full transactions array for date match (robust for ISO date)
-  modalTransactions.value = transactions.value.filter(
-    tx => tx.date && tx.date.slice(0, 10) === label
-  )
+async function onNetBarClick(label) {
+  const result = await fetchTransactions({ start_date: label, end_date: label })
+  modalTransactions.value = result.transactions || []
   modalTitle.value = `Transactions on ${label}`
   showModal.value = true
 }
 
-function onCategoryBarClick(label) {
-  // Use full transactions array for category match
-  modalTransactions.value = transactions.value.filter(
-    tx => tx.category_label === label || tx.category_parent === label
-  )
+async function onCategoryBarClick(label) {
+  const result = await fetchTransactions({
+    category: label,
+    start_date: catRange.value.start,
+    end_date: catRange.value.end,
+  })
+  modalTransactions.value = result.transactions || []
   modalTitle.value = `Transactions: ${label}`
   showModal.value = true
-
 }
 </script>
 


### PR DESCRIPTION
## Summary
- update `fetchTransactions` helper to return data when successful
- trigger API fetch from chart bar click handlers in `Dashboard.vue`
- ensure modal markup is correct and add brief comment

## Testing
- `pre-commit run --all-files` *(fails: missing docs and config)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688c139c16d083299075008c3357496a