### PR TITLE
feat: add actions slot to PageHeader

### DIFF
--- a/docs/frontend/PageHeader.md
+++ b/docs/frontend/PageHeader.md
@@ -1,0 +1,23 @@
+# PageHeader Component
+
+Standard page header used at the top of views. Provides slots for an optional icon, title, subtitle, and an `actions` area on the right.
+
+## Slots
+- `icon` – optional leading icon
+- `title` – main heading text
+- `subtitle` – supporting description text
+- `actions` – optional right‑aligned controls (e.g. buttons)
+
+## Example
+```vue
+<PageHeader>
+  <template #icon>
+    <CreditCard class="w-6 h-6" />
+  </template>
+  <template #title>Transactions</template>
+  <template #subtitle>View and manage your transactions</template>
+  <template #actions>
+    <UiButton variant="outline">Import</UiButton>
+  </template>
+</PageHeader>
+```

--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -50,6 +50,7 @@ declare module 'vue' {
     NetIncomeCharts: typeof import('./components/charts/NetIncomeCharts.vue')['default']
     NetYearComparisonChart: typeof import('./components/charts/NetYearComparisonChart.vue')['default']
     NotificationsBar: typeof import('./components/recurring/NotificationsBar.vue')['default']
+    PageHeader: typeof import('./components/ui/PageHeader.vue')['default']
     PaginationControls: typeof import('./components/tables/PaginationControls.vue')['default']
     PlaidProductScopeSelector: typeof import('./components/forms/PlaidProductScopeSelector.vue')['default']
     RecurringCalendar: typeof import('./components/recurring/RecurringCalendar.vue')['default']

--- a/frontend/src/components/ui/PageHeader.vue
+++ b/frontend/src/components/ui/PageHeader.vue
@@ -1,0 +1,32 @@
+<template>
+  <Card class="p-6 flex items-center">
+    <div class="flex items-center gap-3 flex-1">
+      <slot name="icon" />
+      <div>
+        <h1 class="text-2xl font-bold">
+          <slot name="title" />
+        </h1>
+        <p class="text-muted">
+          <slot name="subtitle" />
+        </p>
+      </div>
+    </div>
+    <div v-if="$slots.actions" class="flex items-center gap-2 ml-auto">
+      <slot name="actions" />
+    </div>
+  </Card>
+</template>
+
+<script setup>
+/**
+ * PageHeader
+ * Standard card header for views with an optional actions slot.
+ *
+ * Slots:
+ * - icon: optional leading icon
+ * - title: main heading text
+ * - subtitle: supporting description text
+ * - actions: optional right-aligned action controls
+ */
+import Card from '@/components/ui/Card.vue'
+</script>

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="transactions-page container py-8 space-y-8">
     <!-- Header -->
-    <Card class="p-6 flex items-center gap-3">
-      <CreditCard class="w-6 h-6" />
-      <div>
-        <h1 class="text-2xl font-bold">Transactions</h1>
-        <p class="text-muted">View and manage your transactions</p>
-      </div>
-    </Card>
+    <PageHeader>
+      <template #icon>
+        <CreditCard class="w-6 h-6" />
+      </template>
+      <template #title>Transactions</template>
+      <template #subtitle>View and manage your transactions</template>
+      <template #actions>
+        <UiButton variant="outline">Import</UiButton>
+      </template>
+    </PageHeader>
 
     <!-- Top Controls -->
     <Card class="p-6">
@@ -60,6 +63,7 @@ import { useTransactions } from '@/composables/useTransactions.js'
 import UpdateTransactionsTable from '@/components/tables/UpdateTransactionsTable.vue'
 import RecurringTransactionSection from '@/components/recurring/RecurringTransactionSection.vue'
 import ImportFileSelector from '@/components/forms/ImportFileSelector.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import { CreditCard } from 'lucide-vue-next'
@@ -70,6 +74,7 @@ export default {
     UpdateTransactionsTable,
     RecurringTransactionSection,
     ImportFileSelector,
+    PageHeader,
     UiButton,
     Card,
     CreditCard,


### PR DESCRIPTION
## Summary
- add `PageHeader` component with optional `actions` slot
- document `PageHeader` usage and show example in Transactions view
- update auto-generated component types

## Testing
- `SKIP=model-field-validation pre-commit run --files frontend/src/components/ui/PageHeader.vue frontend/src/views/Transactions.vue docs/frontend/PageHeader.md`
- `pre-commit run model-field-validation --files tests/test_model_field_validation.py` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- `cd frontend && npm test` *(fails: Accounts.spec and Transactions.spec errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aab617b2108329b12f5b93f21bbd46