### PR TITLE
refactor: rename TransactionModal titleDate prop to subtitle

### DIFF
--- a/frontend/src/components/modals/TransactionModal.vue
+++ b/frontend/src/components/modals/TransactionModal.vue
@@ -14,8 +14,8 @@
               <path d="M7 12h10M12 7v10" stroke-linecap="round" />
             </svg>
             Transactions
-            <span v-if="titleDate" class="ml-2 text-violet-200 text-base font-medium normal-case drop-shadow-none">
-              ({{ titleDate }})
+            <span v-if="subtitle" class="ml-2 text-violet-200 text-base font-medium normal-case drop-shadow-none">
+              ({{ subtitle }})
             </span>
           </h2>
           <button
@@ -63,10 +63,12 @@ import { onMounted, nextTick, computed } from 'vue'
 import ModalTransactionsDisplay from '../tables/ModalTransactionsDisplay.vue'
 import { formatAmount } from "@/utils/format"
 
+// Modal dialog displaying a list of transactions with a summary bar and optional subtitle.
+
 const props = defineProps({
   show: { type: Boolean, default: false },
   transactions: { type: Array, default: () => [] },
-  titleDate: { type: String, default: '' }
+  subtitle: { type: String, default: '' }
 })
 
 const emit = defineEmits(['close'])

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -145,7 +145,7 @@
         </transition>
       </div>
 
-      <TransactionModal :show="showModal" :title-date="modalTitle" :transactions="modalTransactions"
+      <TransactionModal :show="showModal" :subtitle="modalSubtitle" :transactions="modalTransactions"
         @close="showModal = false" />
     </div>
 
@@ -191,7 +191,7 @@ const {
 } = useTransactions(15)
 const showModal = ref(false)
 const modalTransactions = ref([])
-const modalTitle = ref('')
+const modalSubtitle = ref('')
 const userName = import.meta.env.VITE_USER_ID_PLAID || 'Guest'
 const currentDate = new Date().toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })
 const netWorth = ref(0)
@@ -294,7 +294,7 @@ async function loadCategoryGroups() {
 async function onNetBarClick(label) {
   const result = await fetchTransactions({ start_date: label, end_date: label })
   modalTransactions.value = result.transactions || []
-  modalTitle.value = `Net total for ${label}`
+  modalSubtitle.value = `Net total for ${label}`
   showModal.value = true
 }
 
@@ -326,7 +326,7 @@ async function onCategoryBarClick(payload) {
   modalTransactions.value = result.data?.transactions || []
 
   // Display the category label and date span in the modal header
-  modalTitle.value = `${label}: ${start} – ${end}`
+  modalSubtitle.value = `${label}: ${start} – ${end}`
   showModal.value = true
 }
 </script>


### PR DESCRIPTION
## Summary
- replace `titleDate` prop with `subtitle` in `TransactionModal.vue`
- update `Dashboard.vue` to use `subtitle` and corresponding `modalSubtitle` ref
- add comment describing modal component

## Testing
- `npx eslint src/components/modals/TransactionModal.vue src/views/Dashboard.vue`
- `npm test` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff96751b883299fb05b6f86534114