### PR TITLE
[dev] Add kiosk-ready demo database seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ VERBOSE_LOGGING=false          # true enables custom 'VERBOSE' log level
 
 # Database
 DATABASE_NAME=example_database.db  # overrides default DB name
-# Run `python scripts/generate_example_db.py` to create this file
+# Run `python scripts/generate_example_db.py` to create a fully populated demo database
 # Run `python scripts/plaid_link_from_token.py` to import accounts from saved tokens
 
 # Plaid Configuration
@@ -228,7 +228,7 @@ Backend logs are output to `backend/app/logs/app.log` (and `backend/app/logs/ver
 
 ## Troubleshooting
 
-- If you get database errors, ensure `backend/app/data/<DATABASE_NAME>.db` exists (default `developing_dash.db` when `PLAID_ENV=sandbox`, otherwise `main_dash.db`). If the file is missing, create it with `python scripts/generate_example_db.py`.
+- If you get database errors, ensure `backend/app/data/<DATABASE_NAME>.db` exists (default `developing_dash.db` when `PLAID_ENV=sandbox`, otherwise `main_dash.db`). If the file is missing, create it with `python scripts/generate_example_db.py` to seed kiosk-ready demo data for all models.
 - If you already have Plaid tokens saved, run `python scripts/plaid_link_from_token.py` to seed accounts.
 - For Plaid access issues, verify `PLAID_CLIENT_ID`, `PLAID_SECRET_KEY`, and `PLAID_ENV` values.
 - Check logs in `backend/app/logs/` (e.g. `app.log`, `verbose.log`) for details.

--- a/scripts/generate_example_db.py
+++ b/scripts/generate_example_db.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""Utility to generate a sample database for the pyNance dashboard."""
+"""Utility to generate a fully populated demo database for pyNance."""
 
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 import random
 import sys
 import types
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from dateutil.relativedelta import relativedelta
@@ -27,6 +28,10 @@ app_pkg.extensions = extensions_mod
 app_pkg.__path__ = []
 sys.modules["app"] = app_pkg
 sys.modules["app.extensions"] = extensions_mod
+config_mod = types.ModuleType("app.config")
+config_mod.logger = logging.getLogger("generate_example_db")
+app_pkg.config = config_mod
+sys.modules["app.config"] = config_mod
 
 models_path = BACKEND_DIR / "app" / "models.py"
 spec = importlib.util.spec_from_file_location("app.models", models_path)
@@ -37,15 +42,15 @@ Account = models.Account
 Category = models.Category
 Transaction = models.Transaction
 Institution = models.Institution
-
-ah_path = BACKEND_DIR / "app" / "helpers" / "account_history_helper.py"
-ah_spec = importlib.util.spec_from_file_location(
-    "app.helpers.account_history_helper", ah_path
-)
-ah_mod = importlib.util.module_from_spec(ah_spec)
-ah_spec.loader.exec_module(ah_mod)
-sys.modules["app.helpers.account_history_helper"] = ah_mod
-update_account_history = ah_mod.update_account_history
+PlaidAccount = models.PlaidAccount
+PlaidItem = models.PlaidItem
+PlaidWebhookLog = models.PlaidWebhookLog
+TellerAccount = models.TellerAccount
+AccountHistory = models.AccountHistory
+RecurringTransaction = models.RecurringTransaction
+TransactionRule = models.TransactionRule
+PlaidTransactionMeta = models.PlaidTransactionMeta
+FinancialGoal = models.FinancialGoal
 
 
 def create_app(db_uri: str) -> Flask:
@@ -58,29 +63,84 @@ def create_app(db_uri: str) -> Flask:
 
 
 def seed_data() -> None:
-    """Populate the database with 12 months of mock records."""
-    example_bank = Institution(name="Example Bank", provider="manual")
+    """Populate the database with demo records for all models."""
+    example_bank = Institution(
+        name="Example Bank",
+        provider="manual",
+        last_refreshed=datetime.now(),
+    )
     db.session.add(example_bank)
 
     checking = Account(
         account_id="acc_checking",
+        user_id="user_1",
         name="Checking Account",
         type="checking",
         subtype="checking",
         institution_name="Example Bank",
         institution=example_bank,
+        status="active",
+        is_hidden=False,
         balance=1000,
         link_type="manual",
     )
     credit = Account(
         account_id="acc_credit",
+        user_id="user_1",
         name="Credit Card",
         type="credit",
         subtype="credit card",
         institution_name="Example Bank",
         institution=example_bank,
+        status="active",
+        is_hidden=False,
         balance=-500,
         link_type="manual",
+    )
+
+    plaid_account = PlaidAccount(
+        account_id=checking.account_id,
+        plaid_institution_id="ins_1",
+        access_token="plaid-access-token",
+        item_id="item_1",
+        product="transactions",
+        institution_id="inst_123",
+        webhook="https://example.com/webhook",
+        last_refreshed=datetime.now(),
+        institution=example_bank,
+        sync_cursor="cursor_1",
+        is_active=True,
+        last_error=None,
+    )
+
+    teller_account = TellerAccount(
+        account_id=credit.account_id,
+        access_token="teller-access-token",
+        enrollment_id="enroll_1",
+        teller_institution_id="teller_ins_1",
+        provider="Teller",
+        last_refreshed=datetime.now(),
+        institution=example_bank,
+    )
+
+    plaid_item = PlaidItem(
+        user_id="user_1",
+        item_id="item_1",
+        access_token="plaid-access-token",
+        institution_name="Example Bank",
+        product="transactions",
+        last_refreshed=datetime.now(),
+        is_active=True,
+        last_error=None,
+    )
+
+    webhook_log = PlaidWebhookLog(
+        event_type="TRANSACTIONS",
+        webhook_type="TRANSACTIONS",
+        webhook_code="DEFAULT_UPDATE",
+        item_id="item_1",
+        payload={"sample": "payload"},
+        received_at=datetime.now(),
     )
 
     income_cat = Category(
@@ -104,7 +164,20 @@ def seed_data() -> None:
         detailed_category="",
     )
 
-    db.session.add_all([checking, credit, income_cat, food_cat, util_cat, travel_cat])
+    db.session.add_all(
+        [
+            checking,
+            credit,
+            plaid_account,
+            teller_account,
+            plaid_item,
+            webhook_log,
+            income_cat,
+            food_cat,
+            util_cat,
+            travel_cat,
+        ]
+    )
     db.session.commit()
 
     today = datetime.now().replace(day=1)
@@ -160,19 +233,90 @@ def seed_data() -> None:
                 category="Travel",
             )
         )
-    db.session.bulk_save_objects(transactions)
+    db.session.add_all(transactions)
     db.session.commit()
 
-    # Generate account history for forecasting features
-    update_account_history()
+    # Add Plaid metadata for the first grocery transaction
+    sample_tx = transactions[1]
+    meta = PlaidTransactionMeta(
+        transaction=sample_tx,
+        plaid_account_id=plaid_account.account_id,
+        account_owner="John Doe",
+        authorized_date=sample_tx.date.date(),
+        authorized_datetime=sample_tx.date,
+        category=["Food", "Groceries"],
+        category_id="19013000",
+        check_number="123",
+        counterparties=[{"name": "Local Market"}],
+        datetime=sample_tx.date,
+        iso_currency_code="USD",
+        location={"city": "Metropolis"},
+        logo_url="https://example.com/logo.png",
+        merchant_entity_id="merch_1",
+        payment_channel="in_store",
+        payment_meta={"reference_number": "ref123"},
+        pending_transaction_id=None,
+        transaction_code="purchase",
+        transaction_type="special",
+        unofficial_currency_code=None,
+        website="https://market.example.com",
+        pfc_confidence_level="HIGH",
+        is_active=True,
+    )
+    db.session.add(meta)
+
+    # Recurring transaction for utility bill
+    util_tx = next(tx for tx in transactions if tx.transaction_id == "tx_util_0")
+    recurring = RecurringTransaction(
+        transaction=util_tx,
+        account_id=util_tx.account_id,
+        frequency="monthly",
+        next_due_date=util_tx.date.date() + relativedelta(months=1),
+        notes="Monthly utilities",
+        next_instance_id="util_next_1",
+    )
+    db.session.add(recurring)
+
+    # Transaction rule example
+    rule = TransactionRule(
+        user_id="user_1",
+        match_criteria={"description": "Grocery"},
+        action={"category": "Food"},
+        is_active=True,
+    )
+    db.session.add(rule)
+
+    # Financial goal
+    goal = FinancialGoal(
+        user_id="user_1",
+        account_id=checking.account_id,
+        name="Vacation Fund",
+        target_amount=5000,
+        due_date=date.today() + relativedelta(months=12),
+        notes="Trip to Hawaii",
+    )
+    db.session.add(goal)
+
+    # Explicit account history entry
+    hist = AccountHistory(
+        account_id=checking.account_id,
+        user_id="user_1",
+        date=datetime.now(),
+        balance=checking.balance,
+        is_hidden=False,
+    )
+    db.session.add(hist)
+    db.session.commit()
 
 
 def build_example_database(path: str) -> None:
     """Create the example database file and populate it."""
     uri = f"sqlite:///{path}"
     app = create_app(uri)
-    if os.path.exists(path):
-        os.remove(path)
+    db_path = Path(path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        os.remove(db_path)
     with app.app_context():
         db.create_all()
         seed_data()


### PR DESCRIPTION
## Summary
- seed all SQLAlchemy models with demo data for kiosk-style dev mode
- document example DB generator usage in README

## Testing
- `pre-commit run --all-files` *(fails: ruff undefined name `plaid_errors` and mypy duplicate module `env`)*
- `pytest` *(fails: ImportError: cannot import name 'PLAID_ENV')*
- `python scripts/generate_example_db.py`

------
https://chatgpt.com/codex/tasks/task_e_689289e0fc7c8329b900a0ba66d1c1ab