### PR TITLE
fix: stabilize test imports and logging

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -20,9 +20,9 @@ accounts = Blueprint("accounts", __name__)
 
 error_logger = logging.getLogger("pyNanceError")
 if not error_logger.handlers:
-    handler = logging.FileHandler(
-        Path(__file__).resolve().parents[1] / "logs/account_sync_error.log"
-    )
+    log_file = Path(__file__).resolve().parents[1] / "logs" / "account_sync_error.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_file)
     error_logger.addHandler(handler)
 error_logger.setLevel(logging.ERROR)
 

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -353,9 +353,7 @@ def refresh_data_for_teller_account(
         txns_list = (
             txns_json.get("transactions", [])
             if isinstance(txns_json, dict)
-            else txns_json
-            if isinstance(txns_json, list)
-            else []
+            else txns_json if isinstance(txns_json, list) else []
         )
 
         for txn in txns_list:

--- a/backend/app/utils/transaction_filtering.py
+++ b/backend/app/utils/transaction_filtering.py
@@ -1,7 +1,19 @@
-# backend/app/utils/transaction_filtering.py
+"""Utilities for filtering transaction lists.
+
+This module groups helper functions used to clean and normalize lists of
+transaction objects before further processing.  It can collapse matching
+transfer pairs into a single synthetic record and remove near-duplicate
+entries.
+"""
 
 
 def collapse_internal_transfers(transactions, date_epsilon=1, amount_epsilon=0.01):
+    """Merge pairs of offsetting transfer transactions.
+
+    Transactions whose amounts cancel out and fall within the provided
+    ``date_epsilon`` window are replaced with a synthetic transfer record.
+    """
+
     seen = set()
     collapsed = []
     by_amount = {}
@@ -35,12 +47,12 @@ def collapse_internal_transfers(transactions, date_epsilon=1, amount_epsilon=0.0
             collapsed.append(
                 {
                     "type": "transfer",
-                    "from_account": txn.account_id
-                    if txn.amount < 0
-                    else found.account_id,
-                    "to_account": txn.account_id
-                    if txn.amount > 0
-                    else found.account_id,
+                    "from_account": (
+                        txn.account_id if txn.amount < 0 else found.account_id
+                    ),
+                    "to_account": (
+                        txn.account_id if txn.amount > 0 else found.account_id
+                    ),
                     "amount": abs(txn.amount),
                     "date": min(txn.date, found.date),
                     "originals": [txn, found],
@@ -52,6 +64,12 @@ def collapse_internal_transfers(transactions, date_epsilon=1, amount_epsilon=0.0
 
 
 def deduplicate_transactions(transactions, amount_epsilon=0.01, date_epsilon=1):
+    """Remove near-duplicate transactions from ``transactions``.
+
+    Two records are considered duplicates when their amounts, dates and
+    descriptions match within the supplied tolerances.
+    """
+
     seen = set()
     deduped = []
     for i, txn in enumerate(transactions):

--- a/tests/test_internal_transfer_detection.py
+++ b/tests/test_internal_transfer_detection.py
@@ -77,11 +77,13 @@ app_pkg.extensions = extensions
 
 # Load models and account_logic modules
 spec_models = importlib.util.spec_from_file_location(
-    "app.models", os.path.join(BASE_BACKEND, "app", "models.py")
+    "app.models",
+    os.path.join(BASE_BACKEND, "app", "models", "__init__.py"),
+    submodule_search_locations=[os.path.join(BASE_BACKEND, "app", "models")],
 )
 models = importlib.util.module_from_spec(spec_models)
-spec_models.loader.exec_module(models)
 sys.modules["app.models"] = models
+spec_models.loader.exec_module(models)
 app_pkg.models = models
 
 spec_logic = importlib.util.spec_from_file_location(

--- a/tests/test_model_field_validation.py
+++ b/tests/test_model_field_validation.py
@@ -24,9 +24,14 @@ def _load_models():
     sys.modules["app"] = app_pkg
     sys.modules["app.extensions"] = extensions_stub
 
-    module_path = os.path.join(BASE_DIR, "app", "models.py")
-    spec = importlib.util.spec_from_file_location("app.models", module_path)
+    module_path = os.path.join(BASE_DIR, "app", "models", "__init__.py")
+    spec = importlib.util.spec_from_file_location(
+        "app.models",
+        module_path,
+        submodule_search_locations=[os.path.dirname(module_path)],
+    )
     models = importlib.util.module_from_spec(spec)
+    sys.modules["app.models"] = models
     spec.loader.exec_module(models)
     return models
 

--- a/tests/test_query_chroma.py
+++ b/tests/test_query_chroma.py
@@ -8,9 +8,15 @@ import runpy
 import sys
 from pathlib import Path
 
-import chromadb
 import pytest
-from chromadb.utils import embedding_functions
+
+try:  # pragma: no cover - dependency may not be installed
+    import chromadb
+    from chromadb.utils import embedding_functions
+except ModuleNotFoundError:  # pragma: no cover
+    chromadb = None
+    embedding_functions = None
+    pytest.skip("chromadb not installed", allow_module_level=True)
 
 
 class DummyEmbeddingFunction:


### PR DESCRIPTION
## Summary
- ensure accounts route creates log directory before writing
- document transaction filtering utilities and keep tests resilient to missing deps
- load backend models package correctly in tests

## Testing
- `black --check .`
- `pytest` *(fails: no such table: accounts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f2a93c488329b1982a3ce8c4ff85