### PR TITLE
feat: dynamic spectrum styling for TopAccounts widget

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -20,7 +20,7 @@
         <div
           class="flex-1 min-w-[340px] max-w-[400px] bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col justify-between">
           <h2 class="text-2xl font-bold mb-4 text-[var(--color-accent-cyan)] text-center">Top Accounts</h2>
-          <TopAccountSnapshot />
+          <TopAccountSnapshot use-spectrum />
         </div>
         <!-- Net Income Summary Card -->
         <div


### PR DESCRIPTION
## Summary
- add spectrum-based accentColor function for TopAccountSnapshot
- enable dynamic styling via new `use-spectrum` prop in Dashboard

## Testing
- `npx eslint src/views/Dashboard.vue src/components/widgets/TopAccountSnapshot.vue --fix`
- `npm test` *(fails: snapshot mismatch and network error)*
- `pre-commit run --files frontend/src/components/widgets/TopAccountSnapshot.vue frontend/src/views/Dashboard.vue` *(fails: model-field-validation hook)*

------
https://chatgpt.com/codex/tasks/task_e_68a867f86c3483299d869fd791bbb9ab