### PR TITLE
refactor(layout): centralize responsive page gutters

### DIFF
--- a/frontend/src/components/layout/BasePageLayout.vue
+++ b/frontend/src/components/layout/BasePageLayout.vue
@@ -4,37 +4,41 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script setup>
 /**
  * BasePageLayout
- * Simple flex column wrapper that provides configurable padding and gap
- * utilities for page sections.
+ * Responsive container that clamps width and applies consistent horizontal
+ * gutters for page sections.
  *
  * Props:
- * - padding: tailwind padding utility class or `false` to disable (default `p-6`)
- * - gap: tailwind gap utility class (default `gap-6`)
+ * - padding: Tailwind padding utilities or `false` to disable (default
+ *   `px-4 sm:px-6 lg:px-8 py-6`)
+ * - gap: Tailwind gap utility class applied to container (default `gap-6`)
  */
 import { computed } from 'vue'
 
-interface Props {
+const props = defineProps({
   /** Tailwind padding utility or `false` to remove padding */
-  padding?: string | boolean
+  padding: { type: [String, Boolean], default: true },
   /** Tailwind gap utility class applied to container */
-  gap?: string
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  padding: true,
-  gap: 'gap-6'
+  gap: { type: String, default: 'gap-6' },
 })
 
 const paddingClass = computed(() => {
   if (props.padding === false) return ''
   if (typeof props.padding === 'string') return props.padding
-  return 'p-6'
+  return 'px-4 sm:px-6 lg:px-8 py-6'
 })
 
 const classes = computed(() => {
-  return ['flex', 'flex-col', paddingClass.value, props.gap].filter(Boolean)
+  return [
+    'w-full',
+    'max-w-7xl',
+    'mx-auto',
+    'flex',
+    'flex-col',
+    paddingClass.value,
+    props.gap,
+  ].filter(Boolean)
 })
 </script>

--- a/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
+++ b/frontend/src/components/layout/__tests__/BasePageLayout.spec.ts
@@ -6,7 +6,10 @@ import BasePageLayout from '../BasePageLayout.vue'
 describe('BasePageLayout', () => {
   it('renders with default padding and gap', () => {
     const wrapper = mount(BasePageLayout)
-    expect(wrapper.classes()).toContain('p-6')
+    expect(wrapper.classes()).toContain('px-4')
+    expect(wrapper.classes()).toContain('sm:px-6')
+    expect(wrapper.classes()).toContain('lg:px-8')
+    expect(wrapper.classes()).toContain('py-6')
     expect(wrapper.classes()).toContain('gap-6')
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -14,12 +17,12 @@ describe('BasePageLayout', () => {
   it('applies custom padding', () => {
     const wrapper = mount(BasePageLayout, { props: { padding: 'p-2' } })
     expect(wrapper.classes()).toContain('p-2')
-    expect(wrapper.classes()).not.toContain('p-6')
+    expect(wrapper.classes()).not.toContain('px-4')
   })
 
   it('can disable padding', () => {
     const wrapper = mount(BasePageLayout, { props: { padding: false } })
-    expect(wrapper.classes()).not.toContain('p-6')
+    expect(wrapper.classes()).not.toContain('px-4')
   })
 
   it('applies gap prop', () => {

--- a/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/BasePageLayout.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BasePageLayout > renders with default padding and gap 1`] = `"<div class="flex flex-col p-6 gap-6"></div>"`;
+exports[`BasePageLayout > renders with default padding and gap 1`] = `"<div class="w-full max-w-7xl mx-auto flex flex-col px-4 sm:px-6 lg:px-8 py-6 gap-6"></div>"`;

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -1,5 +1,6 @@
+<!-- Accounts.vue - Manage linked accounts and related actions. -->
 <template>
-  <div class="accounts-page container space-y-8">
+  <BasePageLayout class="accounts-page" gap="gap-8">
     <!-- Header -->
     <Card class="p-6 flex items-center gap-3">
       <Wallet class="w-6 h-6" />
@@ -98,7 +99,7 @@
     <footer class="mt-12 text-center text-sm text-muted border-t pt-4">
       &copy; good dashroad.
     </footer>
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
@@ -115,6 +116,8 @@ import { formatAmount } from '@/utils/format'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import TogglePanel from '@/components/ui/TogglePanel.vue'
+
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 
 // Business Components
 import LinkAccount from '@/components/forms/LinkAccount.vue'

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -4,7 +4,7 @@
 -->
 <template>
   <AppLayout>
-    <div class="container">
+    <BasePageLayout gap="gap-8">
       <!-- WELCOME HEADER CARD -->
       <div class="w-20 h-3 rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
       <div class="flex justify-center mb-8">
@@ -17,7 +17,6 @@
       </div>
       </div>
       <div class="w-20 h-3 rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
-      <div class="dashboard-content flex flex-col gap-8 w-full max-w-7xl mx-auto px-2">
       <!-- TOP ROW: Top Accounts Snapshot & Net Income -->
       <div class="flex flex-col md:flex-row gap-6 justify-center items-stretch">
         <!-- Top Accounts Snapshot Card -->
@@ -152,7 +151,6 @@
           </div>
         </transition>
       </div>
-    </div>
 
     <TransactionModal
       :show="showModal"
@@ -160,7 +158,7 @@
       :transactions="modalTransactions"
       @close="showModal = false"
     />
-  </div>
+    </BasePageLayout>
 
     <template #footer>
       &copy; {{ new Date().getFullYear() }} braydio • pyNance.
@@ -173,6 +171,7 @@
 <script setup>
 // Dashboard view showing financial charts and transaction tables.
 import AppLayout from '@/components/layout/AppLayout.vue'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import DailyNetChart from '@/components/charts/DailyNetChart.vue'
 import CategoryBreakdownChart from '@/components/charts/CategoryBreakdownChart.vue'
 import ChartWidgetTopBar from '@/components/ui/ChartWidgetTopBar.vue'
@@ -382,17 +381,6 @@ async function onCategoryBarClick(payload) {
   color: var(--color-text-muted);
 }
 
-dashboard-content {
-  max-width: 90vw;
-}
-
-@media (max-width: 768px) {
-  .dashboard-content {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-    gap: 1.5rem;
-  }
-}
 
 .fade-enter-active,
 .fade-leave-active {

--- a/frontend/src/views/Forecast.vue
+++ b/frontend/src/views/Forecast.vue
@@ -1,10 +1,12 @@
+<!-- Forecast.vue - Entry point for forecasting dashboard. -->
 <template>
-  <div class="forecast-view">
+  <BasePageLayout class="forecast-view">
     <ForecastLayout />
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import ForecastLayout from '@/components/forecast/ForecastLayout.vue'
 </script>
 
@@ -14,9 +16,5 @@ import ForecastLayout from '@/components/forecast/ForecastLayout.vue'
   background-color: var(--page-bg);
   color: var(--theme-fg);
   min-height: 100vh;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
 }
 </style>

--- a/frontend/src/views/Institutions.vue
+++ b/frontend/src/views/Institutions.vue
@@ -1,22 +1,26 @@
+<!-- Institutions.vue - Overview of linked institutions and accounts. -->
 <template>
   <AppLayout>
     <template #header>
-      <div class="container text-center p-4 rounded-lg shadow-md bg-[var(--color-bg)]">
-        <h1 class="text-3xl font-bold text-[var(--color-accent-cyan)]">Institutions</h1>
-        <p class="text-sm text-muted">Overview of all linked providers and accounts</p>
-      </div>
+      <BasePageLayout>
+        <div class="text-center p-4 rounded-lg shadow-md bg-[var(--color-bg)]">
+          <h1 class="text-3xl font-bold text-[var(--color-accent-cyan)]">Institutions</h1>
+          <p class="text-sm text-muted">Overview of all linked providers and accounts</p>
+        </div>
+      </BasePageLayout>
     </template>
-    <div class="container space-y-6">
+    <BasePageLayout>
       <section>
         <InstitutionTable />
       </section>
-    </div>
+    </BasePageLayout>
   </AppLayout>
 </template>
 
 <script setup>
 // Basic institutions page showing existing InstitutionTable
 // Advanced analytics and management features will be added incrementally.
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import InstitutionTable from '@/components/tables/InstitutionTable.vue'
 </script>
 

--- a/frontend/src/views/Investments.vue
+++ b/frontend/src/views/Investments.vue
@@ -1,13 +1,14 @@
+<!-- Investments.vue - Skeleton layout for the future Investments dashboard. -->
 <template>
-  <div class="investments-view">
-    <h1 class="text-2xl font-bold mb-4">Investments</h1>
+  <BasePageLayout class="investments-view">
+    <h1 class="text-2xl font-bold">Investments</h1>
 
-    <section class="mb-6">
+    <section>
       <h2 class="text-xl font-semibold mb-2">Portfolio Overview</h2>
       <p class="text-muted">Key portfolio metrics will appear here.</p>
     </section>
 
-    <section class="mb-6">
+    <section>
       <h2 class="text-xl font-semibold mb-2">Holdings</h2>
       <p class="text-muted">Table of holdings placeholder.</p>
     </section>
@@ -16,7 +17,7 @@
       <h2 class="text-xl font-semibold mb-2">Performance</h2>
       <p class="text-muted">Charts and performance indicators placeholder.</p>
     </section>
-  </div>
+  </BasePageLayout>
 </template>
 
 <script setup>
@@ -24,6 +25,7 @@
  * Skeleton layout for the future Investments dashboard.
  * Replace placeholders with real data and components.
  */
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 </script>
 
 <style scoped>
@@ -33,6 +35,5 @@
   background-color: var(--page-bg);
   color: var(--theme-fg);
   min-height: 100vh;
-  padding: 1.5rem;
 }
 </style>

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -1,5 +1,6 @@
+<!-- Transactions.vue - View and manage transactions. -->
 <template>
-  <div class="transactions-page container py-8 space-y-8">
+  <BasePageLayout class="transactions-page" gap="gap-8" padding="px-4 sm:px-6 lg:px-8 py-8">
     <!-- Header -->
     <PageHeader>
       <template #icon>
@@ -51,7 +52,7 @@
         </div>
       </transition>
     </Card>
-  </div>
+  </BasePageLayout>
 </template>
 
 <script>
@@ -67,6 +68,7 @@ import PageHeader from '@/components/ui/PageHeader.vue'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import { CreditCard } from 'lucide-vue-next'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 
 export default {
   name: 'TransactionsView',
@@ -78,6 +80,7 @@ export default {
     UiButton,
     Card,
     CreditCard,
+    BasePageLayout,
   },
   setup() {
     const {

--- a/frontend/src/views/__tests__/Accounts.spec.js
+++ b/frontend/src/views/__tests__/Accounts.spec.js
@@ -30,7 +30,8 @@ describe('Accounts.vue', () => {
           'AccountsReorderChart',
           'Button',
           'Card',
-          'Wallet'
+          'Wallet',
+          'BasePageLayout'
         ]
       }
     })

--- a/frontend/src/views/__tests__/Transactions.spec.js
+++ b/frontend/src/views/__tests__/Transactions.spec.js
@@ -11,7 +11,7 @@ describe('Transactions.vue', () => {
   it('matches snapshot', () => {
     const wrapper = shallowMount(Transactions, {
       global: {
-        stubs: ['ImportFileSelector', 'UpdateTransactionsTable', 'RecurringTransactionSection', 'Button', 'Card', 'CreditCard']
+        stubs: ['ImportFileSelector', 'UpdateTransactionsTable', 'RecurringTransactionSection', 'Button', 'Card', 'CreditCard', 'BasePageLayout']
       }
     })
     expect(wrapper.html()).toMatchSnapshot()

--- a/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
@@ -1,22 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Accounts.vue > matches snapshot 1`] = `
-"<div class="accounts-page container space-y-8">
-  <!-- Header -->
-  <card-stub class="p-6 flex items-center gap-3"></card-stub><!-- Account Actions -->
-  <card-stub class="p-6"></card-stub><!-- Net Change Summary -->
-  <card-stub class="p-6"></card-stub><!-- Balance History -->
-  <card-stub class="p-6 space-y-4"></card-stub><!-- Recent Transactions -->
-  <card-stub class="p-6 space-y-4"></card-stub><!-- Charts -->
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold">Account Analysis</h2>
-    <div class="flex flex-col gap-6">
-      <card-stub class="p-6"></card-stub>
-      <card-stub class="p-6"></card-stub>
-      <card-stub class="p-6"></card-stub>
-    </div>
-  </section><!-- Accounts Table -->
-  <card-stub class="p-6"></card-stub><!-- Footer -->
-  <footer class="mt-12 text-center text-sm text-muted border-t pt-4"> © good dashroad. </footer>
-</div>"
-`;
+exports[`Accounts.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="true" gap="gap-8" class="accounts-page"></base-page-layout-stub>"`;

--- a/frontend/src/views/__tests__/__snapshots__/Transactions.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Transactions.spec.js.snap
@@ -1,15 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Transactions.vue > matches snapshot 1`] = `
-"<div class="transactions-page container py-8 space-y-8">
-  <!-- Header -->
-  <page-header-stub></page-header-stub><!-- Top Controls -->
-  <card-stub class="p-6"></card-stub><!-- Main Table -->
-  <card-stub class="p-6 space-y-4"></card-stub><!-- Pagination -->
-  <div id="pagination-controls" class="flex items-center justify-center gap-4">
-    <button-stub variant="outline" pill="false" disabled="true"></button-stub><span class="text-muted">Page 1 of 1</span>
-    <button-stub variant="primary" pill="false" disabled="true"></button-stub>
-  </div><!-- Recurring Transactions -->
-  <card-stub class="p-6 space-y-4"></card-stub>
-</div>"
-`;
+exports[`Transactions.vue > matches snapshot 1`] = `"<base-page-layout-stub padding="px-4 sm:px-6 lg:px-8 py-8" gap="gap-8" class="transactions-page"></base-page-layout-stub>"`;


### PR DESCRIPTION
## Summary
- enforce clamped width and responsive gutters in `BasePageLayout`
- rely on `BasePageLayout` for width/padding across Dashboard and other views
- update unit tests and snapshots for new layout defaults

## Testing
- `npm run lint`
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_68aad0ccea4c83298787b46f9f13983b