### PR TITLE
feat: unify page headers with reusable layout

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen flex flex-col">
+  <div class="min-h-screen flex flex-col" style="background-color: var(--page-bg); color: var(--theme-fg);">
     <header class="glass border-b" style="border-color: var(--divider); box-shadow: 0 2px 4px var(--shadow);">
       <div class="container py-6">
         <slot name="header" />

--- a/frontend/src/components/layout/PageHeader.vue
+++ b/frontend/src/components/layout/PageHeader.vue
@@ -1,0 +1,25 @@
+<template>
+  <Card class="p-6 flex flex-col items-center text-center gap-2">
+    <component v-if="icon" :is="icon" class="w-8 h-8" />
+    <div>
+      <h1 class="text-2xl font-bold">{{ title }}</h1>
+      <p v-if="subtitle" class="text-muted">{{ subtitle }}</p>
+    </div>
+  </Card>
+</template>
+
+<script setup>
+/**
+ * PageHeader provides a consistent card-style header with optional icon and subtitle.
+ */
+import Card from '@/components/ui/Card.vue'
+
+defineProps({
+  /** Main heading text for the page */
+  title: { type: String, required: true },
+  /** Optional subtitle displayed below the title */
+  subtitle: { type: String, default: '' },
+  /** Optional icon component rendered above the title */
+  icon: { type: [Object, Function], default: null },
+})
+</script>

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -1,14 +1,10 @@
 <template>
-  <div class="accounts-page container space-y-8">
-    <!-- Header -->
-    <Card class="p-6 flex items-center gap-3">
-      <Wallet class="w-6 h-6" />
-      <div>
-        <h1 class="text-2xl font-bold">Accounts</h1>
-        <p class="text-muted">Link and refresh your accounts</p>
-      </div>
-    </Card>
+  <AppLayout>
+    <template #header>
+      <PageHeader title="Accounts" subtitle="Link and refresh your accounts" :icon="Wallet" />
+    </template>
 
+    <div class="space-y-8">
     <!-- Account Actions -->
     <Card class="p-6">
       <h2 class="text-xl font-semibold mb-4">Account Actions</h2>
@@ -94,11 +90,12 @@
       <InstitutionTable @refresh="refreshCharts" />
     </Card>
 
-    <!-- Footer -->
-    <footer class="mt-12 text-center text-sm text-muted border-t pt-4">
+    </div>
+
+    <template #footer>
       &copy; good dashroad.
-    </footer>
-  </div>
+    </template>
+  </AppLayout>
 </template>
 
 <script setup>
@@ -115,6 +112,8 @@ import { formatAmount } from '@/utils/format'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import TogglePanel from '@/components/ui/TogglePanel.vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 // Business Components
 import LinkAccount from '@/components/forms/LinkAccount.vue'

--- a/frontend/src/views/Forecast.vue
+++ b/frontend/src/views/Forecast.vue
@@ -1,22 +1,15 @@
 <template>
-  <div class="forecast-view">
+  <AppLayout>
+    <template #header>
+      <PageHeader title="Forecasting" subtitle="Project your balances" :icon="LineChart" />
+    </template>
     <ForecastLayout />
-  </div>
+  </AppLayout>
 </template>
 
 <script setup>
+import AppLayout from '@/components/layout/AppLayout.vue'
+import PageHeader from '@/components/layout/PageHeader.vue'
 import ForecastLayout from '@/components/forecast/ForecastLayout.vue'
+import { LineChart } from 'lucide-vue-next'
 </script>
-
-<style scoped>
-@reference "../assets/css/main.css";
-.forecast-view {
-  background-color: var(--page-bg);
-  color: var(--theme-fg);
-  min-height: 100vh;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-</style>

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -1,54 +1,49 @@
 <template>
-  <div class="transactions-page container py-8 space-y-8">
-    <!-- Header -->
-    <Card class="p-6 flex items-center gap-3">
-      <CreditCard class="w-6 h-6" />
-      <div>
-        <h1 class="text-2xl font-bold">Transactions</h1>
-        <p class="text-muted">View and manage your transactions</p>
-      </div>
-    </Card>
+  <AppLayout>
+    <template #header>
+      <PageHeader title="Transactions" subtitle="View and manage your transactions" :icon="CreditCard" />
+    </template>
 
-    <!-- Top Controls -->
-    <Card class="p-6">
-      <div class="grid gap-4 md:grid-cols-2">
-        <ImportFileSelector />
-        <input v-model="searchQuery" type="text" placeholder="Search transactions..." class="input w-full" />
-      </div>
-    </Card>
-
-    <!-- Main Table -->
-    <Card class="p-6 space-y-4">
-      <h2 class="text-2xl font-bold">Recent Transactions</h2>
-      <transition name="fade-in-up" mode="out-in">
-        <UpdateTransactionsTable :key="currentPage" :transactions="filteredTransactions" :sort-key="sortKey"
-          :sort-order="sortOrder" @sort="setSort"
-          @editRecurringFromTransaction="prefillRecurringFromTransaction" />
-      </transition>
-    </Card>
-
-    <!-- Pagination -->
-    <div id="pagination-controls" class="flex items-center justify-center gap-4">
-      <UiButton variant="outline" @click="changePage(-1)" :disabled="currentPage === 1">Prev</UiButton>
-      <span class="text-muted">Page {{ currentPage }} of {{ totalPages }}</span>
-      <UiButton variant="primary" @click="changePage(1)" :disabled="currentPage >= totalPages">Next</UiButton>
-    </div>
-
-    <!-- Recurring Transactions -->
-    <Card class="p-6 space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-bold">Recurring Transactions</h2>
-        <UiButton variant="outline" @click="showRecurring = !showRecurring">
-          {{ showRecurring ? 'Hide' : 'Show' }}
-        </UiButton>
-      </div>
-      <transition name="accordion">
-        <div v-if="showRecurring" class="mt-4">
-          <RecurringTransactionSection ref="recurringFormRef" provider="plaid" />
+    <div class="space-y-8">
+      <!-- Top Controls -->
+      <Card class="p-6">
+        <div class="grid gap-4 md:grid-cols-2">
+          <ImportFileSelector />
+          <input v-model="searchQuery" type="text" placeholder="Search transactions..." class="input w-full" />
         </div>
-      </transition>
-    </Card>
-  </div>
+      </Card>
+
+      <!-- Main Table -->
+      <Card class="p-6 space-y-4">
+        <h2 class="text-2xl font-bold">Recent Transactions</h2>
+        <transition name="fade-in-up" mode="out-in">
+          <UpdateTransactionsTable :key="currentPage" :transactions="filteredTransactions" :sort-key="sortKey" :sort-order="sortOrder" @sort="setSort" @editRecurringFromTransaction="prefillRecurringFromTransaction" />
+        </transition>
+      </Card>
+
+      <!-- Pagination -->
+      <div id="pagination-controls" class="flex items-center justify-center gap-4">
+        <UiButton variant="outline" @click="changePage(-1)" :disabled="currentPage === 1">Prev</UiButton>
+        <span class="text-muted">Page {{ currentPage }} of {{ totalPages }}</span>
+        <UiButton variant="primary" @click="changePage(1)" :disabled="currentPage >= totalPages">Next</UiButton>
+      </div>
+
+      <!-- Recurring Transactions -->
+      <Card class="p-6 space-y-4">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-bold">Recurring Transactions</h2>
+          <UiButton variant="outline" @click="showRecurring = !showRecurring">
+            {{ showRecurring ? 'Hide' : 'Show' }}
+          </UiButton>
+        </div>
+        <transition name="accordion">
+          <div v-if="showRecurring" class="mt-4">
+            <RecurringTransactionSection ref="recurringFormRef" provider="plaid" />
+          </div>
+        </transition>
+      </Card>
+    </div>
+  </AppLayout>
 </template>
 
 <script>
@@ -62,17 +57,20 @@ import RecurringTransactionSection from '@/components/recurring/RecurringTransac
 import ImportFileSelector from '@/components/forms/ImportFileSelector.vue'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import PageHeader from '@/components/layout/PageHeader.vue'
 import { CreditCard } from 'lucide-vue-next'
 
 export default {
   name: 'TransactionsView',
   components: {
+    AppLayout,
+    PageHeader,
     UpdateTransactionsTable,
     RecurringTransactionSection,
     ImportFileSelector,
     UiButton,
     Card,
-    CreditCard,
   },
   setup() {
     const {
@@ -111,6 +109,7 @@ export default {
       showRecurring,
       recurringFormRef,
       prefillRecurringFromTransaction,
+      CreditCard,
     }
   },
 }


### PR DESCRIPTION
## Summary
- add `PageHeader` component for centered header with optional icon
- standardize background colors via `AppLayout`
- refactor Forecast, Accounts, and Transactions views to use shared layout and headers

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68aa129697088329bf5cfa8ff2afb12c