### PR TITLE
feat(dashboard): extract chart trend controls

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -26,6 +26,7 @@ declare module 'vue' {
     CardContent: typeof import('./components/ui/CardContent.vue')['default']
     CategoryBreakdownChart: typeof import('./components/charts/CategoryBreakdownChart.vue')['default']
     Chart: typeof import('./components/unused/Chart.vue')['default']
+    ChartControls: typeof import('./components/ChartControls.vue')['default']
     ChartWidgetTopBar: typeof import('./components/ui/ChartWidgetTopBar.vue')['default']
     DailyNetChart: typeof import('./components/charts/DailyNetChart.vue')['default']
     DownloadCSV: typeof import('./components/unused/DownloadCSV.vue')['default']

--- a/frontend/src/components/ChartControls.vue
+++ b/frontend/src/components/ChartControls.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="chart-controls">
+    <label><input type="checkbox" :checked="show7Day" @change="emit('update:show7Day', $event.target.checked)" /> 7d trend</label>
+    <label><input type="checkbox" :checked="show30Day" @change="emit('update:show30Day', $event.target.checked)" /> 30d trend</label>
+    <label><input type="checkbox" :checked="showAvgIncome" @change="emit('update:showAvgIncome', $event.target.checked)" /> avg income</label>
+    <label><input type="checkbox" :checked="showAvgExpenses" @change="emit('update:showAvgExpenses', $event.target.checked)" /> avg expenses</label>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Checkbox controls for toggling trend and average lines on charts.
+ */
+import { toRefs } from 'vue'
+
+const props = defineProps({
+  show7Day: { type: Boolean, default: false },
+  show30Day: { type: Boolean, default: false },
+  showAvgIncome: { type: Boolean, default: false },
+  showAvgExpenses: { type: Boolean, default: false }
+})
+const emit = defineEmits(['update:show7Day', 'update:show30Day', 'update:showAvgIncome', 'update:showAvgExpenses'])
+const { show7Day, show30Day, showAvgIncome, showAvgExpenses } = toRefs(props)
+</script>
+
+<style scoped>
+.chart-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chart-controls label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+</style>
+

--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="daily-net-chart">
-    <div class="chart-controls">
-      <label><input type="checkbox" v-model="show7Day" /> 7d trend</label>
-      <label><input type="checkbox" v-model="show30Day" /> 30d trend</label>
-      <label><input type="checkbox" v-model="showAvgIncome" /> avg income</label>
-      <label><input type="checkbox" v-model="showAvgExpenses" /> avg expenses</label>
-    </div>
     <div style="height: 400px;">
       <canvas ref="chartCanvas" style="width: 100%; height: 100%;"></canvas>
     </div>
@@ -13,25 +7,27 @@
 </template>
 
 <script setup>
-// Displays income, expenses, and net totals for recent days. Expenses
-// are rendered as negative values so that red bars extend below the
-// X-axis while green income bars remain above it.
+// Displays income, expenses, and net totals for recent days. Trend and
+// average lines are controlled via props passed from the parent.
 import { fetchDailyNet } from '@/api/charts'
-import { ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick, watch, toRefs } from 'vue'
 import { Chart } from 'chart.js/auto'
 import { formatAmount } from "@/utils/format"
 
-const props = defineProps({ zoomedOut: { type: Boolean, default: false } })
+const props = defineProps({
+  zoomedOut: { type: Boolean, default: false },
+  show7Day: { type: Boolean, default: false },
+  show30Day: { type: Boolean, default: false },
+  showAvgIncome: { type: Boolean, default: false },
+  showAvgExpenses: { type: Boolean, default: false }
+})
+const { show7Day, show30Day, showAvgIncome, showAvgExpenses } = toRefs(props)
 // Emits "bar-click" when a bar is selected, "summary-change" when data totals change, and "data-change" when chart data updates
 const emit = defineEmits(['bar-click', 'summary-change', 'data-change'])
 
 const chartInstance = ref(null)
 const chartCanvas = ref(null)
 const chartData = ref([])
-const show7Day = ref(false)
-const show30Day = ref(false)
-const showAvgIncome = ref(false)
-const showAvgExpenses = ref(false)
 // Counts of days exceeding their respective averages; used for summary and chart annotations
 const aboveAvgIncomeDays = ref(0)
 const aboveAvgExpenseDays = ref(0)
@@ -242,7 +238,7 @@ async function renderChart() {
     options: {
       responsive: true,
       maintainAspectRatio: false,
-      layout: { padding: { top: 20, bottom: 20 } },
+      layout: { padding: { top: 20, bottom: 8 } },
       plugins: {
         tooltip: {
           callbacks: {
@@ -368,19 +364,3 @@ onUnmounted(() => {
 })
 </script>
 
-<style scoped>
-.chart-controls {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.chart-controls label {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-</style>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -49,7 +49,22 @@
               </ChartWidgetTopBar>
             </div>
           </div>
-          <DailyNetChart :zoomed-out="zoomedOut" @summary-change="netSummary = $event" @data-change="chartData = $event" @bar-click="onNetBarClick" />
+          <ChartControls
+            v-model:show7-day="show7Day"
+            v-model:show30-day="show30Day"
+            v-model:show-avg-income="showAvgIncome"
+            v-model:show-avg-expenses="showAvgExpenses"
+          />
+          <DailyNetChart
+            :zoomed-out="zoomedOut"
+            :show7-day="show7Day"
+            :show30-day="show30Day"
+            :show-avg-income="showAvgIncome"
+            :show-avg-expenses="showAvgExpenses"
+            @summary-change="netSummary = $event"
+            @data-change="chartData = $event"
+            @bar-click="onNetBarClick"
+          />
         </div>
       </div>
 
@@ -179,6 +194,7 @@ import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import DailyNetChart from '@/components/charts/DailyNetChart.vue'
 import CategoryBreakdownChart from '@/components/charts/CategoryBreakdownChart.vue'
 import ChartWidgetTopBar from '@/components/ui/ChartWidgetTopBar.vue'
+import ChartControls from '@/components/ChartControls.vue'
 import AccountsTable from '@/components/tables/AccountsTable.vue'
 import TransactionsTable from '@/components/tables/TransactionsTable.vue'
 import PaginationControls from '@/components/tables/PaginationControls.vue'
@@ -239,6 +255,10 @@ const netSummary = ref({
 })
 const chartData = ref([])
 const zoomedOut = ref(false)
+const show7Day = ref(false)
+const show30Day = ref(false)
+const showAvgIncome = ref(false)
+const showAvgExpenses = ref(false)
 
 // --- CATEGORY BREAKDOWN STATE ---
 const today = new Date()


### PR DESCRIPTION
## Summary
- create reusable `ChartControls` component to manage trend and average toggles
- wire `DailyNetChart` to accept control props and reduce bottom padding
- embed `ChartControls` in `Dashboard` to drive `DailyNetChart`

## Testing
- `npm test`
- `pytest -q` *(fails: unrecognized arguments: --flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68aaec483c5c83298e6627a1e35b7db0