### PR TITLE
feat(accounts): enable editable transactions with date validation

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -19,8 +19,12 @@ transactions = Blueprint("transactions", __name__)
 
 @transactions.route("/update", methods=["PUT"])
 def update_transaction():
-    """
-    Update a transaction's editable details.
+    """Update mutable fields on a transaction.
+
+    Allowed fields include ``amount``, ``date`` (``YYYY-MM-DD``), ``description``,
+    ``category``, ``merchant_name``, ``merchant_type``, and ``is_internal``.
+    The date value is validated and converted to a :class:`datetime.date` object
+    to ensure proper typing in the database.
     """
     try:
         data = request.json
@@ -40,7 +44,13 @@ def update_transaction():
             txn.amount = float(data["amount"])
             changed_fields["amount"] = True
         if "date" in data:
-            txn.date = data["date"]
+            try:
+                txn.date = datetime.strptime(data["date"], "%Y-%m-%d").date()
+            except (TypeError, ValueError):
+                return (
+                    jsonify({"status": "error", "message": "Invalid date format"}),
+                    400,
+                )
             changed_fields["date"] = True
         if "description" in data:
             txn.description = data["description"]
@@ -97,8 +107,11 @@ def update_transaction():
 
 @transactions.route("/user_modify/update")
 def user_modified_update_transaction():
-    """
-    Update a transaction's editable details.
+    """Update mutable fields on a transaction via user modification.
+
+    This endpoint mirrors :func:`update_transaction` but is intended for
+    direct user adjustments. Date strings are validated and parsed to
+    ``datetime.date`` objects before persistence.
     """
     try:
         data = request.json
@@ -118,7 +131,13 @@ def user_modified_update_transaction():
             txn.amount = float(data["amount"])
             changed_fields["amount"] = True
         if "date" in data:
-            txn.date = data["date"]
+            try:
+                txn.date = datetime.strptime(data["date"], "%Y-%m-%d").date()
+            except (TypeError, ValueError):
+                return (
+                    jsonify({"status": "error", "message": "Invalid date format"}),
+                    400,
+                )
             changed_fields["date"] = True
         if "description" in data:
             txn.description = data["description"]

--- a/frontend/src/components/tables/UpdateTransactionsTable.vue
+++ b/frontend/src/components/tables/UpdateTransactionsTable.vue
@@ -113,6 +113,11 @@
 </template>
 
 <script setup>
+/**
+ * Editable transactions table used on the accounts page. Users may adjust the
+ * ``date``, ``amount``, ``description``, ``category``, and ``merchant_name``
+ * fields while account identifiers remain locked.
+ */
 import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
 import { updateTransaction } from '@/api/transactions'
@@ -161,6 +166,10 @@ function cancelEdit() {
 
 async function saveEdit(tx) {
   try {
+    if (editBuffer.value.date && isNaN(Date.parse(editBuffer.value.date))) {
+      toast.error('Invalid date')
+      return
+    }
     await updateTransaction({
       transaction_id: tx.transaction_id,
       ...editBuffer.value,

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -61,12 +61,15 @@
       <AccountBalanceHistoryChart v-else :balances="accountHistory" data-testid="history-chart" />
     </Card>
 
-    <!-- Recent Transactions -->
+    <!-- Recent Transactions with editing capability -->
     <Card class="p-6 space-y-4">
       <h2 class="text-xl font-semibold">Recent Transactions</h2>
       <div v-if="loadingTransactions" class="text-center py-4 text-muted">Loading...</div>
       <div v-else-if="transactionsError" class="text-center py-4 text-error">Failed to load transactions</div>
-      <TransactionsTable v-else :transactions="recentTransactions" />
+      <UpdateTransactionsTable
+        v-else
+        :transactions="recentTransactions"
+      />
     </Card>
 
     <!-- Charts -->
@@ -102,6 +105,13 @@
 </template>
 
 <script setup>
+/*
+ * Accounts dashboard for managing linked or external accounts. This view also
+ * exposes an editable table for recent transactions where date, amount,
+ * description, category, and merchant name can be adjusted. Account and
+ * institution identifiers remain read-only.
+ */
+
 // Dependencies and 3rd party
 import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -120,7 +130,7 @@ import TogglePanel from '@/components/ui/TogglePanel.vue'
 import LinkAccount from '@/components/forms/LinkAccount.vue'
 import InstitutionTable from '@/components/tables/InstitutionTable.vue'
 import TokenUpload from '@/components/forms/TokenUpload.vue'
-import TransactionsTable from '@/components/tables/TransactionsTable.vue'
+import UpdateTransactionsTable from '@/components/tables/UpdateTransactionsTable.vue'
 
 // Chart Components
 import NetYearComparisonChart from '@/components/charts/NetYearComparisonChart.vue'

--- a/tests/test_api_transaction_update.py
+++ b/tests/test_api_transaction_update.py
@@ -1,0 +1,99 @@
+"""Tests for the transaction update endpoint."""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import date
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+# Config stub with silent logger
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+sys.modules["app.config"] = config_stub
+
+# Extensions stub
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace(
+    session=types.SimpleNamespace(commit=lambda: None)
+)
+sys.modules["app.extensions"] = extensions_stub
+
+# Stub transaction object and query
+_txn = types.SimpleNamespace(
+    transaction_id="t1",
+    amount=0,
+    date=None,
+    description="",
+    category="",
+    merchant_name="",
+    merchant_type="",
+    is_internal=False,
+    internal_match_id=None,
+    user_modified=False,
+    user_modified_fields=None,
+    user_id=1,
+    category_id=None,
+)
+
+
+def _filter_by(transaction_id):
+    class _Result:
+        def first(self_inner):
+            return _txn if transaction_id == _txn.transaction_id else None
+
+    return _Result()
+
+
+models_stub = types.ModuleType("app.models")
+models_stub.Transaction = types.SimpleNamespace(
+    query=types.SimpleNamespace(filter_by=_filter_by)
+)
+models_stub.Account = type("Account", (), {})
+sys.modules["app.models"] = models_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "transactions.py")
+spec = importlib.util.spec_from_file_location("app.routes.transactions", ROUTE_PATH)
+transactions_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transactions_module)
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(
+        transactions_module.transactions, url_prefix="/api/transactions"
+    )
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_update_transaction_valid_date(client):
+    resp = client.put(
+        "/api/transactions/update",
+        json={"transaction_id": "t1", "date": "2024-01-02"},
+    )
+    assert resp.status_code == 200
+    assert _txn.date == date(2024, 1, 2)
+
+
+def test_update_transaction_invalid_date(client):
+    resp = client.put(
+        "/api/transactions/update",
+        json={"transaction_id": "t1", "date": "bad"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["status"] == "error"


### PR DESCRIPTION
## Summary
- allow editing recent transactions on Accounts page
- validate transaction dates on frontend and backend
- add tests for transaction date validation

## Testing
- `pytest tests/test_api_transactions.py tests/test_api_transaction_update.py -q`
- `pre-commit run black --files backend/app/routes/transactions.py tests/test_api_transaction_update.py`
- `pre-commit run isort --files backend/app/routes/transactions.py tests/test_api_transaction_update.py`
- `pre-commit run ruff --files backend/app/routes/transactions.py tests/test_api_transaction_update.py`
- `pre-commit run mypy --files backend/app/routes/transactions.py tests/test_api_transaction_update.py` (fails: missing type stubs and module attributes)
- `pre-commit run pylint --files backend/app/routes/transactions.py tests/test_api_transaction_update.py` (fails: missing imports and style warnings)
- `pre-commit run bandit --files backend/app/routes/transactions.py tests/test_api_transaction_update.py` (fails: requests without timeout, assert usage)


------
https://chatgpt.com/codex/tasks/task_e_68a92326e6d0832988dbf9dcd3e0eba4