### PR TITLE
feat: enhance dashboard transaction modals

### DIFF
--- a/frontend/src/components/modals/TransactionModal.vue
+++ b/frontend/src/components/modals/TransactionModal.vue
@@ -3,21 +3,23 @@
     <div v-if="show" class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur px-4 py-6"
       @click.self="emitClose" @keyup.esc="emitClose" tabindex="0">
       <div
-        class="relative w-full max-w-3xl mx-auto rounded-2xl shadow-2xl bg-gradient-to-br from-[var(--color-accent-purple)]/70 via-[var(--color-bg-dark)]/90 to-[var(--color-accent-blue)]/90 border-2 border-[var(--color-accent-purple)]/40 animate-fadeInUp flex flex-col"
+        class="relative w-full max-w-3xl mx-auto p-4 rounded-2xl shadow-2xl bg-gradient-to-br from-[var(--color-accent-purple)]/70 via-[var(--color-bg-dark)]/90 to-[var(--color-accent-blue)]/90 border-2 border-[var(--color-accent-purple)]/60 animate-fadeInUp flex flex-col"
         role="dialog" aria-modal="true" aria-label="Transactions Modal" style="min-height: 220px">
         <!-- Header -->
         <div
-          class="flex items-center justify-between px-2 py-8 bg-gradient-to-r from-[var(--color-accent-purple)]/70 via-[var(--color-bg-dark)]/70 to-[var(--color-accent-blue)]/70 border-b-2 border-[var(--color-accent-purple)]/40 shadow-lg backdrop-blur-xl">
-          <h2 class="flex items-center gap-2 text-xl font-black text-[var(--color-text-light)] uppercase tracking-wider drop-shadow-sm">
-            <svg class="w-7 h-7 text-[var(--color-accent-purple)]" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <circle cx="12" cy="12" r="10" stroke-opacity="0.7" />
-              <path d="M7 12h10M12 7v10" stroke-linecap="round" />
-            </svg>
-            Transactions
-            <span v-if="subtitle" class="ml-2 text-[var(--color-accent-purple)] text-base font-medium normal-case drop-shadow-none">
-              ({{ subtitle }})
-            </span>
-          </h2>
+          class="relative flex items-start justify-between px-2 py-8 bg-gradient-to-r from-[var(--color-accent-purple)]/70 via-[var(--color-bg-dark)]/70 to-[var(--color-accent-blue)]/70 border-b-2 border-[var(--color-accent-purple)]/40 shadow-lg backdrop-blur-xl">
+          <div class="flex flex-col">
+            <h2 class="flex items-center gap-2 text-xl font-black text-[var(--color-text-light)] uppercase tracking-wider drop-shadow-sm">
+              <svg class="w-7 h-7 text-[var(--color-accent-purple)]" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <circle cx="12" cy="12" r="10" stroke-opacity="0.7" />
+                <path d="M7 12h10M12 7v10" stroke-linecap="round" />
+              </svg>
+              Transactions
+            </h2>
+            <p v-if="subtitle" class="mt-2 text-lg font-semibold text-[var(--color-accent-purple)] drop-shadow-none">
+              {{ subtitle }}
+            </p>
+          </div>
           <button
             class="absolute top-4 right-4 rounded-full hover:bg-[var(--color-accent-purple)]/80 active:bg-[var(--color-accent-purple)]/90 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent-purple)] transition group"
             @click="emitClose" aria-label="Close Transactions Modal">
@@ -53,7 +55,7 @@
           </div>
         </div>
         <!-- END SUMMARY BAR -->
-        <div class="flex-1 p-6 overflow-y-auto max-h-[65vh]">
+        <div class="flex-1 p-8 overflow-y-auto max-h-[65vh]">
           <ModalTransactionsDisplay :transactions="transactions" />
         </div>
       </div>
@@ -67,7 +69,7 @@ import { onMounted, nextTick, computed } from 'vue'
 import ModalTransactionsDisplay from '../tables/ModalTransactionsDisplay.vue'
 import { formatAmount } from "@/utils/format"
 
-// Modal dialog displaying a list of transactions with a summary bar and optional subtitle.
+// Modal dialog displaying a list of transactions with a summary bar and optional prominently displayed subtitle.
 
 const props = defineProps({
   show: { type: Boolean, default: false },

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -304,10 +304,12 @@ async function loadCategoryGroups() {
   }
 }
 
+// Handle clicks on the DailyNetChart bars and open a modal for that date.
 async function onNetBarClick(label) {
   const result = await fetchTransactions({ start_date: label, end_date: label })
   modalTransactions.value = result.transactions || []
-  modalSubtitle.value = `Net total for ${label}`
+  // Show the selected date prominently in the modal header
+  modalSubtitle.value = label
   showModal.value = true
 }
 
@@ -315,7 +317,8 @@ async function onNetBarClick(label) {
  * Handle clicks on the category breakdown chart.
  *
  * Fetches transactions for the clicked category within the active
- * date range and displays them in a modal dialog.
+ * date range and displays them in a modal dialog. If the clicked bar
+ * does not correspond to any user-selected categories, no modal is shown.
  *
  * @param {object|string} payload - Click payload from the chart containing
  *   the bar label and an array of category IDs.
@@ -323,6 +326,9 @@ async function onNetBarClick(label) {
 async function onCategoryBarClick(payload) {
   const { label, ids = [] } =
     typeof payload === 'object' ? payload : { label: payload, ids: [] }
+
+  // Only display the modal when the clicked bar corresponds to selected categories
+  if (!ids.length) return
 
   // Determine the date range in effect for the category chart. The chart emits
   // `summary-change` events that populate `catSummary` with the actual start


### PR DESCRIPTION
## Summary
- highlight transaction modal subtitle with extra padding and border
- emphasize date for DailyNetChart modal
- open category modal only when clicking selected categories

## Testing
- `npx eslint src/components/modals/TransactionModal.vue src/views/Dashboard.vue`
- `npm test` (fails: No "useRouter" export is defined, snapshot mismatch)

------
https://chatgpt.com/codex/tasks/task_e_68a9056f21148329a5f4e6705f957a48