### PR TITLE
feat(dashboard): show above-average day counts

### DIFF
--- a/frontend/src/components/statistics/DailyNetStatistics.vue
+++ b/frontend/src/components/statistics/DailyNetStatistics.vue
@@ -84,6 +84,19 @@
               <span class="stat-value">{{ volatilityLabel }}</span>
             </div>
           </div>
+
+          <!-- Above Average Days -->
+          <div class="stat-group">
+            <h4 class="group-title">Above Avg Days</h4>
+            <div class="stat-item">
+              <span class="stat-label">Income:</span>
+              <span class="stat-value">{{ summary.aboveAvgIncomeDays }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Expenses:</span>
+              <span class="stat-value">{{ summary.aboveAvgExpenseDays }}</span>
+            </div>
+          </div>
         </div>
       </div>
     </Transition>
@@ -97,7 +110,13 @@ import { formatAmount } from '@/utils/format'
 const props = defineProps({
   summary: {
     type: Object,
-    default: () => ({ totalIncome: 0, totalExpenses: 0, totalNet: 0 }),
+    default: () => ({
+      totalIncome: 0,
+      totalExpenses: 0,
+      totalNet: 0,
+      aboveAvgIncomeDays: 0,
+      aboveAvgExpenseDays: 0,
+    }),
   },
   chartData: {
     type: Array,

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -213,7 +213,13 @@ onMounted(async () => {
 })
 
 /** --- DAILY NET STATE --- */
-const netSummary = ref({ totalIncome: 0, totalExpenses: 0, totalNet: 0 })
+const netSummary = ref({
+  totalIncome: 0,
+  totalExpenses: 0,
+  totalNet: 0,
+  aboveAvgIncomeDays: 0,
+  aboveAvgExpenseDays: 0,
+})
 const chartData = ref([])
 const zoomedOut = ref(false)
 


### PR DESCRIPTION
## Summary
- display how many days beat average income or expenses directly on the DailyNetChart
- surface above-average day counts in dashboard's extended financial summary

## Testing
- `npm run lint`
- `npm test` *(fails: missing vue-router mock and snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a88db69fb88329b685f57f148a3544