### PR TITLE
test: update model tests for new backend package

### DIFF
--- a/tests/test_internal_transfer_detection.py
+++ b/tests/test_internal_transfer_detection.py
@@ -1,3 +1,5 @@
+"""Tests for detecting internal transfers with the modularized models."""
+
 import importlib.util
 import os
 import sys
@@ -76,12 +78,15 @@ sys.modules["app.extensions"] = extensions
 app_pkg.extensions = extensions
 
 # Load models and account_logic modules
+models_path = os.path.join(BASE_BACKEND, "app", "models", "__init__.py")
 spec_models = importlib.util.spec_from_file_location(
-    "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+    "app.models",
+    models_path,
+    submodule_search_locations=[os.path.dirname(models_path)],
 )
 models = importlib.util.module_from_spec(spec_models)
-spec_models.loader.exec_module(models)
 sys.modules["app.models"] = models
+spec_models.loader.exec_module(models)
 app_pkg.models = models
 
 spec_logic = importlib.util.spec_from_file_location(

--- a/tests/test_investments_logic.py
+++ b/tests/test_investments_logic.py
@@ -1,3 +1,5 @@
+"""Tests for investment account logic with the new models package."""
+
 import importlib.util
 import os
 import sys
@@ -9,11 +11,17 @@ from flask import Flask
 BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
 
 
-def load_module(name, path):
-    spec = importlib.util.spec_from_file_location(name, path)
+def load_module(name, path, package=False):
+    """Load a module or package from disk for testing."""
+
+    spec = importlib.util.spec_from_file_location(
+        name,
+        path,
+        submodule_search_locations=[os.path.dirname(path)] if package else None,
+    )
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
     sys.modules[name] = module
+    spec.loader.exec_module(module)
     return module
 
 
@@ -21,6 +29,11 @@ def setup_app(tmp_path):
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    for mod in list(sys.modules):
+        if mod == "app" or mod.startswith("app."):
+            sys.modules.pop(mod, None)
+
+    sys.modules.setdefault("app", types.ModuleType("app"))
 
     config_stub = types.ModuleType("app.config")
     config_stub.logger = types.SimpleNamespace(
@@ -45,18 +58,22 @@ def db_ctx(tmp_path):
     app, extensions = setup_app(tmp_path)
     with app.app_context():
         models = load_module(
-            "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+            "app.models",
+            os.path.join(BASE_BACKEND, "app", "models", "__init__.py"),
+            package=True,
         )
-        import sys
-
-        sys.modules["app.models"] = models
         logic = load_module(
             "app.sql.investments_logic",
             os.path.join(BASE_BACKEND, "app", "sql", "investments_logic.py"),
         )
         extensions.db.create_all()
-        yield extensions.db, models, logic
-        extensions.db.drop_all()
+        try:
+            yield extensions.db, models, logic
+        finally:
+            extensions.db.drop_all()
+            for mod in list(sys.modules):
+                if mod == "app" or mod.startswith("app."):
+                    sys.modules.pop(mod, None)
 
 
 def test_get_investment_accounts(db_ctx):

--- a/tests/test_model_field_validation.py
+++ b/tests/test_model_field_validation.py
@@ -15,7 +15,8 @@ BASE_DIR = os.path.join(os.path.dirname(__file__), "..", "backend")
 
 
 def _load_models():
-    """Load backend models with minimal Flask-SQLAlchemy context."""
+    """Load backend models package with minimal Flask-SQLAlchemy context."""
+
     sys.modules.pop("app", None)
     app_pkg = types.ModuleType("app")
     extensions_stub = types.ModuleType("app.extensions")
@@ -24,9 +25,14 @@ def _load_models():
     sys.modules["app"] = app_pkg
     sys.modules["app.extensions"] = extensions_stub
 
-    module_path = os.path.join(BASE_DIR, "app", "models.py")
-    spec = importlib.util.spec_from_file_location("app.models", module_path)
+    module_path = os.path.join(BASE_DIR, "app", "models", "__init__.py")
+    spec = importlib.util.spec_from_file_location(
+        "app.models",
+        module_path,
+        submodule_search_locations=[os.path.dirname(module_path)],
+    )
     models = importlib.util.module_from_spec(spec)
+    sys.modules["app.models"] = models
     spec.loader.exec_module(models)
     return models
 

--- a/tests/test_save_plaid_account.py
+++ b/tests/test_save_plaid_account.py
@@ -1,3 +1,5 @@
+"""Tests for saving Plaid accounts using the modularized models package."""
+
 import importlib.util
 import os
 import sys
@@ -9,11 +11,21 @@ from flask import Flask
 BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
 
 
-def load_module(name, path):
-    spec = importlib.util.spec_from_file_location(name, path)
+def load_module(name, path, package=False):
+    """Dynamically load a module or package from ``path``.
+
+    When ``package`` is True, the loader treats the target as a package so
+    relative imports within it resolve correctly.
+    """
+
+    spec = importlib.util.spec_from_file_location(
+        name,
+        path,
+        submodule_search_locations=[os.path.dirname(path)] if package else None,
+    )
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
     sys.modules[name] = module
+    spec.loader.exec_module(module)
     return module
 
 
@@ -21,6 +33,12 @@ def setup_app(tmp_path):
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    # Ensure a clean import state across tests
+    for mod in list(sys.modules):
+        if mod == "app" or mod.startswith("app."):
+            sys.modules.pop(mod, None)
+
+    sys.modules.setdefault("app", types.ModuleType("app"))
 
     config_stub = types.ModuleType("app.config")
     config_stub.logger = types.SimpleNamespace(
@@ -74,15 +92,40 @@ def db_ctx(tmp_path):
     app, extensions = setup_app(tmp_path)
     with app.app_context():
         models = load_module(
-            "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+            "app.models",
+            os.path.join(BASE_BACKEND, "app", "models", "__init__.py"),
+            package=True,
         )
+        sql_pkg = types.ModuleType("app.sql")
+        trl = types.ModuleType("app.sql.transaction_rules_logic")
+        trl.apply_rules = lambda user_id, tx: tx
+        refresh_meta = types.ModuleType("app.sql.refresh_metadata")
+        refresh_meta.refresh_or_insert_plaid_metadata = lambda *a, **k: None
+        sys.modules["app.sql"] = sql_pkg
+        sys.modules["app.sql.transaction_rules_logic"] = trl
+        sys.modules["app.sql.refresh_metadata"] = refresh_meta
+        sql_pkg.transaction_rules_logic = trl
+        sql_pkg.refresh_metadata = refresh_meta
+        plaid_stub = types.ModuleType("plaid")
+
+        class ApiException(Exception):
+            pass
+
+        plaid_stub.ApiException = ApiException
+        sys.modules["plaid"] = plaid_stub
         logic = load_module(
             "app.sql.account_logic",
             os.path.join(BASE_BACKEND, "app", "sql", "account_logic.py"),
         )
         extensions.db.create_all()
-        yield extensions.db, models, logic
-        extensions.db.drop_all()
+        try:
+            yield extensions.db, models, logic
+        finally:
+            extensions.db.drop_all()
+            # Remove dynamically loaded modules to avoid cross-test interference
+            for mod in list(sys.modules):
+                if mod == "app" or mod.startswith("app.") or mod.startswith("plaid"):
+                    sys.modules.pop(mod, None)
 
 
 def test_save_plaid_account_inserts_and_updates(db_ctx):


### PR DESCRIPTION
## Summary
- reset module cache before/after backend model tests to avoid stale SQLAlchemy instances
- isolate recurring bridge service modules to keep tests independent

## Testing
- `SKIP=pylint,bandit,model-field-validation pre-commit run --files tests/test_save_plaid_account.py tests/test_investments_logic.py tests/test_recurring_bridge.py`
- `pytest tests/test_save_plaid_account.py tests/test_investments_logic.py tests/test_recurring_bridge.py tests/test_model_field_validation.py tests/test_internal_transfer_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_68a53b81b4148329b00d734b6d6b9fb4