### PR TITLE
test(lint): enforce flake8 on tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 # pytest.ini
 [pytest]
 pythonpath = backend
+addopts = --flake8
+flake8-max-line-length = 120
+flake8-ignore = E203,W503
 markers =
     integration: marks tests that require external services or integration dependencies (e.g. ChromaDB)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,12 @@
 black==25.1.0
 isort==5.10.1
 ruff==0.4.0
+flake8==7.3.0
 mypy==1.10.0
 pylint==3.1.0
 bandit==1.7.5
 pytest==8.4.0
+pytest-flake8==1.3.0
 pre-commit==4.1.0
 chromadb==1.0.12
 qdrant-client

--- a/tests/test_forecast_orchestrator.py
+++ b/tests/test_forecast_orchestrator.py
@@ -1,14 +1,16 @@
+"""Tests for the ForecastOrchestrator service."""
+
 import importlib.util
 import os
 import sys
 from datetime import datetime, timedelta
+import types
 
 import pytest
 
 BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
 sys.path.insert(0, BASE_BACKEND)
 sys.modules.pop("app", None)
-import types
 
 config_stub = types.ModuleType("app.config")
 config_stub.logger = types.SimpleNamespace(info=lambda *a, **k: None)

--- a/tests/test_forecast_route.py
+++ b/tests/test_forecast_route.py
@@ -6,6 +6,7 @@ import sys
 import types
 from datetime import datetime, timedelta
 
+from flask import Flask
 import pytest
 
 # ---- Paths and Imports ----
@@ -124,8 +125,6 @@ try:
     spec.loader.exec_module(forecast_module)
 except Exception:
     pytest.skip("forecast module import failed", allow_module_level=True)
-
-from flask import Flask
 
 # ---- Load forecast orchestrator for monkeypatching ----
 SERVICES_PATH = os.path.join(


### PR DESCRIPTION
## Summary
- run flake8 via pytest and limit to project style
- add flake8 and pytest-flake8 dev dependencies
- fix forecast tests to satisfy flake8 and add docstring

## Testing
- `flake8 tests --max-line-length 120 --ignore=E203,W503`
- `pytest tests/test_forecast_orchestrator.py tests/test_forecast_route.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a804ac4f7083298a1c6fd1d65fa61a