### PR TITLE
feat(layout): add BasePageLayout component and tests

### DIFF
--- a/frontend/src/components/layout/BasePageLayout.vue
+++ b/frontend/src/components/layout/BasePageLayout.vue
@@ -1,0 +1,42 @@
+<template>
+  <div :class="classes">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * BasePageLayout
+ * Generic flex column container with configurable padding and gap.
+ *
+ * Props:
+ * - padding: tailwind padding class or false to disable (default: 'p-6')
+ * - gap: numeric or string tailwind gap value (e.g., 4 -> 'gap-4')
+ */
+import { computed } from 'vue'
+
+interface Props {
+  padding?: string | boolean
+  gap?: string | number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  padding: 'p-6',
+})
+
+const classes = computed(() => {
+  const paddingClass =
+    props.padding === false
+      ? ''
+      : typeof props.padding === 'string'
+      ? props.padding
+      : 'p-6'
+  const gapClass =
+    props.gap === undefined
+      ? ''
+      : typeof props.gap === 'number'
+      ? `gap-${props.gap}`
+      : `gap-${props.gap}`.replace('gap-gap-', 'gap-')
+  return ['flex', 'flex-col', paddingClass, gapClass].filter(Boolean).join(' ')
+})
+</script>

--- a/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
+++ b/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BasePageLayout from '../BasePageLayout.vue'
+
+describe('BasePageLayout', () => {
+  it('uses default padding', () => {
+    const wrapper = mount(BasePageLayout, {
+      slots: { default: '<div>Content</div>' },
+    })
+    expect(wrapper.classes()).toContain('p-6')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('accepts custom padding', () => {
+    const wrapper = mount(BasePageLayout, {
+      props: { padding: 'p-4' },
+      slots: { default: '<div>Content</div>' },
+    })
+    expect(wrapper.classes()).toContain('p-4')
+    expect(wrapper.classes()).not.toContain('p-6')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('applies gap class when provided', () => {
+    const wrapper = mount(BasePageLayout, {
+      props: { gap: 4 },
+      slots: { default: '<div>A</div><div>B</div>' },
+    })
+    expect(wrapper.classes()).toContain('gap-4')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BasePageLayout > accepts custom padding 1`] = `
+"<div class="flex flex-col p-4">
+  <div>Content</div>
+</div>"
+`;
+
+exports[`BasePageLayout > applies gap class when provided 1`] = `
+"<div class="flex flex-col p-6 gap-4">
+  <div>A</div>
+  <div>B</div>
+</div>"
+`;
+
+exports[`BasePageLayout > uses default padding 1`] = `
+"<div class="flex flex-col p-6">
+  <div>Content</div>
+</div>"
+`;

--- a/frontend/src/components/ui/__tests__/PageHeader.spec.ts
+++ b/frontend/src/components/ui/__tests__/PageHeader.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PageHeader from '../PageHeader.vue'
+
+describe('PageHeader', () => {
+  it('renders title', () => {
+    const wrapper = mount(PageHeader, {
+      slots: { title: 'Dashboard' },
+    })
+    expect(wrapper.find('h1').text()).toBe('Dashboard')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders optional subtitle and icon', () => {
+    const wrapper = mount(PageHeader, {
+      slots: {
+        title: 'Dashboard',
+        subtitle: 'Overview',
+        icon: '<span class="icon" />',
+      },
+    })
+    expect(wrapper.find('p.text-muted').text()).toBe('Overview')
+    expect(wrapper.find('.icon').exists()).toBe(true)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders actions slot', () => {
+    const wrapper = mount(PageHeader, {
+      slots: {
+        title: 'Dashboard',
+        actions: '<button>Action</button>',
+      },
+    })
+    expect(wrapper.find('div.flex.items-center.gap-2.ml-auto').exists()).toBe(true)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageHeader > renders actions slot 1`] = `
+"<div class="card glass p-6 flex items-center">
+  <div class="flex items-center gap-3 flex-1">
+    <div>
+      <h1 class="text-2xl font-bold">Dashboard</h1>
+      <p class="text-muted"></p>
+    </div>
+  </div>
+  <div class="flex items-center gap-2 ml-auto"><button>Action</button></div>
+</div>"
+`;
+
+exports[`PageHeader > renders optional subtitle and icon 1`] = `
+"<div class="card glass p-6 flex items-center">
+  <div class="flex items-center gap-3 flex-1"><span class="icon"></span>
+    <div>
+      <h1 class="text-2xl font-bold">Dashboard</h1>
+      <p class="text-muted">Overview</p>
+    </div>
+  </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`PageHeader > renders title 1`] = `
+"<div class="card glass p-6 flex items-center">
+  <div class="flex items-center gap-3 flex-1">
+    <div>
+      <h1 class="text-2xl font-bold">Dashboard</h1>
+      <p class="text-muted"></p>
+    </div>
+  </div>
+  <!--v-if-->
+</div>"
+`;


### PR DESCRIPTION
## Summary
- add `BasePageLayout` container with configurable padding and gap
- cover `BasePageLayout` padding and gap props with snapshots
- add `PageHeader` tests for title, subtitle/icon, and actions slot

## Testing
- `npx vitest --run -u src/components/layout/__tests__/BasePageLayout.spec.ts src/components/ui/__tests__/PageHeader.spec.ts`
- `npm test` *(fails: No "useRouter" export in vue-router mock; snapshot mismatch in Transactions.spec.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba21bce88329a2634337fea93f3e