### PR TITLE
[docs] Clarify style and pre-commit instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Folders:
 
 ## Style Guidelines
 
-- Use PEP 8.1 and beyond, TypeAnnotations
+- Use PEP 8 with type annotations
 - Docs should match existing deployment types
 - Use `lint`, `black`, `ruff` for style
 - Run `bash scripts/setup.sh` to prepare the environment (creates `.venv`, installs deps, links hooks)
@@ -25,7 +25,7 @@ Folders:
 - Node 20 required for the frontend
 - Run `pytest` from root to validate
 - `pre-commit` is configured
-- Run `pre-commit run --all-files` before pushing
+- Run `pre-commit run --all-files` before pushing (runs black, isort, ruff, mypy, pylint, and bandit)
 
 ## Git Hooks
 
@@ -63,7 +63,7 @@ git config core.hooksPath .githooks
 ## Testing Checklist
 
 - ✅ `pytest`
-- ✅ `pre-commit run --all-files`
+- ✅ `pre-commit run --all-files` (black, isort, ruff, mypy, pylint, bandit)
 - ✅ Add tests for API or dispatcher behavior
 - ✅ Validate test_model_fields_are_valid does not fail
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ pre-commit install
 Install these before running tests or formatting hooks:
 
 ```bash
-pre-commit run --all-files
+pre-commit run --all-files  # runs black, isort, ruff, mypy, pylint, and bandit
 pytest -q
 ```
 
@@ -155,7 +155,7 @@ npm run dev
 
 ```bash
 pytest -q
-pre-commit run --all-files
+pre-commit run --all-files  # runs black, isort, ruff, mypy, pylint, and bandit
 ```
 
 All tests should pass when dependencies are installed.


### PR DESCRIPTION
## Summary
- clarify style guideline wording
- document tools invoked by `pre-commit run --all-files`

## Testing
- `pre-commit run --files AGENTS.md README.md` *(fails: Validate model fields: no tests run)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6893bde93c1c832983a466b2942996d4