### PR TITLE
[docs] Fix stray parenthesis in AGENTS Folders list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository has a main goal: to streamline fintech and personal financial da
 
 ```
 Folders:
-- `backend/` - Flask Backend app code, including tellers, plaid, sync)
+- `backend/` - Flask Backend app code, including tellers, plaid, sync
 - `frontend` - Vue 3 + Vite + TypeScript frontend
 - `docs` - Documentation sync, Internal tracks for helpers like ChatMpdb
 - `scripts` - Useful bash setup scripts


### PR DESCRIPTION
## Summary
- remove stray parenthesis in repository AGENTS guide

## Testing
- `pre-commit run --all-files` *(fails: not found errors for some files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689329ca0a2c83299439da48fe3bb2b0