### PR TITLE
fix(layout): render AppLayout header conditionally

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="min-h-screen flex flex-col">
-    <header class="glass border-b" style="border-color: var(--divider); box-shadow: 0 2px 4px var(--shadow);">
+    <header
+      v-if="hasHeader"
+      class="glass border-b"
+      style="border-color: var(--divider); box-shadow: 0 2px 4px var(--shadow);"
+    >
       <div class="container py-6">
         <slot name="header" />
       </div>
     </header>
-    <main class="flex-1 container py-6">
+    <main class="flex-1 py-6">
       <slot />
     </main>
     <footer class="glass border-t" style="border-color: var(--divider);">
@@ -17,5 +21,6 @@
 </template>
 
 <script setup>
-// Layout wrapper, no additional logic
+const slots = useSlots()
+const hasHeader = !!slots.header
 </script>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -4,9 +4,10 @@
 -->
 <template>
   <AppLayout>
-    <!-- WELCOME HEADER CARD -->
+    <div class="container">
+      <!-- WELCOME HEADER CARD -->
       <div class="w-20 h-3 rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
-    <div class="flex justify-center mb-8">
+      <div class="flex justify-center mb-8">
         <div
           class="w-full max-w-3xl bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-2xl p-8 flex flex-col items-center gap-2">
           <h1 class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow">Welcome, <span
@@ -14,10 +15,9 @@
         <p class="text-lg text-muted">Today is {{ currentDate }}</p>
         <p class="italic text-muted">{{ netWorthMessage }}</p>
       </div>
-
-    </div>
+      </div>
       <div class="w-20 h-3 rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
-    <div class="dashboard-content flex flex-col gap-8 w-full max-w-7xl mx-auto px-2">
+      <div class="dashboard-content flex flex-col gap-8 w-full max-w-7xl mx-auto px-2">
       <!-- TOP ROW: Top Accounts Snapshot & Net Income -->
       <div class="flex flex-col md:flex-row gap-6 justify-center items-stretch">
         <!-- Top Accounts Snapshot Card -->

--- a/frontend/src/views/Institutions.vue
+++ b/frontend/src/views/Institutions.vue
@@ -1,10 +1,12 @@
 <template>
   <AppLayout>
-    <div class="space-y-6">
-      <header class="text-center p-4 rounded-lg shadow-md bg-[var(--color-bg)]">
+    <template #header>
+      <div class="text-center p-4 rounded-lg shadow-md bg-[var(--color-bg)]">
         <h1 class="text-3xl font-bold text-[var(--color-accent-cyan)]">Institutions</h1>
         <p class="text-sm text-muted">Overview of all linked providers and accounts</p>
-      </header>
+      </div>
+    </template>
+    <div class="container space-y-6">
       <section>
         <InstitutionTable />
       </section>


### PR DESCRIPTION
## Summary
- Render AppLayout header only when slot content exists and remove container from main to avoid nested containers
- Wrap dashboard and institutions views in a container; move institutions heading to layout header slot

## Testing
- `npm test` *(fails: No "useRouter" export defined in vue-router mock, snapshot mismatch)*
- `npm run lint` *(fails: No "useRouter" export defined in vue-router mock, snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68aab2b9a8b48329bc70c4f552216cdb