### PR TITLE
refactor(ui): redesign PageHeader with icon prop

### DIFF
--- a/docs/frontend/PageHeader.md
+++ b/docs/frontend/PageHeader.md
@@ -1,19 +1,18 @@
 # PageHeader Component
 
-Standard page header used at the top of views. Provides slots for an optional icon, title, subtitle, and an `actions` area on the right.
+Standard page header used at the top of views. Centers title and subtitle with an optional icon and `actions` area aligned to the right.
+
+## Props
+- `icon` – optional icon component rendered on the right
 
 ## Slots
-- `icon` – optional leading icon
 - `title` – main heading text
 - `subtitle` – supporting description text
 - `actions` – optional right‑aligned controls (e.g. buttons)
 
 ## Example
 ```vue
-<PageHeader>
-  <template #icon>
-    <CreditCard class="w-6 h-6" />
-  </template>
+<PageHeader :icon="CreditCard">
   <template #title>Transactions</template>
   <template #subtitle>View and manage your transactions</template>
   <template #actions>

--- a/docs/frontend/PageLayout.md
+++ b/docs/frontend/PageLayout.md
@@ -19,15 +19,12 @@ Wrap each top-level view with `BasePageLayout` to apply flex column layout and s
 
 ## PageHeader
 
-Standard header used within `BasePageLayout`. Provides slots for an optional icon, title, subtitle, and right-aligned actions.
+Standard header used within `BasePageLayout`. Centers the title/subtitle stack and supports an optional icon prop with right-aligned `actions` slot.
 
 ### Example: icon and subtitle
 ```vue
 <BasePageLayout>
-  <PageHeader>
-    <template #icon>
-      <SettingsIcon class="w-6 h-6" />
-    </template>
+  <PageHeader :icon="SettingsIcon">
     <template #title>Settings</template>
     <template #subtitle>Update your preferences</template>
     <template #actions>
@@ -39,7 +36,7 @@ Standard header used within `BasePageLayout`. Provides slots for an optional ico
 </BasePageLayout>
 ```
 
-Refer to [PageHeader docs](PageHeader.md) for additional slot details.
+Refer to [PageHeader docs](PageHeader.md) for prop and slot details.
 
 ## Contributor guidance
 

--- a/frontend/src/components/ui/PageHeader.vue
+++ b/frontend/src/components/ui/PageHeader.vue
@@ -1,17 +1,16 @@
 <template>
   <Card class="p-6 flex items-center">
-    <div class="flex items-center gap-3 flex-1">
-      <slot name="icon" />
-      <div>
-        <h1 class="text-2xl font-bold">
-          <slot name="title" />
-        </h1>
-        <p class="text-muted">
-          <slot name="subtitle" />
-        </p>
-      </div>
+    <div class="flex-1" />
+    <div class="text-center">
+      <h1 class="text-2xl font-bold">
+        <slot name="title" />
+      </h1>
+      <p v-if="$slots.subtitle" class="text-muted">
+        <slot name="subtitle" />
+      </p>
     </div>
-    <div v-if="$slots.actions" class="flex items-center gap-2 ml-auto">
+    <div class="flex-1 flex items-center justify-end gap-2">
+      <component v-if="icon" :is="icon" class="w-6 h-6" />
       <slot name="actions" />
     </div>
   </Card>
@@ -20,13 +19,22 @@
 <script setup>
 /**
  * PageHeader
- * Standard card header for views with an optional actions slot.
+ * Standard card header for views with an optional actions slot and trailing icon.
+ *
+ * Props:
+ * - icon: optional icon component rendered on the right
  *
  * Slots:
- * - icon: optional leading icon
  * - title: main heading text
  * - subtitle: supporting description text
  * - actions: optional right-aligned action controls
  */
 import Card from '@/components/ui/Card.vue'
+
+defineProps({
+  icon: {
+    type: [String, Object],
+    default: null
+  }
+})
 </script>

--- a/frontend/src/components/ui/__tests__/PageHeader.spec.ts
+++ b/frontend/src/components/ui/__tests__/PageHeader.spec.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import PageHeader from '../PageHeader.vue'
+import { defineComponent } from 'vue'
 
 describe('PageHeader', () => {
   it('renders title slot', () => {
@@ -13,11 +14,12 @@ describe('PageHeader', () => {
   })
 
   it('renders optional subtitle and icon', () => {
+    const Icon = defineComponent({ template: '<span class="icon" />' })
     const wrapper = mount(PageHeader, {
+      props: { icon: Icon },
       slots: {
         title: 'Accounts',
-        subtitle: 'Overview',
-        icon: '<span class="icon" />'
+        subtitle: 'Overview'
       }
     })
     expect(wrapper.find('p').text()).toBe('Overview')

--- a/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/PageHeader.spec.ts.snap
@@ -2,12 +2,13 @@
 
 exports[`PageHeader > renders title slot 1`] = `
 "<div class="card glass p-6 flex items-center">
-  <div class="flex items-center gap-3 flex-1">
-    <div>
-      <h1 class="text-2xl font-bold">Dashboard</h1>
-      <p class="text-muted"></p>
-    </div>
+  <div class="flex-1"></div>
+  <div class="text-center">
+    <h1 class="text-2xl font-bold">Dashboard</h1>
+    <!--v-if-->
   </div>
-  <!--v-if-->
+  <div class="flex-1 flex items-center justify-end gap-2">
+    <!--v-if-->
+  </div>
 </div>"
 `;

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -1,14 +1,10 @@
 <!-- Accounts.vue - Manage linked accounts and related actions. -->
 <template>
   <BasePageLayout class="accounts-page" gap="gap-8">
-    <!-- Header -->
-    <Card class="p-6 flex items-center gap-3">
-      <Wallet class="w-6 h-6" />
-      <div>
-        <h1 class="text-2xl font-bold">Accounts</h1>
-        <p class="text-muted">Link and refresh your accounts</p>
-      </div>
-    </Card>
+    <PageHeader :icon="Wallet">
+      <template #title>Accounts</template>
+      <template #subtitle>Link and refresh your accounts</template>
+    </PageHeader>
 
     <!-- Account Actions -->
     <Card class="p-6">
@@ -116,6 +112,7 @@ import { formatAmount } from '@/utils/format'
 import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import TogglePanel from '@/components/ui/TogglePanel.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
 
 import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 

--- a/frontend/src/views/ArbitrageLive.vue
+++ b/frontend/src/views/ArbitrageLive.vue
@@ -1,9 +1,6 @@
 <template>
   <BasePageLayout>
-    <PageHeader>
-      <template #icon>
-        <Activity class="w-6 h-6" />
-      </template>
+    <PageHeader :icon="Activity">
       <template #title>R/S Arbitrage Monitor</template>
       <template #subtitle>Live R/S arbitrage feed</template>
     </PageHeader>

--- a/frontend/src/views/Forecast.vue
+++ b/frontend/src/views/Forecast.vue
@@ -1,6 +1,10 @@
 <!-- Forecast.vue - Entry point for forecasting dashboard. -->
 <template>
   <BasePageLayout class="forecast-view">
+    <PageHeader :icon="LineChart">
+      <template #title>Forecast</template>
+      <template #subtitle>Project your financial future</template>
+    </PageHeader>
     <ForecastLayout />
   </BasePageLayout>
 </template>
@@ -8,6 +12,8 @@
 <script setup>
 import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import ForecastLayout from '@/components/forecast/ForecastLayout.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import { LineChart } from 'lucide-vue-next'
 </script>
 
 <style scoped>

--- a/frontend/src/views/Planning.vue
+++ b/frontend/src/views/Planning.vue
@@ -1,9 +1,6 @@
 <template>
   <BasePageLayout>
-    <PageHeader>
-      <template #icon>
-        <Calendar class="w-6 h-6" />
-      </template>
+    <PageHeader :icon="Calendar">
       <template #title>Planning</template>
       <template #subtitle>Manage your budgeting and allocations</template>
     </PageHeader>

--- a/frontend/src/views/RecurringScanDemo.vue
+++ b/frontend/src/views/RecurringScanDemo.vue
@@ -1,9 +1,6 @@
 <template>
   <BasePageLayout>
-    <PageHeader>
-      <template #icon>
-        <Repeat class="w-6 h-6" />
-      </template>
+    <PageHeader :icon="Repeat">
       <template #title>Recurring Scan Demo</template>
       <template #subtitle>Demo results for recurring transaction scan</template>
     </PageHeader>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1,9 +1,6 @@
 <template>
   <BasePageLayout>
-    <PageHeader>
-      <template #icon>
-        <SettingsIcon class="w-6 h-6" />
-      </template>
+    <PageHeader :icon="SettingsIcon">
       <template #title>Settings</template>
       <template #subtitle>Manage application preferences</template>
     </PageHeader>
@@ -28,12 +25,12 @@ export default {
   components: {
     BasePageLayout,
     PageHeader,
-    SettingsIcon,
   },
   data() {
     return {
       themes: [],
       selectedTheme: '',
+      SettingsIcon,
     }
   },
   async created() {

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -2,10 +2,7 @@
 <template>
   <BasePageLayout class="transactions-page" gap="gap-8" padding="px-4 sm:px-6 lg:px-8 py-8">
     <!-- Header -->
-    <PageHeader>
-      <template #icon>
-        <CreditCard class="w-6 h-6" />
-      </template>
+    <PageHeader :icon="CreditCard">
       <template #title>Transactions</template>
       <template #subtitle>View and manage your transactions</template>
       <template #actions>
@@ -79,7 +76,6 @@ export default {
     PageHeader,
     UiButton,
     Card,
-    CreditCard,
     BasePageLayout,
   },
   setup() {
@@ -119,6 +115,7 @@ export default {
       showRecurring,
       recurringFormRef,
       prefillRecurringFromTransaction,
+      CreditCard,
     }
   },
 }


### PR DESCRIPTION
## Summary
- center PageHeader titles and move icon/actions to the right via new `icon` prop
- document new PageHeader API and layout usage
- update views to pass icons via prop and use header `actions` slot

## Testing
- `npm run lint`
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_68aad655a5ac8329945ea3f28cc68766