### PR TITLE
feat: account balance history chart and API

### DIFF
--- a/ACCOUNTS_ROADMAP.md
+++ b/ACCOUNTS_ROADMAP.md
@@ -97,8 +97,10 @@ Replace placeholder chart with:
 
 ### 3.5 Cypress Tests
 - Visit `/accounts/:id`.
-- Assert chart renders and tooltip shows "Balance: $X".
-- Verify filter dropdown switches ranges.
+- Assert `[data-testid="history-chart"]` exists and tooltip shows
+  "Balance: $X".
+- Change `[data-testid="filter-dropdown"]` to a new range and verify
+  new data loads.
 
 ## 4. Documentation
 - Describe reverse-mapping algorithm and `/accounts/:id/history` endpoint.

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -454,31 +454,54 @@ def account_net_changes(account_id):
 # Endpoint to fetch account balance history
 @accounts.route("/<account_id>/history", methods=["GET"])
 def get_account_history(account_id):
-    """Return daily balance history for a given account."""
-    from app.models import AccountHistory
+    """Return reverse-mapped daily balance history for an account.
+
+    The calculation starts from the account's current balance and walks
+    backwards through transaction deltas to derive prior day balances.
+    A ``range`` query parameter like ``7d`` or ``30d`` limits how many
+    days are returned.
+    """
+    from datetime import timedelta
+    from app.models import Account, Transaction
+    from app.services.account_history import compute_balance_history
+    from sqlalchemy import func
 
     try:
-        # Optional date filters (ISO format)
-        start_date_str = request.args.get("start_date")
-        end_date_str = request.args.get("end_date")
-        query = AccountHistory.query.filter_by(account_id=account_id)
-        if start_date_str:
-            start_dt = datetime.fromisoformat(start_date_str)
-            query = query.filter(AccountHistory.date >= start_dt)
-        if end_date_str:
-            end_dt = datetime.fromisoformat(end_date_str)
-            query = query.filter(AccountHistory.date <= end_dt)
-        # Retrieve and sort records by date
-        records = query.order_by(AccountHistory.date.asc()).all()
-        history = [
-            {
-                "date": rec.date.isoformat(),
-                "balance": rec.balance,
-                "is_hidden": rec.is_hidden,
-            }
-            for rec in records
-        ]
-        return jsonify({"status": "success", "history": history}), 200
+        range_param = request.args.get("range", "30d")
+        days = int(range_param.rstrip("d")) if range_param.endswith("d") else 30
+
+        account = Account.query.filter_by(account_id=account_id).first()
+        if not account:
+            return jsonify({"error": "Account not found"}), 404
+
+        end_date = datetime.now(timezone.utc).date()
+        start_date = end_date - timedelta(days=days - 1)
+
+        tx_rows = (
+            db.session.query(func.date(Transaction.date), func.sum(Transaction.amount))
+            .filter(Transaction.account_id == account_id)
+            .filter(Transaction.date >= start_date)
+            .filter(Transaction.date <= end_date)
+            .group_by(func.date(Transaction.date))
+            .all()
+        )
+
+        txs = [{"date": row[0], "amount": float(row[1])} for row in tx_rows]
+
+        balances = compute_balance_history(
+            account.balance, txs, start_date, end_date
+        )
+
+        return (
+            jsonify(
+                {
+                    "accountId": account_id,
+                    "asOfDate": end_date.isoformat(),
+                    "balances": balances,
+                }
+            ),
+            200,
+        )
     except Exception as e:
         logger.error(f"Error in get_account_history: {e}", exc_info=True)
-        return jsonify({"status": "error", "message": str(e)}), 500
+        return jsonify({"error": str(e)}), 500

--- a/backend/app/services/account_history.py
+++ b/backend/app/services/account_history.py
@@ -1,0 +1,48 @@
+"""Utilities for computing account balance history via reverse mapping.
+
+This module exposes helper functions to reconstruct historical daily
+balances for an account given its current balance and a sequence of
+transactions. It is used by the `/api/accounts/<id>/history` endpoint.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import Iterable, List, Dict
+
+
+def compute_balance_history(
+    starting_balance: float,
+    transactions: Iterable[Dict[str, float]],
+    start_date: date,
+    end_date: date,
+) -> List[Dict[str, float]]:
+    """Reverse-map daily balances for an account.
+
+    Args:
+        starting_balance: Known balance on ``end_date``.
+        transactions: Iterable of transactions with ``date`` (``date``)
+            and ``amount`` (float) fields.
+        start_date: Earliest date to include, inclusive.
+        end_date: Latest date to include, inclusive. Represents the date
+            of ``starting_balance``.
+
+    Returns:
+        A list of ``{"date": str, "balance": float}`` dictionaries ordered
+        by ascending date covering every day in the range.
+    """
+    # Aggregate transaction deltas by date for quick lookup.
+    deltas = defaultdict(float)
+    for tx in transactions:
+        deltas[tx["date"]] += tx["amount"]
+
+    results: List[Dict[str, float]] = []
+    balance = starting_balance
+    current = end_date
+    while current >= start_date:
+        results.append({"date": current.isoformat(), "balance": round(balance, 2)})
+        balance -= deltas.get(current, 0.0)
+        current -= timedelta(days=1)
+
+    results.reverse()
+    return results

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -24,6 +24,7 @@ This document serves as the authoritative reference for API routing conventions,
 GET    /api/transactions/get_transactions
 GET    /api/accounts/get_accounts
 POST   /api/accounts/refresh_accounts
+GET    /api/accounts/<id>/history
 GET    /api/institutions
 POST   /api/institutions/<id>/refresh
 GET    /api/goals
@@ -50,6 +51,28 @@ Response body on success:
 
 ```json
 { "status": "success", "updated_accounts": ["name"], "refreshed_counts": { "Bank A": 2 } }
+```
+
+**GET /api/accounts/<id>/history**
+
+Returns daily balances for the specified account. Accepts an optional `range`
+query parameter such as `7d`, `30d`, `90d`, or `365d` to limit how many days
+are returned.
+
+**Query Parameters**
+
+- `range` – number of days of history to return (default: `30d`)
+
+**Response Body**
+
+```json
+{
+  "accountId": "uuid",
+  "asOfDate": "YYYY-MM-DD",
+  "balances": [
+    {"date": "YYYY-MM-DD", "balance": 1523.21}
+  ]
+}
 ```
 
 ### 🔹 Provider-Specific Resources

--- a/docs/COMPONENTS_MIGRATION.md
+++ b/docs/COMPONENTS_MIGRATION.md
@@ -38,6 +38,7 @@ frontend/src/components/
 │   └── NetYearComparisonChart.vue
 │   └── AccountsReorderChart.vue
 │   └── AssetsBarTrended.vue
+│   └── AccountBalanceHistoryChart.vue
 │
 ├── tables/              # Structured row/column UI
 │   └── AccountsTable.vue

--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -27,9 +27,10 @@ export const fetchRecentTransactions = async (accountId, limit = 10) => {
  * Fetch recent balance history for an account.
  *
  * @param {string} accountId
- * @param {object} params
+ * @param {string} [range='30d'] - Range of days (e.g. '7d', '30d').
  */
-export const fetchAccountHistory = async (accountId, params = {}) => {
+export const fetchAccountHistory = async (accountId, range = '30d') => {
+  const params = { range }
   const response = await axios.get(
     `/api/accounts/${accountId}/history`,
     { params }

--- a/tests/test_account_history_service.py
+++ b/tests/test_account_history_service.py
@@ -1,0 +1,37 @@
+import os
+import importlib.util
+from datetime import date
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+
+spec = importlib.util.spec_from_file_location(
+    "account_history", os.path.join(BASE_BACKEND, "app", "services", "account_history.py")
+)
+account_history = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(account_history)
+compute_balance_history = account_history.compute_balance_history
+
+
+def test_compute_balance_history_reverse_mapping():
+    txs = [
+        {"date": date(2025, 8, 2), "amount": 25.0},
+        {"date": date(2025, 8, 1), "amount": -50.0},
+    ]
+    start = date(2025, 8, 1)
+    end = date(2025, 8, 3)
+    result = compute_balance_history(100.0, txs, start, end)
+    assert result == [
+        {"date": "2025-08-01", "balance": 75.0},
+        {"date": "2025-08-02", "balance": 100.0},
+        {"date": "2025-08-03", "balance": 100.0},
+    ]
+
+
+def test_compute_balance_history_fills_gaps():
+    txs = []
+    start = date(2025, 1, 1)
+    end = date(2025, 1, 3)
+    result = compute_balance_history(10.0, txs, start, end)
+    assert len(result) == 3
+    assert result[0]["date"] == "2025-01-01"
+    assert result[-1]["balance"] == 10.0


### PR DESCRIPTION
## Summary
- add `/api/accounts/:id/history` with reverse-mapped balances
- expose balance history in UI with range dropdown and chart
- document new endpoint and component usage

## Testing
- `pytest tests/test_account_history_service.py`
- `npm --prefix frontend run test:unit` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a812280d0883299b42566830fe82e7