### PR TITLE
feat(summary): expand financial metrics and API

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -32,6 +32,7 @@ def create_app():
     from app.routes.plaid_transactions import plaid_transactions
     from app.routes.recurring import recurring
     from app.routes.rules import rules as rules_bp
+    from app.routes.summary import summary as summary_bp
     from app.routes.teller import link_teller
     from app.routes.teller_transactions import teller_transactions
     from app.routes.teller_webhook import disabled_webhooks, webhooks
@@ -56,6 +57,7 @@ def create_app():
     app.register_blueprint(link_teller, url_prefix="/api/teller")
     app.register_blueprint(teller_transactions, url_prefix="/api/teller/transactions")
     app.register_blueprint(institutions, url_prefix="/api/institutions")
+    app.register_blueprint(summary_bp, url_prefix="/api/summary")
 
     if TELLER_WEBHOOK_SECRET:
         app.register_blueprint(webhooks, url_prefix="/api/webhooks")

--- a/backend/app/routes/summary.py
+++ b/backend/app/routes/summary.py
@@ -1,0 +1,136 @@
+"""Financial summary API routes."""
+
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List
+
+from app.config import logger
+from app.extensions import db
+from app.models import Transaction
+from app.utils.finance_utils import display_transaction_amount
+from flask import Blueprint, jsonify, request
+
+summary = Blueprint("summary", __name__)
+
+
+def _calculate_trend(values: List[float]) -> float:
+    """Return slope of a simple linear regression for the provided values."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    x = list(range(n))
+    sum_x = sum(x)
+    sum_y = sum(values)
+    sum_xy = sum(xi * yi for xi, yi in zip(x, values))
+    sum_xx = sum(xi * xi for xi in x)
+    denominator = n * sum_xx - sum_x * sum_x
+    if denominator == 0:
+        return 0.0
+    return (n * sum_xy - sum_x * sum_y) / denominator
+
+
+def _calculate_volatility(values: List[float]) -> float:
+    """Return standard deviation of the provided values."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean = sum(values) / n
+    variance = sum((v - mean) ** 2 for v in values) / n
+    return variance**0.5
+
+
+def _detect_outliers(values: List[float], dates: List[str]) -> List[str]:
+    """Return dates where the net value deviates more than 2σ from the mean."""
+    if not values:
+        return []
+    mean = sum(values) / len(values)
+    std = _calculate_volatility(values)
+    if std == 0:
+        return []
+    return [d for d, v in zip(dates, values) if abs(v - mean) > 2 * std]
+
+
+@summary.route("/financial", methods=["GET"])
+def financial_summary() -> Any:
+    """Aggregate financial metrics for a date range.
+
+    Query Parameters:
+        start_date: optional ISO date string (YYYY-MM-DD)
+        end_date: optional ISO date string (YYYY-MM-DD)
+
+    Returns:
+        JSON payload containing totals, highest income/expense days,
+        trend slope, volatility, and outlier dates.
+    """
+    start_date_str = request.args.get("start_date")
+    end_date_str = request.args.get("end_date")
+
+    if start_date_str:
+        start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+    else:
+        start_date = (datetime.now() - timedelta(days=30)).date()
+    if end_date_str:
+        end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+    else:
+        end_date = datetime.now().date()
+
+    logger.info("[summary] start_date=%s end_date=%s", start_date, end_date)
+
+    transactions = (
+        db.session.query(Transaction)
+        .filter(Transaction.date >= start_date)
+        .filter(Transaction.date <= end_date)
+        .filter(
+            (Transaction.is_internal.is_(False)) | (Transaction.is_internal.is_(None))
+        )
+        .all()
+    )
+
+    day_map: Dict[str, Dict[str, float]] = defaultdict(
+        lambda: {"income": 0.0, "expenses": 0.0, "net": 0.0}
+    )
+    for tx in transactions:
+        tx_date = tx.date if isinstance(tx.date, date) else tx.date.date()
+        amount = display_transaction_amount(tx)
+        d = day_map[tx_date.strftime("%Y-%m-%d")]
+        if amount > 0:
+            d["income"] += amount
+        elif amount < 0:
+            d["expenses"] += amount
+        d["net"] += amount
+
+    daily = []
+    for day, values in sorted(day_map.items()):
+        daily.append({"date": day, **values})
+
+    total_income = sum(d["income"] for d in daily)
+    total_expenses = sum(d["expenses"] for d in daily)
+    total_net = sum(d["net"] for d in daily)
+
+    highest_income = max(daily, key=lambda d: d["income"], default=None)
+    highest_expense = min(daily, key=lambda d: d["expenses"], default=None)
+
+    net_values = [d["net"] for d in daily]
+    dates = [d["date"] for d in daily]
+    trend = _calculate_trend(net_values)
+    volatility = _calculate_volatility(net_values)
+    outliers = _detect_outliers(net_values, dates)
+
+    result = {
+        "totalIncome": round(total_income, 2),
+        "totalExpenses": round(total_expenses, 2),
+        "totalNet": round(total_net, 2),
+        "highestIncomeDay": {
+            "date": highest_income["date"] if highest_income else None,
+            "amount": round(highest_income["income"], 2) if highest_income else 0,
+        },
+        "highestExpenseDay": {
+            "date": highest_expense["date"] if highest_expense else None,
+            "amount": round(highest_expense["expenses"], 2) if highest_expense else 0,
+        },
+        "trend": trend,
+        "volatility": volatility,
+        "outliers": outliers,
+    }
+
+    return jsonify({"status": "success", "data": result}), 200

--- a/docs/backend/app/routes/summary.md
+++ b/docs/backend/app/routes/summary.md
@@ -1,15 +1,18 @@
 ## 📘 `summary.py`
 
-```markdown
+````markdown
 # Summary Route
 
 ## Purpose
+
 Aggregates income and expense transactions over a date range and derives higher level metrics for dashboard display.
 
 ## Key Endpoints
+
 - `GET /summary/financial` – totals and statistical metrics for the requested date window.
 
 ## Inputs & Outputs
+
 - **GET /summary/financial**
   - **Params:** optional `start_date`, `end_date` (YYYY-MM-DD)
   - **Output:**
@@ -30,15 +33,18 @@ Aggregates income and expense transactions over a date range and derives higher 
     ```
 
 ## Internal Dependencies
+
 - `models.Transaction`
 - `utils.finance_utils.display_transaction_amount`
 - SQLAlchemy via `extensions.db`
 
 ## Known Behaviors
+
 - Ignores internal transfers.
 - Defaults to the previous 30 days when no range is supplied.
 - Outliers flagged when net values deviate by more than two standard deviations.
 
 ## Related Docs
+
 - [`docs/frontend/FINANCIAL_SUMMARY.md`](../../frontend/FINANCIAL_SUMMARY.md)
-```
+````

--- a/docs/backend/app/routes/summary.md
+++ b/docs/backend/app/routes/summary.md
@@ -1,0 +1,44 @@
+## 📘 `summary.py`
+
+```markdown
+# Summary Route
+
+## Purpose
+Aggregates income and expense transactions over a date range and derives higher level metrics for dashboard display.
+
+## Key Endpoints
+- `GET /summary/financial` – totals and statistical metrics for the requested date window.
+
+## Inputs & Outputs
+- **GET /summary/financial**
+  - **Params:** optional `start_date`, `end_date` (YYYY-MM-DD)
+  - **Output:**
+    ```json
+    {
+      "status": "success",
+      "data": {
+        "totalIncome": 123.45,
+        "totalExpenses": -67.89,
+        "totalNet": 55.56,
+        "highestIncomeDay": { "date": "2024-01-03", "amount": 300.0 },
+        "highestExpenseDay": { "date": "2024-01-02", "amount": -200.0 },
+        "trend": 10.5,
+        "volatility": 50.0,
+        "outliers": ["2024-01-02"]
+      }
+    }
+    ```
+
+## Internal Dependencies
+- `models.Transaction`
+- `utils.finance_utils.display_transaction_amount`
+- SQLAlchemy via `extensions.db`
+
+## Known Behaviors
+- Ignores internal transfers.
+- Defaults to the previous 30 days when no range is supplied.
+- Outliers flagged when net values deviate by more than two standard deviations.
+
+## Related Docs
+- [`docs/frontend/FINANCIAL_SUMMARY.md`](../../frontend/FINANCIAL_SUMMARY.md)
+```

--- a/docs/frontend/FINANCIAL_SUMMARY.md
+++ b/docs/frontend/FINANCIAL_SUMMARY.md
@@ -3,13 +3,16 @@
 Renders key income and expense totals along with extended statistics such as moving averages, trend, volatility, highest income/expense days, and outlier detection.
 
 ## Props
+
 - `summary` – object containing totals and above‑average day counts.
 - `chartData` – daily net data used to derive extended statistics.
 - `zoomedOut` – whether the parent chart is zoomed out; affects display of above‑average day counts.
 - `defaultExtended` – if true, the extended statistics panel is shown initially.
 
 ## Related Views
+
 - `FinancialSummaryDetailed.vue` displays this component with the extended panel enabled by default.
 
 ## Related API
+
 - [`GET /api/summary/financial`](../backend/app/routes/summary.md)

--- a/docs/frontend/FINANCIAL_SUMMARY.md
+++ b/docs/frontend/FINANCIAL_SUMMARY.md
@@ -1,0 +1,15 @@
+# Financial Summary Component
+
+Renders key income and expense totals along with extended statistics such as moving averages, trend, volatility, highest income/expense days, and outlier detection.
+
+## Props
+- `summary` – object containing totals and above‑average day counts.
+- `chartData` – daily net data used to derive extended statistics.
+- `zoomedOut` – whether the parent chart is zoomed out; affects display of above‑average day counts.
+- `defaultExtended` – if true, the extended statistics panel is shown initially.
+
+## Related Views
+- `FinancialSummaryDetailed.vue` displays this component with the extended panel enabled by default.
+
+## Related API
+- [`GET /api/summary/financial`](../backend/app/routes/summary.md)

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -223,11 +223,7 @@ const extendedStats = computed(() => {
   // Outlier detection based on net values
   const mean = netValues.reduce((a, b) => a + b, 0) / netValues.length
   const outliers = data
-    .filter(
-      (d) =>
-        Math.abs((d.net?.parsedValue || 0) - mean) > 2 * volatility &&
-        volatility > 0,
-    )
+    .filter((d) => Math.abs((d.net?.parsedValue || 0) - mean) > 2 * volatility && volatility > 0)
     .map((d) => d.date)
 
   return {

--- a/frontend/src/services/summary.js
+++ b/frontend/src/services/summary.js
@@ -1,0 +1,12 @@
+/**
+ * Summary API helpers.
+ *
+ * Provides endpoints for retrieving financial summary metrics including
+ * highest income/expense day, trend, volatility, and detected outlier days.
+ */
+import axios from 'axios'
+
+export async function fetchFinancialSummary(params = {}) {
+  const response = await axios.get('/api/summary/financial', { params })
+  return response.data
+}

--- a/frontend/src/views/FinancialSummaryDetailed.vue
+++ b/frontend/src/views/FinancialSummaryDetailed.vue
@@ -1,0 +1,55 @@
+<!--
+  FinancialSummaryDetailed.vue
+  Standalone view rendering the FinancialSummary component with
+  extended metrics enabled by default.
+-->
+<template>
+  <div class="p-6">
+    <FinancialSummary
+      :summary="summary"
+      :chart-data="chartData"
+      :zoomed-out="false"
+      default-extended
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import FinancialSummary from '@/components/statistics/FinancialSummary.vue'
+import { fetchDailyNet } from '@/api/charts'
+
+const summary = ref({
+  totalIncome: 0,
+  totalExpenses: 0,
+  totalNet: 0,
+  aboveAvgIncomeDays: 0,
+  aboveAvgExpenseDays: 0,
+})
+const chartData = ref([])
+
+onMounted(async () => {
+  const response = await fetchDailyNet()
+  if (response.status === 'success') {
+    chartData.value = response.data
+    computeSummary()
+  }
+})
+
+function computeSummary() {
+  const data = chartData.value
+  const totalIncome = data.reduce((sum, d) => sum + (d.income?.parsedValue || 0), 0)
+  const totalExpenses = data.reduce((sum, d) => sum + (d.expenses?.parsedValue || 0), 0)
+  const totalNet = data.reduce((sum, d) => sum + (d.net?.parsedValue || 0), 0)
+  const days = data.length || 1
+  const avgIncome = totalIncome / days
+  const avgExpenses = totalExpenses / days
+  summary.value = {
+    totalIncome,
+    totalExpenses,
+    totalNet,
+    aboveAvgIncomeDays: data.filter((d) => (d.income?.parsedValue || 0) > avgIncome).length,
+    aboveAvgExpenseDays: data.filter((d) => Math.abs(d.expenses?.parsedValue || 0) > Math.abs(avgExpenses)).length,
+  }
+}
+</script>

--- a/frontend/src/views/FinancialSummaryDetailed.vue
+++ b/frontend/src/views/FinancialSummaryDetailed.vue
@@ -49,7 +49,9 @@ function computeSummary() {
     totalExpenses,
     totalNet,
     aboveAvgIncomeDays: data.filter((d) => (d.income?.parsedValue || 0) > avgIncome).length,
-    aboveAvgExpenseDays: data.filter((d) => Math.abs(d.expenses?.parsedValue || 0) > Math.abs(avgExpenses)).length,
+    aboveAvgExpenseDays: data.filter(
+      (d) => Math.abs(d.expenses?.parsedValue || 0) > Math.abs(avgExpenses),
+    ).length,
   }
 }
 </script>

--- a/tests/test_api_summary.py
+++ b/tests/test_api_summary.py
@@ -1,0 +1,107 @@
+import importlib.util
+import os
+import sys
+import types
+from datetime import date
+
+import pytest
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+sys.modules["flask_cors"] = types.SimpleNamespace(CORS=lambda app: app)
+sys.modules["flask_migrate"] = types.SimpleNamespace(Migrate=lambda *a, **k: None)
+
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+config_stub.FLASK_ENV = "test"
+config_stub.plaid_client = None
+sys.modules["app.config"] = config_stub
+
+env_stub = types.ModuleType("app.config.environment")
+env_stub.TELLER_WEBHOOK_SECRET = "dummy"
+sys.modules["app.config.environment"] = env_stub
+
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace()
+sys.modules["app.extensions"] = extensions_stub
+
+models_stub = types.ModuleType("app.models")
+
+
+class _DummyField:
+    def __ge__(self, other):
+        return self
+
+    def __le__(self, other):
+        return self
+
+    def is_(self, other):
+        return self
+
+    def __or__(self, other):
+        return self
+
+
+dummy_field = _DummyField()
+models_stub.Transaction = type(
+    "Transaction", (), {"date": dummy_field, "is_internal": dummy_field}
+)
+sys.modules["app.models"] = models_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "summary.py")
+spec = importlib.util.spec_from_file_location("app.routes.summary", ROUTE_PATH)
+summary_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(summary_module)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    mock_transactions = [
+        types.SimpleNamespace(date=date(2024, 1, 1), amount=100, is_internal=False),
+        types.SimpleNamespace(date=date(2024, 1, 2), amount=-200, is_internal=False),
+        types.SimpleNamespace(date=date(2024, 1, 3), amount=300, is_internal=False),
+    ]
+
+    query = types.SimpleNamespace(
+        filter=lambda *a, **k: query,
+        filter_by=lambda **k: query,
+        all=lambda: mock_transactions,
+    )
+    monkeypatch.setattr(
+        summary_module.db,
+        "session",
+        types.SimpleNamespace(query=lambda model: query),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        summary_module,
+        "display_transaction_amount",
+        lambda tx: tx.amount,
+        raising=False,
+    )
+
+    app = Flask(__name__)
+    app.register_blueprint(summary_module.summary, url_prefix="/api/summary")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_financial_summary_metrics(client):
+    resp = client.get(
+        "/api/summary/financial?start_date=2024-01-01&end_date=2024-01-03"
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()["data"]
+    assert payload["highestIncomeDay"]["date"] == "2024-01-03"
+    assert payload["highestExpenseDay"]["date"] == "2024-01-02"
+    assert "trend" in payload
+    assert "volatility" in payload
+    assert isinstance(payload["outliers"], list)


### PR DESCRIPTION
## Summary
- compute additional statistics in `FinancialSummary.vue` including highest income/expense day, trend, volatility, and outlier detection
- expose `/api/summary/financial` endpoint and helper to deliver new metrics
- add standalone `FinancialSummaryDetailed` view and basic unit test for new endpoint

## Testing
- `pre-commit run --files backend/app/__init__.py backend/app/routes/summary.py tests/test_api_summary.py` *(fails: ModuleNotFoundError: No module named 'plaid')*
- `SKIP=model-field-validation pre-commit run --files frontend/src/components/statistics/FinancialSummary.vue frontend/src/services/summary.js frontend/src/views/FinancialSummaryDetailed.vue`
- `pytest tests/test_api_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab265289848329a4053c978f157363