### PR TITLE
feat(summary): add advanced financial metrics

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -32,6 +32,7 @@ def create_app():
     from app.routes.plaid_transactions import plaid_transactions
     from app.routes.recurring import recurring
     from app.routes.rules import rules as rules_bp
+    from app.routes.summary import summary
     from app.routes.teller import link_teller
     from app.routes.teller_transactions import teller_transactions
     from app.routes.teller_webhook import disabled_webhooks, webhooks
@@ -56,6 +57,7 @@ def create_app():
     app.register_blueprint(link_teller, url_prefix="/api/teller")
     app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
     app.register_blueprint(institutions, url_prefix="/api/institutions")
+    app.register_blueprint(summary, url_prefix="/api/summary")
 
     if TELLER_WEBHOOK_SECRET:
         app.register_blueprint(webhooks, url_prefix="/api/webhooks")

--- a/backend/app/routes/summary.py
+++ b/backend/app/routes/summary.py
@@ -1,0 +1,133 @@
+"""Routes providing aggregate financial summary metrics."""
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+from app.extensions import db
+from app.models import Account, Transaction
+from flask import Blueprint, jsonify, request
+from sqlalchemy import case, func, or_
+
+summary = Blueprint("summary", __name__)
+
+
+@summary.route("/financial", methods=["GET"])
+def financial_summary() -> tuple[Any, int]:
+    """Return income, expense and net statistics for the given date range."""
+    start_date_str = request.args.get("start_date")
+    end_date_str = request.args.get("end_date")
+
+    try:
+        if start_date_str:
+            start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+        else:
+            start_date = datetime.now().date() - timedelta(days=30)
+        if end_date_str:
+            end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+        else:
+            end_date = datetime.now().date()
+
+        rows = (
+            db.session.query(
+                Transaction.date.label("date"),
+                func.sum(
+                    case((Transaction.amount > 0, Transaction.amount), else_=0)
+                ).label("income"),
+                func.sum(
+                    case(
+                        (Transaction.amount < 0, func.abs(Transaction.amount)), else_=0
+                    )
+                ).label("expenses"),
+                func.sum(Transaction.amount).label("net"),
+            )
+            .join(Account, Transaction.account_id == Account.account_id)
+            .filter((Account.is_hidden.is_(False)) | (Account.is_hidden.is_(None)))
+            .filter(
+                or_(
+                    Transaction.is_internal.is_(False),
+                    Transaction.is_internal.is_(None),
+                )
+            )
+            .filter(Transaction.date >= start_date)
+            .filter(Transaction.date <= end_date)
+            .group_by(Transaction.date)
+            .order_by(Transaction.date)
+            .all()
+        )
+
+        if not rows:
+            empty = {
+                "totalIncome": 0,
+                "totalExpenses": 0,
+                "totalNet": 0,
+                "aboveAvgIncomeDays": 0,
+                "aboveAvgExpenseDays": 0,
+                "highestIncomeDay": None,
+                "highestExpenseDay": None,
+                "trend": 0,
+                "volatility": 0,
+                "outlierDates": [],
+            }
+            return jsonify({"status": "success", "data": empty}), 200
+
+        income_vals = [r.income or 0 for r in rows]
+        expense_vals = [r.expenses or 0 for r in rows]
+        net_vals = [r.net or 0 for r in rows]
+
+        total_income = sum(income_vals)
+        total_expenses = sum(expense_vals)
+        total_net = sum(net_vals)
+        days = len(rows)
+
+        avg_income = total_income / days
+        avg_expenses = total_expenses / days
+        above_income = sum(1 for v in income_vals if v > avg_income)
+        above_expense = sum(1 for v in expense_vals if v > avg_expenses)
+
+        max_income_idx = income_vals.index(max(income_vals))
+        max_expense_idx = expense_vals.index(max(expense_vals))
+        highest_income_day = {
+            "date": rows[max_income_idx].date.isoformat(),
+            "amount": income_vals[max_income_idx],
+        }
+        highest_expense_day = {
+            "date": rows[max_expense_idx].date.isoformat(),
+            "amount": expense_vals[max_expense_idx],
+        }
+
+        # Trend via simple linear regression slope
+        n = days
+        x = list(range(n))
+        sum_x = sum(x)
+        sum_y = sum(net_vals)
+        sum_xy = sum(x[i] * net_vals[i] for i in range(n))
+        sum_xx = sum(xi * xi for xi in x)
+        trend = (
+            (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x) if n > 1 else 0
+        )
+
+        mean_net = total_net / days
+        variance = sum((v - mean_net) ** 2 for v in net_vals) / days
+        volatility = variance**0.5
+        threshold = 2 * volatility
+        outlier_dates = [
+            rows[i].date.isoformat()
+            for i, v in enumerate(net_vals)
+            if abs(v - mean_net) > threshold
+        ]
+
+        data: Dict[str, Any] = {
+            "totalIncome": round(total_income, 2),
+            "totalExpenses": round(total_expenses, 2),
+            "totalNet": round(total_net, 2),
+            "aboveAvgIncomeDays": above_income,
+            "aboveAvgExpenseDays": above_expense,
+            "highestIncomeDay": highest_income_day,
+            "highestExpenseDay": highest_expense_day,
+            "trend": trend,
+            "volatility": volatility,
+            "outlierDates": outlier_dates,
+        }
+        return jsonify({"status": "success", "data": data}), 200
+
+    except Exception as exc:  # pragma: no cover - defensive
+        return jsonify({"status": "error", "message": str(exc)}), 500

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -14,6 +14,7 @@ import NetYearComparisonChart from '@/components/charts/NetYearComparisonChart.v
 import AccountsTable from '@/components/tables/AccountsTable.vue'
 import ForecastMock from '@/views/ForecastMock.vue'
 import RecurringScanDemo from '@/views/RecurringScanDemo.vue'
+import FinancialSummaryDetailed from '@/views/FinancialSummaryDetailed.vue'
 
 
 const Investments = () => import('../views/Investments.vue')
@@ -38,6 +39,7 @@ const routes = [
     name: 'RecurringScanDemo',
     component: RecurringScanDemo,
   },
+  { path: '/summary', name: 'FinancialSummaryDetailed', component: FinancialSummaryDetailed },
   { path: '/forecast-mock', name: 'ForecastMock', component: ForecastMock },
 
 ]

--- a/frontend/src/services/summary.js
+++ b/frontend/src/services/summary.js
@@ -1,0 +1,14 @@
+// summary.js
+// Helper for fetching financial summary metrics (totals, highest days, trend,
+// volatility and outlier dates) from the backend.
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL || '/api',
+  headers: { 'Content-Type': 'application/json' },
+})
+
+export async function fetchFinancialSummary(params = {}) {
+  const response = await apiClient.get('/summary/financial', { params })
+  return response.data
+}

--- a/frontend/src/views/FinancialSummaryDetailed.vue
+++ b/frontend/src/views/FinancialSummaryDetailed.vue
@@ -1,0 +1,39 @@
+<!-- FinancialSummaryDetailed.vue
+  Standalone view displaying DailyNetChart with expanded financial summary metrics.
+-->
+<template>
+  <BasePageLayout class="financial-summary-detailed" gap="gap-8">
+    <div class="flex justify-end mb-4">
+      <DateRangeSelector
+        v-model:start-date="dateRange.start"
+        v-model:end-date="dateRange.end"
+        v-model:zoomed-out="zoomedOut"
+      />
+    </div>
+    <DailyNetChart
+      :start-date="dateRange.start"
+      :end-date="dateRange.end"
+      :zoomed-out="zoomedOut"
+      @summary-change="summary = $event"
+      @data-change="chartData = $event"
+    />
+    <FinancialSummary
+      :summary="summary"
+      :chart-data="chartData"
+      :zoomed-out="zoomedOut"
+    />
+  </BasePageLayout>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import DateRangeSelector from '@/components/DateRangeSelector.vue'
+import DailyNetChart from '@/components/charts/DailyNetChart.vue'
+import FinancialSummary from '@/components/statistics/FinancialSummary.vue'
+
+const dateRange = ref({ start: '', end: '' })
+const zoomedOut = ref(false)
+const summary = ref({})
+const chartData = ref([])
+</script>


### PR DESCRIPTION
## Summary
- compute highest income/expense day, trend, volatility, and outliers in `FinancialSummary`
- expose detailed summary view and API service
- add backend `/summary/financial` endpoint and route

## Testing
- `pre-commit run --files backend/app/routes/summary.py backend/app/__init__.py`
- `npm test --prefix frontend`
- `pytest` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68ab13d816ec83299ebbf243f9c27b18