### PR TITLE
fix(tables): remove deprecated Vue $set usage

### DIFF
--- a/frontend/src/components/tables/InstitutionTable.vue
+++ b/frontend/src/components/tables/InstitutionTable.vue
@@ -55,8 +55,12 @@ export default {
     return { institutions: [], expanded: {}, loading: true };
   },
   methods: {
+    /**
+     * Toggle expansion state for a given institution row.
+     * @param {number|string} id - Institution identifier.
+     */
     toggle(id) {
-      this.$set(this.expanded, id, !this.expanded[id]);
+      this.expanded[id] = !this.expanded[id];
     },
     formatDate(d) {
       if (!d) return 'N/A';


### PR DESCRIPTION
## Summary
- replace deprecated `$set` usage in InstitutionTable with direct assignment
- document toggle method for clarity

## Testing
- `npm run lint` *(fails: 'err' is defined but never used; Unexpected token `<` in NetIncomeHeader.jsx)*
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68a7a8bd07a08329bcfa3086bb030519