### PR TITLE
docs: document BasePageLayout and PageHeader usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Refer to [`docs/index/INDEX.md`](docs/index/INDEX.md) for a full documentation m
 This project maintains comprehensive documentation to help with development, maintenance, and contribution:
 
 - **[Documentation Index](docs/index/INDEX.md)** - Complete map of all available documentation
+- **[Page layout components](docs/frontend/PageLayout.md)** - When and how to use `BasePageLayout` and `PageHeader`
 - **[Contributing Guide](CONTRIBUTING.md)** - Guidelines for contributing to the project
 - **[Maintenance Checklist](docs/maintenance/cleanup_checklist.md)** - Regular maintenance tasks and procedures
 

--- a/docs/frontend/PageLayout.md
+++ b/docs/frontend/PageLayout.md
@@ -1,0 +1,46 @@
+# Page Layout Components
+
+Use `BasePageLayout` and `PageHeader` to keep view structure and spacing consistent across the application. Combine them at the top of every view to provide a standard header and predictable padding.
+
+## BasePageLayout
+
+Wrap each top-level view with `BasePageLayout` to apply flex column layout and spacing utilities.
+
+### Props
+- `padding` – Tailwind padding class or `false` to remove padding. Defaults to `p-6`.
+- `gap` – Tailwind gap utility class. Defaults to `gap-6`.
+
+### Example: custom padding
+```vue
+<BasePageLayout padding="p-2" gap="gap-4">
+  <!-- view content -->
+</BasePageLayout>
+```
+
+## PageHeader
+
+Standard header used within `BasePageLayout`. Provides slots for an optional icon, title, subtitle, and right-aligned actions.
+
+### Example: icon and subtitle
+```vue
+<BasePageLayout>
+  <PageHeader>
+    <template #icon>
+      <SettingsIcon class="w-6 h-6" />
+    </template>
+    <template #title>Settings</template>
+    <template #subtitle>Update your preferences</template>
+    <template #actions>
+      <UiButton variant="outline">Save</UiButton>
+    </template>
+  </PageHeader>
+
+  <!-- rest of view -->
+</BasePageLayout>
+```
+
+Refer to [PageHeader docs](PageHeader.md) for additional slot details.
+
+## Contributor guidance
+
+For conventions around layout and slot usage, see [CODEX.md](../../CODEX.md) and [CONTRIBUTING.md](../../CONTRIBUTING.md). Following these guides ensures consistent adoption of layout components throughout the project.


### PR DESCRIPTION
## Summary
- add PageLayout guide for BasePageLayout and PageHeader with examples
- reference layout guide from README

## Testing
- `SKIP=model-field-validation pre-commit run --files README.md docs/frontend/PageLayout.md`


------
https://chatgpt.com/codex/tasks/task_e_68aacaaaa76c83299beeeb364887b70f