### PR TITLE
feat(theme): adopt Nightfox dark palette

### DIFF
--- a/docs/frontend/THEMING_GUIDE.md
+++ b/docs/frontend/THEMING_GUIDE.md
@@ -1,6 +1,7 @@
-# Neon Dark Theming Guide
+# Nightfox Dark Theming Guide
 
 This document describes how to configure and extend the frontend theme for *pyNance*.
+The project now uses the [Nightfox](https://github.com/EdenEast/nightfox.nvim) dark palette as the default theme.
 It introduces a modular approach built around CSS custom properties.
 
 ## Directory Layout
@@ -14,22 +15,21 @@ frontend/
    └─ styles/
       ├─ global-colors.css   # imports the active theme
       └─ themes/
-         ├─ neon-dark.css    # default neon dark palette
-         └─ dark-frost.css   # dark frost with neon accents
+         ├─ nightfox.css     # default Nightfox palette
+         ├─ dark-frost.css   # legacy dark frost theme
+         └─ neon-dark.css    # legacy neon dark theme
 ```
 
 * `global-colors.css` defines the variables that components rely on. It imports
   a theme file so new themes can be swapped without editing components.
-* `themes/neon-dark.css` is the initial theme with neon accents and frosted
-  surfaces.
-* `themes/dark-frost.css` extends the palette with slightly darker backgrounds
-  but keeps the neon accent variables intact. It powers the "Dark Frost" look
-  used across components.
+* `themes/nightfox.css` is the official theme based on the Nightfox palette.
+* `themes/dark-frost.css` and `themes/neon-dark.css` are legacy themes retained
+  for reference.
 
 ## Adding a New Theme
 
 1. Create a file in `frontend/src/styles/themes/` with the same variable names
-   as `neon-dark.css`.
+   as `nightfox.css`.
 2. Replace the `@import` line at the top of `global-colors.css` to point to the
    new theme file or dynamically inject the file at runtime.
 3. Keep variable names consistent so existing components continue to work.
@@ -91,7 +91,7 @@ existing link.
 
 ## Frosted Glass Effect
 
-The neon dark theme uses semi-transparent backgrounds (`--themed-bg`) and subtle
+The Nightfox theme uses semi-transparent backgrounds (`--themed-bg`) and subtle
 borders (`--themed-border`) to create a frosted glass look. Components can apply
 these styles using `backdrop-filter: blur(6px)` or by setting the background and
 border variables directly.

--- a/frontend/src/assets/css/theme.css
+++ b/frontend/src/assets/css/theme.css
@@ -1,29 +1,6 @@
+@import '../../styles/global-colors.css';
+
+/* Entry point for theme variables. Nightfox dark palette is the default. */
 :root {
-  /* Dark mode colors */
-  --color-bg-dark: #1e1e1e;
-  --color-bg-secondary: #242424;
-  --text-primary: #f5f5f5;
-  --color-text-light: var(--text-primary);
-  --text-muted: #a1a1aa;
-  --color-text-muted: var(--text-muted);
-  --color-border-secondary: #3f3f46;
-  --divider: rgba(255, 255, 255, 0.12);
-  --shadow: rgba(0, 0, 0, 0.6);
-
-  /* Neon accents */
-  --neon-purple: #c084fc;
-  --neon-mint: #2fffa7;
-  --color-accent-yellow: #facc15;
-  --color-accent-purple-hover: #d9a6fd;
-  --color-accent-mint: #2fffa7;
-  --hover-glow: rgba(192, 132, 252, 0.6);
-
-  /* Frosted glass */
-  --frosted-bg: rgba(255, 255, 255, 0.08);
-  --hover: rgba(255, 255, 255, 0.1);
-  --color-hover-light: rgba(255, 255, 255, 0.06);
-  --color-error: #f87171;
-  --color-bg-sec: rgba(255, 255, 255, 0.1);
-  /* Font family */
   --font-sans: 'Source Code Pro', ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/src/styles/global-colors.css
+++ b/frontend/src/styles/global-colors.css
@@ -1,4 +1,4 @@
-@import './themes/dark-frost.css';
+@import './themes/nightfox.css';
 
 :root {
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.45);

--- a/frontend/src/styles/themes/nightfox.css
+++ b/frontend/src/styles/themes/nightfox.css
@@ -1,0 +1,46 @@
+:root {
+  --page-bg: #192330;
+  --background: var(--page-bg);
+  --color-bg: #212e3f;
+  --color-bg-dark: #131a24;
+  --color-bg-secondary: #29394f;
+  --themed-bg: rgba(41, 57, 79, 0.65);
+  --theme-bg: var(--themed-bg);
+  --frosted-bg: var(--themed-bg);
+  --themed-border: rgba(57, 80, 109, 0.4);
+  --surface: #212e3f;
+  --input-bg: #2b3b51;
+  --divider: #39506d;
+  --color-border-secondary: #39506d;
+
+  --theme-fg: #cdcecf;
+  --text-primary: #cdcecf;
+  --color-text-dark: #000000;
+  --color-text-light: var(--text-primary);
+  --color-text-muted: #71839b;
+
+  --primary: #719cd6;
+  --primary-dark: #39506d;
+
+  --neon-mint: #63cdcf;
+  --neon-purple: #9d79d6;
+  --color-accent-mint: var(--neon-mint);
+  --color-accent-yellow: #dbc074;
+  --color-accent-magenta: #d67ad2;
+  --color-accent-ice: #63cdcf;
+  --color-accent-purple-hover: #b093e6;
+  --color-accent: var(--neon-mint);
+
+  --hover-bg: rgba(255, 255, 255, 0.05);
+  --color-hover-light: rgba(255, 255, 255, 0.08);
+  --hover-glow: 0 0 8px rgba(113, 156, 214, 0.6);
+
+  --button-bg: #2b3b51;
+  --link-hover-color: var(--neon-mint);
+  --asset-gradient-start: #719cd6;
+  --asset-gradient-end: #63cdcf;
+  --liability-gradient-start: #c94f6d;
+  --liability-gradient-end: #d67ad2;
+  --bar-gradient-end: #d67ad2;
+  --accent-yellow-soft: rgba(219, 192, 116, 0.5);
+}


### PR DESCRIPTION
## Summary
- add Nightfox-based theme and make it the default import
- wire global theme entry to the new palette
- document Nightfox as the project's official color scheme

## Testing
- `pre-commit run --all-files` *(fails: path errors for non-existent files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b5aad65883298c19fce94937935d