### PR TITLE
feat: extend Nightfox palette and tidy transactions layout

### DIFF
--- a/docs/frontend/THEMING_GUIDE.md
+++ b/docs/frontend/THEMING_GUIDE.md
@@ -68,6 +68,10 @@ all of them:
 | `--primary` / `--primary-dark` | generic button colors |
 | `--hover-bg` | hover background for buttons |
 | `--hover-glow` | drop shadow for hover effects |
+| `--color-success` / `--color-bg-success` | success states |
+| `--color-error` / `--color-bg-error` | error states |
+| `--color-warning` / `--color-bg-warning` | warning states |
+| `--color-info` / `--color-bg-info` | informational states |
 
 Additional variables such as `--color-accent-magenta`, `--color-accent-cyan`,
 `--bar-gradient-end`, `--asset-gradient-start`/`--asset-gradient-end`, and

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -51,6 +51,40 @@
     color: var(--color-bg-dark);
   }
 
+  .btn-primary {
+    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    background-color: var(--primary);
+    border-color: var(--primary);
+    color: var(--color-bg-dark);
+  }
+
+  .btn-primary:hover {
+    background-color: var(--primary-dark);
+    border-color: var(--primary-dark);
+  }
+
+  .btn-success {
+    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    background-color: var(--color-success);
+    border-color: var(--color-success);
+    color: var(--color-bg-dark);
+  }
+
+  .btn-success:hover {
+    filter: brightness(1.1);
+  }
+
+  .btn-alert {
+    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    background-color: var(--color-error);
+    border-color: var(--color-error);
+    color: var(--color-bg-dark);
+  }
+
+  .btn-alert:hover {
+    filter: brightness(1.1);
+  }
+
   .input {
     @apply w-full px-2 py-1 rounded border text-sm;
     background-color: var(--color-bg-dark);
@@ -112,5 +146,19 @@
     @apply text-center text-xl font-bold mb-3;
     color: var(--color-accent-cyan);
     text-shadow: 0 0 6px var(--color-accent-purple);
+  }
+
+  .success-badge,
+  .error-badge {
+    @apply font-semibold px-3 py-1 rounded;
+    color: var(--color-bg-dark);
+  }
+
+  .success-badge {
+    background-color: var(--color-bg-success);
+  }
+
+  .error-badge {
+    background-color: var(--color-bg-error);
   }
 }

--- a/frontend/src/components/ui/Button.vue
+++ b/frontend/src/components/ui/Button.vue
@@ -10,7 +10,7 @@ import { computed } from 'vue';
 const props = defineProps({
   variant: {
     type: String,
-    default: '', // 'outline', 'success', 'alert'
+    default: '', // 'outline', 'primary', 'success', 'alert'
   },
   pill: {
     type: Boolean,

--- a/frontend/src/styles/themes/nightfox.css
+++ b/frontend/src/styles/themes/nightfox.css
@@ -33,6 +33,15 @@
   --color-accent-purple-hover: #b093e6;
   --color-accent: var(--color-accent-cyan);
 
+  --color-success: var(--color-accent-green);
+  --color-bg-success: var(--color-accent-green);
+  --color-error: var(--color-accent-red);
+  --color-bg-error: var(--color-accent-red);
+  --color-warning: var(--color-accent-orange);
+  --color-bg-warning: var(--color-accent-orange);
+  --color-info: var(--color-accent-blue);
+  --color-bg-info: var(--color-accent-blue);
+
   --hover-bg: rgba(255, 255, 255, 0.05);
   --color-hover-light: rgba(255, 255, 255, 0.08);
   --hover-glow: 0 0 8px rgba(113, 156, 214, 0.6);

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="transactions-page container space-y-8">
+  <div class="transactions-page container py-8 space-y-8">
     <!-- Header -->
-    <Card class="p-6 flex items-center gap-3">
-      <CreditCard class="w-6 h-6" />
+    <Card class="p-6 flex items-center gap-4">
+      <CreditCard class="w-6 h-6 text-[var(--color-accent-cyan)]" />
       <div>
         <h1 class="text-2xl font-bold">Transactions</h1>
         <p class="text-muted">View and manage your transactions</p>
@@ -11,7 +11,7 @@
 
     <!-- Top Controls -->
     <Card class="p-6">
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <ImportFileSelector />
         <input v-model="searchQuery" type="text" placeholder="Search transactions..." class="input w-full" />
       </div>


### PR DESCRIPTION
## Summary
- add success, error, warning, and info colors to Nightfox theme
- provide matching button variants and badge utilities
- tweak Transactions view spacing and apply theme colors

## Testing
- `npm test` *(fails: Snapshot `Transactions.vue > matches snapshot 1` mismatched)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68a81068aea88329afb1c83c8773401b