### PR TITLE
fix: filter category modal by selected categories

### DIFF
--- a/frontend/src/components/charts/CategoryBreakdownChart.vue
+++ b/frontend/src/components/charts/CategoryBreakdownChart.vue
@@ -133,7 +133,10 @@ async function renderChart() {
           const index = points[0].index
           const label = chartInstance.value.data.labels[index]
           const node = categoryTree.value.find((cat) => cat.label === label)
-          const ids = (node?.children || []).map((c) => c.id)
+          // Only emit IDs for categories currently selected by the user
+          const ids = (node?.children || [])
+            .filter((c) => props.selectedCategoryIds.includes(c.id))
+            .map((c) => c.id)
           emit('bar-click', { label, ids })
         }
       },

--- a/frontend/src/components/charts/__tests__/CategoryBreakdownChart.spec.js
+++ b/frontend/src/components/charts/__tests__/CategoryBreakdownChart.spec.js
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import CategoryBreakdownChart from '../CategoryBreakdownChart.vue'
+
+// Stub canvas context
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}))
+
+// Capture onClick handler from chart config
+let clickHandler
+const mockChartInstance = {
+  destroy: vi.fn(),
+  getElementsAtEventForMode: vi.fn().mockReturnValue([{ index: 0 }]),
+  data: {},
+}
+
+vi.mock('chart.js/auto', () => {
+  const Chart = vi.fn().mockImplementation((ctx, cfg) => {
+    clickHandler = cfg.options.onClick
+    mockChartInstance.data = cfg.data
+    return mockChartInstance
+  })
+  Chart.getChart = vi.fn().mockReturnValue(null)
+  return { Chart }
+})
+
+vi.mock('@/api/charts', () => ({
+  fetchCategoryBreakdownTree: vi.fn().mockResolvedValue({
+    status: 'success',
+    data: [
+      {
+        id: 'p1',
+        label: 'Parent',
+        amount: 100,
+        children: [
+          { id: 'c1', label: 'Child 1', amount: 60 },
+          { id: 'c2', label: 'Child 2', amount: 40 },
+        ],
+      },
+    ],
+  }),
+}))
+
+describe('CategoryBreakdownChart.vue', () => {
+  it('emits only selected category IDs on bar click', async () => {
+    const wrapper = shallowMount(CategoryBreakdownChart, {
+      props: {
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        selectedCategoryIds: ['c1'],
+        groupOthers: false,
+      },
+    })
+
+    await flushPromises()
+
+    // Simulate chart click
+    clickHandler(new Event('click'))
+
+    const emitted = wrapper.emitted('bar-click')
+    expect(emitted).toBeTruthy()
+    expect(emitted[0][0]).toEqual({ label: 'Parent', ids: ['c1'] })
+  })
+})


### PR DESCRIPTION
## Summary
- ensure CategoryBreakdownChart emits only selected category ids for modal filtering
- add unit test verifying bar-click payload respects selected categories

## Testing
- `npm test` *(fails: snapshot mismatches in Accounts.spec.js and Transactions.spec.js)*
- `npm run lint` *(fails: no-unused-vars in src/views/Accounts.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d67f8b08329bc391b5541ff4863