### PR TITLE
feat(transactions): support category filter in dashboard

### DIFF
--- a/docs/frontend/DASHBOARD_MODAL_GUIDE.md
+++ b/docs/frontend/DASHBOARD_MODAL_GUIDE.md
@@ -24,18 +24,18 @@ const modalTransactions = ref([])
 async function openModalByDate(date: string) {
   modalTitle.value = `Transactions for ${date}`
   const res = await fetchTransactions({ date })
-  modalTransactions.value = res.data.transactions || []
+  modalTransactions.value = res.transactions || []
   showModal.value = true
 }
 
 async function openModalByCategory(payload: { label: string; ids: number[] }) {
   modalTitle.value = `Transactions in ${payload.label}`
-  const res = await fetchCategoryTransactions({
-    category_ids: payload.ids.join(','),
+  const res = await fetchTransactions({
+    category_ids: payload.ids,
     start_date: catRange.value.start,
     end_date: catRange.value.end,
   })
-  modalTransactions.value = res.data.transactions || []
+  modalTransactions.value = res.transactions || []
   showModal.value = true
 }
 ```

--- a/frontend/src/api/charts.js
+++ b/frontend/src/api/charts.js
@@ -1,4 +1,10 @@
 
+/**
+ * Chart API helpers.
+ *
+ * Provides endpoints for retrieving data used by dashboard charts.
+ * Includes category breakdowns and daily net values.
+ */
 import axios from 'axios'
 
 // Tree (hierarchical) breakdown for the new chart
@@ -16,13 +22,6 @@ export async function fetchCategoryBreakdown(params = {}) {
 // For daily net chart
 export async function fetchDailyNet(params = {}) {
   const response = await axios.get('/api/charts/daily_net', { params })
-  return response.data
-}
-
-// ..reviewing for additional
-
-export async function fetchCategoryTransactions(params = {}) {
-  const response = await axios.get('/api/charts/category_transactions', { params })
   return response.data
 }
 

--- a/frontend/src/api/transactions.js
+++ b/frontend/src/api/transactions.js
@@ -15,11 +15,22 @@ import axios from 'axios'
 /**
  * Fetch transactions from the backend.
  *
- * @param {Object} params - Query parameters to send with the request.
+ * @param {Object} params - Query parameters such as `start_date`, `end_date`,
+ *   and an optional `category_ids` array or comma-separated string.
  * @returns {Promise<Object>} Result containing a transactions array.
  */
 export const fetchTransactions = async (params = {}) => {
-  const response = await axios.get('/api/transactions/get_transactions', { params })
+  const { category_ids, ...rest } = params
+  const query = { ...rest }
+
+  // Allow callers to pass an array of IDs or a preformatted string
+  if (Array.isArray(category_ids)) {
+    query.category_ids = category_ids.join(',')
+  } else if (category_ids) {
+    query.category_ids = category_ids
+  }
+
+  const response = await axios.get('/api/transactions/get_transactions', { params: query })
   return (response.data?.status === 'success') ? response.data.data : { transactions: [] }
 }
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -176,7 +176,6 @@ import api from '@/services/api'
 import { useTransactions } from '@/composables/useTransactions.js'
 import { fetchCategoryTree } from '@/api/categories'
 import { fetchTransactions } from '@/api/transactions'
-import { fetchCategoryTransactions } from '@/api/charts'
 
 // Transactions and user
 const {
@@ -318,12 +317,12 @@ async function onCategoryBarClick(payload) {
   const start = catSummary.value.startDate || catRange.value.start
   const end = catSummary.value.endDate || catRange.value.end
 
-  const result = await fetchCategoryTransactions({
-    category_ids: ids.join(','),
+  const result = await fetchTransactions({
+    category_ids: ids,
     start_date: start,
     end_date: end,
   })
-  modalTransactions.value = result.data?.transactions || []
+  modalTransactions.value = result.transactions || []
 
   // Display the category label and date span in the modal header
   modalTitle.value = `${label}: ${start} – ${end}`


### PR DESCRIPTION
## Summary
- allow `fetchTransactions` to accept `category_ids` and forward them to the backend
- replace dashboard category transaction calls with `fetchTransactions`
- drop deprecated `fetchCategoryTransactions` helper and update docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: AccountSparkline.vue no-unused-vars; NetIncomeHeader.jsx parsing error)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689ff9d53a8883299c29058e8e0eff6c