### PR TITLE
feat(planning): scaffold view and route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ This document consolidates previous agent instructions into the authoritative ro
 - [x] `frontend/src/types/planning.ts`
 - [x] `frontend/src/services/planningService.ts` (local persistence)
 - [x] `frontend/src/composables/usePlanning.ts`
-- [ ] `frontend/src/views/Planning.vue` with `/planning` route and sidebar link
-- [ ] `frontend/src/components/planning/` (`BillForm.vue`, `BillList.vue`, `Allocator.vue`, `PlanningSummary.vue`)
+ - [x] `frontend/src/views/Planning.vue` with `/planning` route and sidebar link
+ - [ ] `frontend/src/components/planning/` (`BillForm.vue`, `BillList.vue`, `Allocator.vue`, `PlanningSummary.vue`)
 - [ ] Replace `frontend/src/utils/currency.ts` with conversion helpers
 - [ ] Extend `frontend/src/services/planningService.ts` with list/get/put helpers for future API mode
 - [ ] Cypress component tests at `frontend/src/views/__tests__/Planning.cy.js`

--- a/PLANNING_ROADMAP.md
+++ b/PLANNING_ROADMAP.md
@@ -1,0 +1,22 @@
+# 🧮 Roadmap: Planning Module
+
+## 1. Current Status
+- Types, service, and composable implemented.
+- View scaffolded with route and navigation link.
+
+## 2. Frontend
+### 2.1 Upcoming Components
+- `frontend/src/components/planning/` (`BillForm.vue`, `BillList.vue`, `Allocator.vue`, `PlanningSummary.vue`)
+- Replace `frontend/src/utils/currency.ts` with conversion helpers
+- Extend `frontend/src/services/planningService.ts` with list/get/put helpers for future API mode
+- Cypress component tests at `frontend/src/views/__tests__/Planning.cy.js`
+
+## 3. Backend
+- Require login and scope data to `current_user`
+- `tests/test_api_planning.py` for scenario CRUD, percent-cap enforcement, and user isolation
+
+## 4. Next Steps
+1. Implement bill management components and integrate into Planning view.
+2. Add currency conversion utilities and API-ready service helpers.
+3. Enforce authentication in planning routes and add backend tests.
+4. Create Cypress component tests for the Planning view.

--- a/frontend/src/components/layout/Navbar.vue
+++ b/frontend/src/components/layout/Navbar.vue
@@ -6,12 +6,16 @@
       <router-link to="/accounts" class="nav-link">Accounts</router-link>
       <router-link to="/transactions" class="nav-link">Transactions</router-link>
       <router-link to="/forecast" class="nav-link">Forecasting</router-link>
+      <router-link to="/planning" class="nav-link">Planning</router-link>
       <router-link to="/recurring-transactions" class="nav-link">Recurring Tx</router-link>
     </div>
   </nav>
 </template>
 
 <script>
+/**
+ * Primary navigation bar with links to top-level routes.
+ */
 export default {
   name: 'Navbar',
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,17 +1,21 @@
+// frontend/src/router/index.js
+// Centralized application route definitions.
+
 import { createRouter, createWebHistory } from 'vue-router'
 import Dashboard from '../views/Dashboard.vue'
 import Accounts from '../views/Accounts.vue'
 import Transactions from '../views/Transactions.vue'
 import RecurringTX from '../views/RecurringTX.vue'
-import Forecast from '@/views/Forecast.vue';
-import Investments from '../views/Investments.vue';
-import Institutions from '../views/Institutions.vue';
-import DailyNetChart from '@/components/charts/DailyNetChart.vue';
-import CategoryBreakdownChart from '@/components/charts/CategoryBreakdownChart.vue';
-import NetYearComparisonChart from '@/components/charts/NetYearComparisonChart.vue';
-import AccountsTable from '@/components/tables/AccountsTable.vue';
-import ForecastMock from '@/views/ForecastMock.vue';
-import RecurringScanDemo from '@/views/RecurringScanDemo.vue';
+import Forecast from '@/views/Forecast.vue'
+import Planning from '@/views/Planning.vue'
+import Investments from '../views/Investments.vue'
+import Institutions from '../views/Institutions.vue'
+import DailyNetChart from '@/components/charts/DailyNetChart.vue'
+import CategoryBreakdownChart from '@/components/charts/CategoryBreakdownChart.vue'
+import NetYearComparisonChart from '@/components/charts/NetYearComparisonChart.vue'
+import AccountsTable from '@/components/tables/AccountsTable.vue'
+import ForecastMock from '@/views/ForecastMock.vue'
+import RecurringScanDemo from '@/views/RecurringScanDemo.vue'
 
 
 const routes = [
@@ -19,6 +23,7 @@ const routes = [
   { path: '/accounts', name: 'Accounts', component: Accounts },
   { path: '/transactions', name: 'Transactions', component: Transactions },
   { path: '/forecast', name: 'Forecast', component: Forecast },
+  { path: '/planning', name: 'Planning', component: Planning },
   { path: '/charts/cashflow', name: 'DailyNetChart', component: DailyNetChart },
   { path: '/charts/category', name: 'CategoryChart', component: CategoryBreakdownChart },
   {

--- a/frontend/src/views/Planning.vue
+++ b/frontend/src/views/Planning.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="planning-view">
+    <h1 class="text-2xl font-bold mb-4">Planning</h1>
+    <pre>{{ JSON.stringify(state, null, 2) }}</pre>
+  </div>
+</template>
+
+<script setup>
+import { usePlanning } from '@/composables/usePlanning'
+
+/**
+ * Top-level view for budgeting and allocation planning.
+ * Currently displays the raw planning state as a scaffold.
+ */
+const { state } = usePlanning()
+</script>
+
+<style scoped>
+@reference "../assets/css/main.css";
+.planning-view {
+  background-color: var(--page-bg);
+  color: var(--theme-fg);
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Planning view and link in router and navbar
- document roadmap progress for planning module

## Testing
- `npm test` (fails: Snapshot tests mismatch)
- `npm run lint` (fails: no-unused-vars in Accounts.vue)
- `pre-commit run --files AGENTS.md PLANNING_ROADMAP.md frontend/src/components/layout/Navbar.vue frontend/src/router/index.js frontend/src/views/Planning.vue` (fails: pytest missing plugin --flake8)

------
https://chatgpt.com/codex/tasks/task_e_68a85915edc083298274735712f9aafe