### PR TITLE
refactor(frontend): unify page layouts

### DIFF
--- a/frontend/src/views/ArbitrageLive.vue
+++ b/frontend/src/views/ArbitrageLive.vue
@@ -1,19 +1,26 @@
 <template>
-  <div class="p-6 space-y-4">
-    <h1 class="text-2xl font-bold text-[var(--color-accent-yellow)]">
-      R/S Arbitrage Monitor
-    </h1>
+  <BasePageLayout>
+    <PageHeader>
+      <template #icon>
+        <Activity class="w-6 h-6" />
+      </template>
+      <template #title>R/S Arbitrage Monitor</template>
+      <template #subtitle>Live R/S arbitrage feed</template>
+    </PageHeader>
     <pre
       v-if="content"
       class="bg-gray-800 text-white p-4 rounded whitespace-pre-wrap"
     >{{ content }}</pre>
     <div v-else>Loading...</div>
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import { fetchArbitrageData } from '@/api/arbitrage'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import { Activity } from 'lucide-vue-next'
 
 const content = ref('')
 

--- a/frontend/src/views/Planning.vue
+++ b/frontend/src/views/Planning.vue
@@ -1,12 +1,21 @@
 <template>
-  <div class="planning-view">
-    <h1 class="text-2xl font-bold mb-4">Planning</h1>
+  <BasePageLayout>
+    <PageHeader>
+      <template #icon>
+        <Calendar class="w-6 h-6" />
+      </template>
+      <template #title>Planning</template>
+      <template #subtitle>Manage your budgeting and allocations</template>
+    </PageHeader>
     <pre>{{ JSON.stringify(state, null, 2) }}</pre>
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
 import { usePlanning } from '@/composables/usePlanning'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import { Calendar } from 'lucide-vue-next'
 
 /**
  * Top-level view for budgeting and allocation planning.
@@ -14,13 +23,3 @@ import { usePlanning } from '@/composables/usePlanning'
  */
 const { state } = usePlanning()
 </script>
-
-<style scoped>
-@reference "../assets/css/main.css";
-.planning-view {
-  background-color: var(--page-bg);
-  color: var(--theme-fg);
-  min-height: 100vh;
-  padding: 1.5rem;
-}
-</style>

--- a/frontend/src/views/RecurringScanDemo.vue
+++ b/frontend/src/views/RecurringScanDemo.vue
@@ -1,30 +1,39 @@
 <template>
-  <div class="p-6 space-y-6">
-    <h1 class="text-2xl font-bold">Recurring Scan Demo</h1>
+  <BasePageLayout>
+    <PageHeader>
+      <template #icon>
+        <Repeat class="w-6 h-6" />
+      </template>
+      <template #title>Recurring Scan Demo</template>
+      <template #subtitle>Demo results for recurring transaction scan</template>
+    </PageHeader>
     <ScanResultsModal :results="scanResults" />
     <ScanResultsTable :results="scanResults" />
     <ScanResultsList :results="scanResults" />
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
-import { useRoute } from 'vue-router';
-import { scanRecurringTransactions } from '@/api/recurring';
-import ScanResultsModal from '@/components/recurring/ScanResultsModal.vue';
-import ScanResultsTable from '@/components/recurring/ScanResultsTable.vue';
-import ScanResultsList from '@/components/recurring/ScanResultsList.vue';
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { scanRecurringTransactions } from '@/api/recurring'
+import ScanResultsModal from '@/components/recurring/ScanResultsModal.vue'
+import ScanResultsTable from '@/components/recurring/ScanResultsTable.vue'
+import ScanResultsList from '@/components/recurring/ScanResultsList.vue'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import { Repeat } from 'lucide-vue-next'
 
-const route = useRoute();
-const accountId = route.params.accountId || '1';
-const scanResults = ref([]);
+const route = useRoute()
+const accountId = route.params.accountId || '1'
+const scanResults = ref([])
 
 onMounted(async () => {
   try {
-    const data = await scanRecurringTransactions(accountId);
-    scanResults.value = data.actions || [];
+    const data = await scanRecurringTransactions(accountId)
+    scanResults.value = data.actions || []
   } catch (err) {
-    console.error('Failed to load scan results', err);
+    console.error('Failed to load scan results', err)
   }
-});
+})
 </script>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1,48 +1,63 @@
 <template>
-    <div>
-      <h1>Settings</h1>
-      <label for="themes">Select Theme:</label>
-      <select v-model="selectedTheme" @change="setTheme">
-        <option v-for="theme in themes" :key="theme" :value="theme">
-          {{ theme }}
-        </option>
-      </select>
-    </div>
-  </template>
-  
-  <script>
-  import axios from "axios";
-  
-  export default {
-    name: "Settings",
-    data() {
-      return {
-        themes: [],
-        selectedTheme: "",
-      };
+  <BasePageLayout>
+    <PageHeader>
+      <template #icon>
+        <SettingsIcon class="w-6 h-6" />
+      </template>
+      <template #title>Settings</template>
+      <template #subtitle>Manage application preferences</template>
+    </PageHeader>
+
+    <label for="themes">Select Theme:</label>
+    <select v-model="selectedTheme" @change="setTheme">
+      <option v-for="theme in themes" :key="theme" :value="theme">
+        {{ theme }}
+      </option>
+    </select>
+  </BasePageLayout>
+</template>
+
+<script>
+import axios from 'axios'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import { Settings as SettingsIcon } from 'lucide-vue-next'
+
+export default {
+  name: 'Settings',
+  components: {
+    BasePageLayout,
+    PageHeader,
+    SettingsIcon,
+  },
+  data() {
+    return {
+      themes: [],
+      selectedTheme: '',
+    }
+  },
+  async created() {
+    await this.fetchThemes()
+  },
+  methods: {
+    async fetchThemes() {
+      try {
+        const response = await axios.get('/themes')
+        this.themes = response.data.themes
+        this.selectedTheme = response.data.current_theme
+      } catch (error) {
+        console.error('Failed to fetch themes:', error)
+      }
     },
-    async created() {
-      await this.fetchThemes();
+    async setTheme() {
+      try {
+        await axios.post('/set_theme', { theme: this.selectedTheme })
+        alert(`Theme set to ${this.selectedTheme}`)
+      } catch (error) {
+        console.error('Failed to set theme:', error)
+      }
     },
-    methods: {
-      async fetchThemes() {
-        try {
-          const response = await axios.get("/themes");
-          this.themes = response.data.themes;
-          this.selectedTheme = response.data.current_theme;
-        } catch (error) {
-          console.error("Failed to fetch themes:", error);
-        }
-      },
-      async setTheme() {
-        try {
-          await axios.post("/set_theme", { theme: this.selectedTheme });
-          alert(`Theme set to ${this.selectedTheme}`);
-        } catch (error) {
-          console.error("Failed to set theme:", error);
-        }
-      },
-    },
-  };
-  </script>
-  
+  },
+}
+</script>
+

--- a/frontend/src/views/__tests__/Accounts.spec.js
+++ b/frontend/src/views/__tests__/Accounts.spec.js
@@ -5,7 +5,8 @@ import Accounts from '../Accounts.vue'
 import { vi } from 'vitest'
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: {} })
+  useRoute: () => ({ params: {} }),
+  useRouter: () => ({ push: vi.fn() })
 }))
 
 vi.mock('@/api/accounts', () => ({

--- a/frontend/src/views/__tests__/ArbitrageLive.spec.js
+++ b/frontend/src/views/__tests__/ArbitrageLive.spec.js
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import ArbitrageLive from '../ArbitrageLive.vue'
+
+vi.mock('@/api/arbitrage', () => ({
+  fetchArbitrageData: vi.fn().mockResolvedValue({ content: '' })
+}))
+
+describe('ArbitrageLive.vue', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(ArbitrageLive, {
+      global: {
+        stubs: ['BasePageLayout', 'PageHeader', 'Activity']
+      }
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/views/__tests__/Planning.spec.js
+++ b/frontend/src/views/__tests__/Planning.spec.js
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import Planning from '../Planning.vue'
+
+vi.mock('@/composables/usePlanning', () => ({
+  usePlanning: () => ({ state: {} })
+}))
+
+describe('Planning.vue', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(Planning, {
+      global: {
+        stubs: ['BasePageLayout', 'PageHeader', 'Calendar']
+      }
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/views/__tests__/RecurringScanDemo.spec.js
+++ b/frontend/src/views/__tests__/RecurringScanDemo.spec.js
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import RecurringScanDemo from '../RecurringScanDemo.vue'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {} })
+}))
+
+vi.mock('@/api/recurring', () => ({
+  scanRecurringTransactions: vi.fn().mockResolvedValue({ actions: [] })
+}))
+
+describe('RecurringScanDemo.vue', () => {
+  it('matches snapshot', async () => {
+    const wrapper = shallowMount(RecurringScanDemo, {
+      global: {
+        stubs: ['BasePageLayout', 'PageHeader', 'ScanResultsModal', 'ScanResultsTable', 'ScanResultsList', 'Repeat']
+      }
+    })
+    await flushPromises()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/views/__tests__/Settings.spec.js
+++ b/frontend/src/views/__tests__/Settings.spec.js
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import SettingsView from '../Settings.vue'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: { themes: [], current_theme: '' } }),
+    post: vi.fn().mockResolvedValue({})
+  }
+}))
+
+describe('Settings.vue', () => {
+  it('matches snapshot', async () => {
+    const wrapper = shallowMount(SettingsView, {
+      global: {
+        stubs: ['BasePageLayout', 'PageHeader', 'SettingsIcon']
+      }
+    })
+    await flushPromises()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/views/__tests__/Transactions.spec.js
+++ b/frontend/src/views/__tests__/Transactions.spec.js
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
 import Transactions from '../Transactions.vue'
+
+vi.mock('@/api/transactions', () => ({
+  fetchTransactions: vi.fn().mockResolvedValue({ transactions: [], total: 0 })
+}))
 
 describe('Transactions.vue', () => {
   it('matches snapshot', () => {

--- a/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
@@ -5,13 +5,17 @@ exports[`Accounts.vue > matches snapshot 1`] = `
   <!-- Header -->
   <card-stub class="p-6 flex items-center gap-3"></card-stub><!-- Account Actions -->
   <card-stub class="p-6"></card-stub><!-- Net Change Summary -->
-  <card-stub class="p-6"></card-stub><!-- Recent Transactions -->
-  <card-stub class="p-6 space-y-2"></card-stub><!-- Charts -->
-  <div class="flex flex-col gap-6">
-    <card-stub class="p-6"></card-stub>
-    <card-stub class="p-6"></card-stub>
-    <card-stub class="p-6"></card-stub>
-  </div><!-- Accounts Table -->
+  <card-stub class="p-6"></card-stub><!-- Balance History -->
+  <card-stub class="p-6 space-y-4"></card-stub><!-- Recent Transactions -->
+  <card-stub class="p-6 space-y-4"></card-stub><!-- Charts -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Account Analysis</h2>
+    <div class="flex flex-col gap-6">
+      <card-stub class="p-6"></card-stub>
+      <card-stub class="p-6"></card-stub>
+      <card-stub class="p-6"></card-stub>
+    </div>
+  </section><!-- Accounts Table -->
   <card-stub class="p-6"></card-stub><!-- Footer -->
   <footer class="mt-12 text-center text-sm text-muted border-t pt-4"> © good dashroad. </footer>
 </div>"

--- a/frontend/src/views/__tests__/__snapshots__/ArbitrageLive.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/ArbitrageLive.spec.js.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ArbitrageLive.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="true" gap="gap-6"></base-page-layout-stub>"`;

--- a/frontend/src/views/__tests__/__snapshots__/Planning.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Planning.spec.js.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Planning.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="true" gap="gap-6"></base-page-layout-stub>"`;

--- a/frontend/src/views/__tests__/__snapshots__/RecurringScanDemo.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/RecurringScanDemo.spec.js.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RecurringScanDemo.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="true" gap="gap-6"></base-page-layout-stub>"`;

--- a/frontend/src/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Settings.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="true" gap="gap-6"></base-page-layout-stub>"`;

--- a/frontend/src/views/__tests__/__snapshots__/Transactions.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Transactions.spec.js.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Transactions.vue > matches snapshot 1`] = `
-"<div class="transactions-page container space-y-8">
+"<div class="transactions-page container py-8 space-y-8">
   <!-- Header -->
-  <card-stub class="p-6 flex items-center gap-3"></card-stub><!-- Top Controls -->
+  <page-header-stub></page-header-stub><!-- Top Controls -->
   <card-stub class="p-6"></card-stub><!-- Main Table -->
   <card-stub class="p-6 space-y-4"></card-stub><!-- Pagination -->
   <div id="pagination-controls" class="flex items-center justify-center gap-4">


### PR DESCRIPTION
## Summary
- wrap Planning, Settings, ArbitrageLive, and RecurringScanDemo in BasePageLayout and PageHeader
- remove legacy wrapper styles and stub APIs in tests
- add snapshot tests for updated views and refresh existing ones

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aabb282f848329804480ffebacb7c9