### PR TITLE
feat: account balance history chart and API

### DIFF
--- a/ACCOUNTS_ROADMAP.md
+++ b/ACCOUNTS_ROADMAP.md
@@ -97,8 +97,10 @@ Replace placeholder chart with:
 
 ### 3.5 Cypress Tests
 - Visit `/accounts/:id`.
-- Assert chart renders and tooltip shows "Balance: $X".
-- Verify filter dropdown switches ranges.
+- Assert `[data-testid="history-chart"]` exists and tooltip shows
+  "Balance: $X".
+- Change `[data-testid="filter-dropdown"]` to a new range and verify
+  new data loads.
 
 ## 4. Documentation
 - Describe reverse-mapping algorithm and `/accounts/:id/history` endpoint.

--- a/backend/app/services/account_history.py
+++ b/backend/app/services/account_history.py
@@ -1,0 +1,48 @@
+"""Utilities for computing account balance history via reverse mapping.
+
+This module exposes helper functions to reconstruct historical daily
+balances for an account given its current balance and a sequence of
+transactions. It is used by the `/api/accounts/<id>/history` endpoint.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import Iterable, List, Dict
+
+
+def compute_balance_history(
+    starting_balance: float,
+    transactions: Iterable[Dict[str, float]],
+    start_date: date,
+    end_date: date,
+) -> List[Dict[str, float]]:
+    """Reverse-map daily balances for an account.
+
+    Args:
+        starting_balance: Known balance on ``end_date``.
+        transactions: Iterable of transactions with ``date`` (``date``)
+            and ``amount`` (float) fields.
+        start_date: Earliest date to include, inclusive.
+        end_date: Latest date to include, inclusive. Represents the date
+            of ``starting_balance``.
+
+    Returns:
+        A list of ``{"date": str, "balance": float}`` dictionaries ordered
+        by ascending date covering every day in the range.
+    """
+    # Aggregate transaction deltas by date for quick lookup.
+    deltas = defaultdict(float)
+    for tx in transactions:
+        deltas[tx["date"]] += tx["amount"]
+
+    results: List[Dict[str, float]] = []
+    balance = starting_balance
+    current = end_date
+    while current >= start_date:
+        results.append({"date": current.isoformat(), "balance": round(balance, 2)})
+        balance -= deltas.get(current, 0.0)
+        current -= timedelta(days=1)
+
+    results.reverse()
+    return results

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -24,6 +24,7 @@ This document serves as the authoritative reference for API routing conventions,
 GET    /api/transactions/get_transactions
 GET    /api/accounts/get_accounts
 POST   /api/accounts/refresh_accounts
+GET    /api/accounts/<id>/history
 GET    /api/institutions
 POST   /api/institutions/<id>/refresh
 GET    /api/goals
@@ -50,6 +51,29 @@ Response body on success:
 
 ```json
 { "status": "success", "updated_accounts": ["name"], "refreshed_counts": { "Bank A": 2 } }
+```
+
+**GET /api/accounts/<id>/history**
+
+Returns daily balances for the specified account. The `<id>` segment accepts
+either the external `account_id` or the numeric primary key. An optional `range`
+query parameter such as `7d`, `30d`, `90d`, or `365d` limits how many days are
+returned.
+
+**Query Parameters**
+
+- `range` – number of days of history to return (default: `30d`)
+
+**Response Body**
+
+```json
+{
+  "accountId": "uuid",
+  "asOfDate": "YYYY-MM-DD",
+  "balances": [
+    {"date": "YYYY-MM-DD", "balance": 1523.21}
+  ]
+}
 ```
 
 ### 🔹 Provider-Specific Resources

--- a/docs/COMPONENTS_MIGRATION.md
+++ b/docs/COMPONENTS_MIGRATION.md
@@ -38,6 +38,7 @@ frontend/src/components/
 │   └── NetYearComparisonChart.vue
 │   └── AccountsReorderChart.vue
 │   └── AssetsBarTrended.vue
+│   └── AccountBalanceHistoryChart.vue
 │
 ├── tables/              # Structured row/column UI
 │   └── AccountsTable.vue

--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -27,9 +27,10 @@ export const fetchRecentTransactions = async (accountId, limit = 10) => {
  * Fetch recent balance history for an account.
  *
  * @param {string} accountId
- * @param {object} params
+ * @param {string} [range='30d'] - Range of days (e.g. '7d', '30d').
  */
-export const fetchAccountHistory = async (accountId, params = {}) => {
+export const fetchAccountHistory = async (accountId, range = '30d') => {
+  const params = { range }
   const response = await axios.get(
     `/api/accounts/${accountId}/history`,
     { params }

--- a/tests/test_account_history_service.py
+++ b/tests/test_account_history_service.py
@@ -1,0 +1,37 @@
+import os
+import importlib.util
+from datetime import date
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+
+spec = importlib.util.spec_from_file_location(
+    "account_history", os.path.join(BASE_BACKEND, "app", "services", "account_history.py")
+)
+account_history = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(account_history)
+compute_balance_history = account_history.compute_balance_history
+
+
+def test_compute_balance_history_reverse_mapping():
+    txs = [
+        {"date": date(2025, 8, 2), "amount": 25.0},
+        {"date": date(2025, 8, 1), "amount": -50.0},
+    ]
+    start = date(2025, 8, 1)
+    end = date(2025, 8, 3)
+    result = compute_balance_history(100.0, txs, start, end)
+    assert result == [
+        {"date": "2025-08-01", "balance": 75.0},
+        {"date": "2025-08-02", "balance": 100.0},
+        {"date": "2025-08-03", "balance": 100.0},
+    ]
+
+
+def test_compute_balance_history_fills_gaps():
+    txs = []
+    start = date(2025, 1, 1)
+    end = date(2025, 1, 3)
+    result = compute_balance_history(10.0, txs, start, end)
+    assert len(result) == 3
+    assert result[0]["date"] == "2025-01-01"
+    assert result[-1]["balance"] == 10.0

--- a/tests/test_api_account_history.py
+++ b/tests/test_api_account_history.py
@@ -1,0 +1,141 @@
+import importlib.util
+import os
+import sys
+import types
+from datetime import date
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+sys.modules["flask_cors"] = types.SimpleNamespace(CORS=lambda app: app)
+sys.modules["flask_migrate"] = types.SimpleNamespace(Migrate=lambda *a, **k: None)
+
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+config_stub.FLASK_ENV = "test"
+config_stub.plaid_client = None
+sys.modules["app.config"] = config_stub
+
+env_stub = types.ModuleType("app.config.environment")
+env_stub.TELLER_WEBHOOK_SECRET = ""
+sys.modules["app.config.environment"] = env_stub
+
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace(session=None)
+sys.modules["app.extensions"] = extensions_stub
+
+models_stub = types.ModuleType("app.models")
+models_stub.Account = type("Account", (), {})
+
+
+class _Col:
+    def __init__(self, name):
+        self.name = name
+
+    def __ge__(self, other):
+        return True
+
+    def __le__(self, other):
+        return True
+
+    def __eq__(self, other):
+        return True
+
+
+models_stub.Transaction = type(
+    "Transaction",
+    (),
+    {"date": _Col("date"), "amount": _Col("amount"), "account_id": _Col("account_id")},
+)
+models_stub.RecurringTransaction = type("RecurringTransaction", (), {})
+models_stub.AccountHistory = type("AccountHistory", (), {})
+sys.modules["app.models"] = models_stub
+
+sql_pkg = types.ModuleType("app.sql")
+forecast_stub = types.ModuleType("app.sql.forecast_logic")
+forecast_stub.update_account_history = lambda *a, **k: None
+sys.modules["app.sql"] = sql_pkg
+sys.modules["app.sql.forecast_logic"] = forecast_stub
+
+services_pkg = types.ModuleType("app.services")
+history_stub = types.ModuleType("app.services.account_history")
+history_stub.compute_balance_history = (
+    lambda *a, **k: [{"date": "2024-01-01", "balance": 100.0}]
+)
+sys.modules["app.services"] = services_pkg
+sys.modules["app.services.account_history"] = history_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "accounts.py")
+spec = importlib.util.spec_from_file_location("app.routes.accounts", ROUTE_PATH)
+accounts_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(accounts_module)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Stub Account.query to handle account_id or id lookups
+    mock_account = types.SimpleNamespace(account_id="acc1", id=1, balance=100.0)
+
+    def filter_by(**kwargs):
+        if kwargs.get("account_id") == "acc1":
+            return types.SimpleNamespace(first=lambda: mock_account)
+        if kwargs.get("id") == 1:
+            return types.SimpleNamespace(first=lambda: mock_account)
+        return types.SimpleNamespace(first=lambda: None)
+
+    monkeypatch.setattr(
+        accounts_module.Account,
+        "query",
+        types.SimpleNamespace(filter_by=filter_by),
+        raising=False,
+    )
+
+    # Stub db.session.query chain
+    class TxQuery:
+        def filter(self, *a, **k):
+            return self
+
+        def group_by(self, *a, **k):
+            return self
+
+        def all(self):
+            return [(date(2024, 1, 1), 0.0)]
+
+    monkeypatch.setattr(
+        accounts_module.db,
+        "session",
+        types.SimpleNamespace(query=lambda *a, **k: TxQuery()),
+    )
+
+    # Stub sqlalchemy func
+    sqlalchemy_stub = types.SimpleNamespace(func=types.SimpleNamespace(date=lambda x: x, sum=lambda x: x))
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy_stub)
+
+    app = Flask(__name__)
+    app.register_blueprint(accounts_module.accounts, url_prefix="/api/accounts")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_history_accepts_numeric_id(client):
+    resp = client.get("/api/accounts/1/history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["accountId"] == "acc1"
+    assert data["balances"][0]["balance"] == 100.0
+
+
+def test_history_accepts_account_id(client):
+    resp = client.get("/api/accounts/acc1/history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["accountId"] == "acc1"


### PR DESCRIPTION
## Summary
- add `/api/accounts/:id/history` with reverse-mapped balances
- expose balance history in UI with range dropdown and chart
- document new endpoint and component usage
- allow numeric `id` in history endpoint and document behavior

## Testing
- `pytest tests/test_account_history_service.py tests/test_api_account_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68a812280d0883299b42566830fe82e7