### PR TITLE
feat: add global date range selector for dashboard charts

### DIFF
--- a/frontend/src/components/DateRangeSelector.vue
+++ b/frontend/src/components/DateRangeSelector.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="flex items-center gap-2">
+    <input
+      type="date"
+      :value="startDate"
+      @input="onStart($event.target.value)"
+      class="date-picker px-2 py-1 rounded border border-[var(--divider)] bg-[var(--theme-bg)] text-[var(--color-text-light)] focus:ring-2 focus:ring-[var(--color-accent-cyan)]"
+    />
+    <input
+      type="date"
+      :value="endDate"
+      @input="onEnd($event.target.value)"
+      class="date-picker px-2 py-1 rounded border border-[var(--divider)] bg-[var(--theme-bg)] text-[var(--color-text-light)] focus:ring-2 focus:ring-[var(--color-accent-cyan)]"
+    />
+    <button
+      v-if="!disableZoom"
+      class="btn btn-outline hover-lift ml-2"
+      :disabled="disableZoom"
+      @click="toggleZoom"
+    >
+      {{ zoomedOut ? 'Zoom In' : 'Zoom Out' }}
+    </button>
+  </div>
+</template>
+
+<script setup>
+/**
+ * DateRangeSelector
+ * Provides start/end date inputs and a zoom toggle for switching
+ * between detailed and aggregated chart views.
+ */
+import { toRefs } from 'vue'
+
+const props = defineProps({
+  startDate: { type: String, required: true },
+  endDate: { type: String, required: true },
+  zoomedOut: { type: Boolean, default: false },
+  disableZoom: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:startDate', 'update:endDate', 'update:zoomedOut'])
+const { startDate, endDate, zoomedOut, disableZoom } = toRefs(props)
+
+function onStart(val) {
+  emit('update:startDate', val)
+}
+function onEnd(val) {
+  emit('update:endDate', val)
+}
+function toggleZoom() {
+  if (disableZoom.value) return
+  emit('update:zoomedOut', !zoomedOut.value)
+}
+</script>
+
+<style scoped>
+.date-picker {
+  min-width: 10rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add reusable `DateRangeSelector` with start/end inputs and zoom toggle
- wire selector into dashboard and propagate range to charts
- update `DailyNetChart` to honor passed range and aggregated view

## Testing
- `SKIP=model-field-validation pre-commit run --files frontend/src/components/DateRangeSelector.vue frontend/src/views/Dashboard.vue frontend/src/components/charts/DailyNetChart.vue`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab117c2eac83299668b6f5030bd040