### PR TITLE
docs: improve docs index

### DIFF
--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -1,9 +1,19 @@
 # Documentation Index
 
-- Backend: docs/backend/
-- Frontend: docs/frontend/
-- Architecture: docs/architecture/
-- Process: docs/process/
-- Maintenance: docs/maintenance/
-- Maps: docs/maps/
-- Dev Notes: docs/devnotes/
+## Core
+
+- [Backend](../backend/) – server-side code and features
+- [Frontend](../frontend/) – client-side components
+- [Architecture](../architecture/) – system design overview
+- [Process](../process/) – development workflows
+- [Maintenance](../maintenance/) – operations and upkeep
+- [Maps](../maps/) – diagrams and visual references
+
+## Additional Resources
+
+- [Dataflow](../dataflow/) – data movement and transformations
+- [Forecast](../forecast/) – financial forecasting docs
+- [Integrations](../integrations/) – third-party connections
+- [Internal](../internal/) – internal notes
+- [Codex](../codex/) – exploratory reports
+- [Latest](../latest/) – recent drafts and experiments


### PR DESCRIPTION
## Summary
- replace plain text references with markdown links
- expand navigation with additional resource sections

## Testing
- `pre-commit run --files docs/index/INDEX.md` (fails: model-field-validation hook missing file)
- `pytest` (fails: ModuleNotFoundError: No module named 'flask`)


------
https://chatgpt.com/codex/tasks/task_e_68a0d0f057cc8329a3cafb7e2c9d7c9d