### PR TITLE
[docs] Remove outdated doc-sync references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ git config core.hooksPath .githooks
 - Title format: `[component] Fix or Add <title>`
 - Description must include affected modules (backend/frontend/test)
 - If adding API, reflect in docs and add test coverage
-- Use `scripts/entr_docsync.sh` if syncing doc updates automatically
+- After editing documentation, run `python scripts/doc_cleaner.py` to regenerate the docs index and verify metadata
 - Commit messages: `<type>(<scope>): <description>` (e.g. `feat(auth): add token helper`)
 
 ## Agents Should
@@ -72,5 +72,5 @@ git config core.hooksPath .githooks
 This guide exists to help agents operate predictably and reduce context churn.
 
 If a test fails, check test structure before code.
-If docs are out of sync, run `entr_docsync.sh` or `auto_docsync.sh`.
+If docs are out of sync, regenerate the index with `python scripts/doc_cleaner.py` and review `docs/index/INDEX.md` before committing.
 If you update sync behavior, please update CLI and add to coverage.


### PR DESCRIPTION
## Summary
- remove references to non-existent doc-sync scripts in AGENTS.md
- recommend `python scripts/doc_cleaner.py` to regenerate docs index

## Testing
- `pre-commit run --all-files` *(fails: black reformatted unrelated files)*
- `pre-commit run --files AGENTS.md` *(fails: Validate model fields hook cannot find AGENTS.md)*
- `pytest` *(fails: ImportError: cannot import name 'PLAID_ENV' from 'app.config.environment')*


------
https://chatgpt.com/codex/tasks/task_e_6893e96bcd04832982837e1dc4f63b32