### PR TITLE
Add BasePageLayout and PageHeader component tests

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     BaseCard: typeof import('./components/base/BaseCard.vue')['default']
     BaseChart: typeof import('./components/unused/BaseChart.vue')['default']
     BaseIcon: typeof import('./components/icons/BaseIcon.vue')['default']
+    BasePageLayout: typeof import('./components/layout/BasePageLayout.vue')['default']
     BaseTable: typeof import('./components/base/BaseTable.vue')['default']
     Button: typeof import('./components/ui/Button.vue')['default']
     Card: typeof import('./components/ui/Card.vue')['default']

--- a/frontend/src/components/layout/BasePageLayout.vue
+++ b/frontend/src/components/layout/BasePageLayout.vue
@@ -1,0 +1,40 @@
+<template>
+  <div :class="classes">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * BasePageLayout
+ * Simple flex column wrapper that provides configurable padding and gap
+ * utilities for page sections.
+ *
+ * Props:
+ * - padding: tailwind padding utility class or `false` to disable (default `p-6`)
+ * - gap: tailwind gap utility class (default `gap-6`)
+ */
+import { computed } from 'vue'
+
+interface Props {
+  /** Tailwind padding utility or `false` to remove padding */
+  padding?: string | boolean
+  /** Tailwind gap utility class applied to container */
+  gap?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  padding: true,
+  gap: 'gap-6'
+})
+
+const paddingClass = computed(() => {
+  if (props.padding === false) return ''
+  if (typeof props.padding === 'string') return props.padding
+  return 'p-6'
+})
+
+const classes = computed(() => {
+  return ['flex', 'flex-col', paddingClass.value, props.gap].filter(Boolean)
+})
+</script>

--- a/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
+++ b/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BasePageLayout from '../BasePageLayout.vue'
+
+describe('BasePageLayout', () => {
+  it('renders with default padding and gap', () => {
+    const wrapper = mount(BasePageLayout)
+    expect(wrapper.classes()).toContain('p-6')
+    expect(wrapper.classes()).toContain('gap-6')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('applies custom padding', () => {
+    const wrapper = mount(BasePageLayout, { props: { padding: 'p-2' } })
+    expect(wrapper.classes()).toContain('p-2')
+    expect(wrapper.classes()).not.toContain('p-6')
+  })
+
+  it('can disable padding', () => {
+    const wrapper = mount(BasePageLayout, { props: { padding: false } })
+    expect(wrapper.classes()).not.toContain('p-6')
+  })
+
+  it('applies gap prop', () => {
+    const wrapper = mount(BasePageLayout, { props: { gap: 'gap-4' } })
+    expect(wrapper.classes()).toContain('gap-4')
+  })
+})

--- a/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BasePageLayout > renders with default padding and gap 1`] = `"<div class="flex flex-col p-6 gap-6"></div>"`;

--- a/frontend/src/components/ui/__tests__/PageHeader.spec.ts
+++ b/frontend/src/components/ui/__tests__/PageHeader.spec.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PageHeader from '../PageHeader.vue'
+
+describe('PageHeader', () => {
+  it('renders title slot', () => {
+    const wrapper = mount(PageHeader, {
+      slots: { title: 'Dashboard' }
+    })
+    expect(wrapper.find('h1').text()).toBe('Dashboard')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders optional subtitle and icon', () => {
+    const wrapper = mount(PageHeader, {
+      slots: {
+        title: 'Accounts',
+        subtitle: 'Overview',
+        icon: '<span class="icon" />'
+      }
+    })
+    expect(wrapper.find('p').text()).toBe('Overview')
+    expect(wrapper.find('.icon').exists()).toBe(true)
+  })
+
+  it('renders actions slot', () => {
+    const wrapper = mount(PageHeader, {
+      slots: {
+        title: 'Settings',
+        actions: '<button class="action">Act</button>'
+      }
+    })
+    expect(wrapper.find('.action').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageHeader > renders title slot 1`] = `
+"<div class="card glass p-6 flex items-center">
+  <div class="flex items-center gap-3 flex-1">
+    <div>
+      <h1 class="text-2xl font-bold">Dashboard</h1>
+      <p class="text-muted"></p>
+    </div>
+  </div>
+  <!--v-if-->
+</div>"
+`;


### PR DESCRIPTION
## Summary
- implement BasePageLayout with configurable padding and gap
- add snapshot tests for BasePageLayout padding and gap options
- cover PageHeader title, subtitle, icon, and actions slots

## Testing
- `npm test` *(fails: No "useRouter" export defined)*
- `npx vitest src/components/layout/__tests__/BasePageLayout.spec.ts src/components/ui/__tests__/PageHeader.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aab9b01b90832995068983cb5aafc0