### PR TITLE
feat(transactions): restyle transfer scanner

### DIFF
--- a/frontend/cypress/e2e/transactions.cy.js
+++ b/frontend/cypress/e2e/transactions.cy.js
@@ -1,0 +1,22 @@
+// transactions.cy.js - tests for transactions view
+
+describe('Transactions View', () => {
+  it('toggles internal transfer scanner', () => {
+    cy.visit('/transactions')
+
+    // Scanner hidden by default
+    cy.contains('Internal Transfer Scanner')
+    cy.contains('button', 'Show').should('exist')
+    cy.contains('Scan').should('not.exist')
+
+    // Show scanner
+    cy.contains('button', 'Show').click()
+    cy.contains('button', 'Hide').should('exist')
+    cy.contains('Scan').should('exist')
+
+    // Hide again
+    cy.contains('button', 'Hide').click()
+    cy.contains('Scan').should('not.exist')
+  })
+})
+

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import './theme.css';
+@import '../../styles/animations.css';
 
 /* Tailwind Directives */
 @import 'tailwindcss/preflight';

--- a/frontend/src/components/transactions/InternalTransferScanner.vue
+++ b/frontend/src/components/transactions/InternalTransferScanner.vue
@@ -1,9 +1,8 @@
 <!-- InternalTransferScanner.vue - Detect and confirm internal transfer pairs -->
 <template>
-  <Card class="p-6 space-y-4">
-    <div class="flex items-center justify-between">
-      <h2 class="text-2xl font-bold">Internal Transfers</h2>
-      <UiButton @click="scan" :disabled="loading">
+  <div class="space-y-4">
+    <div class="flex justify-end">
+      <UiButton size="sm" @click="scan" :disabled="loading">
         {{ loading ? 'Scanning...' : 'Scan' }}
       </UiButton>
     </div>
@@ -11,13 +10,13 @@
       <div
         v-for="pair in pairs"
         :key="pair.transaction_id"
-        class="flex items-start justify-between border p-4 rounded"
+        class="flex items-start justify-between border p-4 rounded-md"
       >
         <div class="text-sm">
           <p class="font-medium">
             {{ pair.description }} ({{ formatAmount(pair.amount) }})
           </p>
-          <p class="text-muted">
+          <p class="text-gray-500">
             ↔
             {{ pair.counterpart.description }}
             ({{ formatAmount(pair.counterpart.amount) }})
@@ -26,15 +25,16 @@
         <UiButton variant="primary" @click="confirm(pair)">Mark Internal</UiButton>
       </div>
     </div>
-    <p v-else-if="scanned" class="text-muted">No internal transfers found.</p>
-  </Card>
+    <p v-else-if="scanned" class="text-sm text-gray-500">
+      No internal transfers found.
+    </p>
+  </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
 import api from '@/services/api.js'
 import UiButton from '@/components/ui/Button.vue'
-import Card from '@/components/ui/Card.vue'
 import { formatAmount } from '@/utils/format'
 
 const pairs = ref([])
@@ -70,10 +70,4 @@ async function confirm(pair) {
   }
 }
 </script>
-
-<style scoped>
-.text-muted {
-  color: var(--color-text-muted);
-}
-</style>
 

--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1,0 +1,13 @@
+/* animations.css - shared animation utilities */
+
+.accordion-enter-active,
+.accordion-leave-active {
+  transition: all 250ms ease-in-out;
+}
+
+.accordion-enter-from,
+.accordion-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -36,7 +36,25 @@
     </div>
 
     <!-- Internal Transfer Detection -->
-    <InternalTransferScanner />
+    <Card class="p-6 rounded-2xl shadow-sm bg-white dark:bg-gray-800">
+      <div class="flex items-center justify-between">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          Internal Transfer Scanner
+        </h2>
+        <UiButton
+          variant="outline"
+          size="sm"
+          @click="showScanner = !showScanner"
+        >
+          {{ showScanner ? 'Hide' : 'Show' }}
+        </UiButton>
+      </div>
+      <transition name="accordion">
+        <div v-if="showScanner" class="mt-4">
+          <InternalTransferScanner />
+        </div>
+      </transition>
+    </Card>
 
     <!-- Recurring Transactions -->
     <Card class="p-6 space-y-4">
@@ -95,6 +113,7 @@ export default {
       setSort,
     } = useTransactions(15)
 
+    const showScanner = ref(false)
     const showRecurring = ref(false)
     const recurringFormRef = ref(null)
 
@@ -117,6 +136,7 @@ export default {
       sortKey,
       sortOrder,
       setSort,
+      showScanner,
       showRecurring,
       recurringFormRef,
       prefillRecurringFromTransaction,


### PR DESCRIPTION
## Summary
- style the internal transfer scanner with card wrapper and accordion animation
- streamline scanner component layout
- add cypress test for scanner toggle

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: process hung while starting server)*

------
https://chatgpt.com/codex/tasks/task_e_68aaee3f09d88329ba398cb0043ffc48