### PR TITLE
[accounts] Surface refresh errors in results

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -1,6 +1,8 @@
 """Account management and refresh routes."""
 
+import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
 from app.config import logger
 from app.extensions import db
@@ -16,13 +18,22 @@ from flask import Blueprint, jsonify, request
 accounts = Blueprint("accounts", __name__)
 
 
+error_logger = logging.getLogger("pyNanceError")
+if not error_logger.handlers:
+    handler = logging.FileHandler(Path(__file__).resolve().parents[3] / "error_log.log")
+    error_logger.addHandler(handler)
+error_logger.setLevel(logging.ERROR)
+
+
 @accounts.route("/refresh_accounts", methods=["POST"])
 def refresh_all_accounts():
     """Refresh all linked accounts.
 
     Iterates through every account and refreshes data for the appropriate
     provider. Returns a list of updated account names and a mapping of
-    ``institution_name`` to refresh count under ``refreshed_counts``.
+    ``institution_name`` to refresh count under ``refreshed_counts``. Any
+    failures are aggregated under ``errors`` with institution, account details,
+    and Plaid error information.
     """
     try:
         from app.config import FILES, TELLER_API_BASE_URL
@@ -41,6 +52,7 @@ def refresh_all_accounts():
         accounts = query.all()
         updated_accounts = []
         refreshed_counts: dict[str, int] = {}
+        error_map: dict[tuple[str, str, str], dict] = {}
 
         # Load Teller tokens once
         from app.helpers.teller_helpers import load_tokens
@@ -57,16 +69,37 @@ def refresh_all_accounts():
                     continue
 
                 logger.debug(f"Refreshing Plaid account {account.account_id}")
-                updated = account_logic.refresh_data_for_plaid_account(
+                updated, err = account_logic.refresh_data_for_plaid_account(
                     access_token,
                     account.account_id,
                     start_date=start_date,
                     end_date=end_date,
                 )
-                if updated and account.plaid_account:
+                inst = account.institution_name or "Unknown"
+                if err:
+                    key = (
+                        inst,
+                        err.get("plaid_error_code"),
+                        err.get("plaid_error_message"),
+                    )
+                    if key not in error_map:
+                        error_map[key] = {
+                            "institution_name": inst,
+                            "account_ids": [account.account_id],
+                            "account_names": [account.name],
+                            "plaid_error_code": err.get("plaid_error_code"),
+                            "plaid_error_message": err.get("plaid_error_message"),
+                        }
+                    else:
+                        error_map[key]["account_ids"].append(account.account_id)
+                        error_map[key]["account_names"].append(account.name)
+                    error_logger.error(
+                        f"Plaid error on refresh: Institution: {inst}, Accounts: {account.name}, "
+                        f"Error Code: {err.get('plaid_error_code')}, Message: {err.get('plaid_error_message')}"
+                    )
+                elif updated and account.plaid_account:
                     account.plaid_account.last_refreshed = datetime.now(timezone.utc)
                     updated_accounts.append(account.name)
-                    inst = account.institution_name or "Unknown"
                     refreshed_counts[inst] = refreshed_counts.get(inst, 0) + 1
 
             elif account.link_type == "Teller":
@@ -110,6 +143,7 @@ def refresh_all_accounts():
                     "message": "All linked accounts refreshed.",
                     "updated_accounts": updated_accounts,
                     "refreshed_counts": refreshed_counts,
+                    "errors": list(error_map.values()),
                 }
             ),
             200,
@@ -143,7 +177,7 @@ def refresh_single_account(account_id):
                 jsonify({"status": "error", "message": "Missing Plaid token"}),
                 400,
             )
-        updated = account_logic.refresh_data_for_plaid_account(
+        updated, err = account_logic.refresh_data_for_plaid_account(
             token,
             account_id,
             start_date=start_date,

--- a/backend/app/routes/institutions.py
+++ b/backend/app/routes/institutions.py
@@ -70,7 +70,7 @@ def refresh_institution(institution_id: int):
             token = getattr(account.plaid_account, "access_token", None)
             if not token:
                 continue
-            updated = account_logic.refresh_data_for_plaid_account(
+            updated, _ = account_logic.refresh_data_for_plaid_account(
                 token,
                 account.account_id,
                 start_date=start_date,

--- a/backend/app/routes/plaid_transactions.py
+++ b/backend/app/routes/plaid_transactions.py
@@ -202,7 +202,7 @@ def refresh_accounts_endpoint():
         refreshed = []
         for acct in accounts:
             if acct.plaid_account and acct.plaid_account.access_token:
-                refreshed_flag = account_logic.refresh_data_for_plaid_account(
+                refreshed_flag, _ = account_logic.refresh_data_for_plaid_account(
                     access_token=acct.plaid_account.access_token,
                     account_id=acct.account_id,
                     start_date=start_date,
@@ -211,7 +211,7 @@ def refresh_accounts_endpoint():
                 if refreshed_flag:
                     refreshed.append(
                         acct.name or acct.account_id
-                    )  # ✅ returneadable name
+                    )  # ✅ return readable name
             else:
                 logger.warning(
                     f"Missing access token for account {acct.account_id} (user {user_id})"

--- a/tests/test_api_institutions.py
+++ b/tests/test_api_institutions.py
@@ -52,7 +52,7 @@ sys.modules["app.utils.finance_utils"] = finance_utils_stub
 # SQL stub
 sql_pkg = types.ModuleType("app.sql")
 account_logic_stub = types.ModuleType("app.sql.account_logic")
-account_logic_stub.refresh_data_for_plaid_account = lambda *a, **k: True
+account_logic_stub.refresh_data_for_plaid_account = lambda *a, **k: (True, None)
 account_logic_stub.refresh_data_for_teller_account = lambda *a, **k: True
 sys.modules["app.sql"] = sql_pkg
 sys.modules["app.sql.account_logic"] = account_logic_stub

--- a/tests/test_api_plaid_transactions.py
+++ b/tests/test_api_plaid_transactions.py
@@ -35,7 +35,7 @@ sys.modules["app.config.environment"] = env_stub
 # SQL stub
 sql_pkg = types.ModuleType("app.sql")
 account_logic_stub = types.ModuleType("app.sql.account_logic")
-account_logic_stub.refresh_data_for_plaid_account = lambda *a, **k: True
+account_logic_stub.refresh_data_for_plaid_account = lambda *a, **k: (True, None)
 sys.modules["app.sql"] = sql_pkg
 sys.modules["app.sql.account_logic"] = account_logic_stub
 sql_pkg.account_logic = account_logic_stub
@@ -146,7 +146,7 @@ def test_refresh_accounts_filters_and_dates(client, monkeypatch):
 
     def fake_refresh(access_token, account_id, start_date=None, end_date=None):
         captured.append((account_id, start_date, end_date))
-        return True
+        return True, None
 
     monkeypatch.setattr(
         plaid_module.account_logic, "refresh_data_for_plaid_account", fake_refresh


### PR DESCRIPTION
## Summary
- return Plaid refresh error details from account logic
- aggregate refresh errors in accounts API and log to `error_log.log`
- display refreshed accounts and errors in Plaid/Teller refresh widgets

## Testing
- `pre-commit run --files backend/app/sql/account_logic.py backend/app/routes/accounts.py backend/app/routes/institutions.py backend/app/routes/plaid_transactions.py tests/test_api_institutions.py tests/test_api_plaid_transactions.py` *(fails: ModuleNotFoundError: No module named 'plaid')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688e0a3b29948329856d5dde9ce6d78a