### PR TITLE
feat(charts): refine category breakdown filtering

### DIFF
--- a/frontend/src/api/categories.js
+++ b/frontend/src/api/categories.js
@@ -2,10 +2,23 @@ import axios from 'axios'
 
 /**
  * API helpers for Category resources.
- * Currently exposes ``fetchCategoryTree`` to retrieve the full
- * category hierarchy for UI dropdowns.
+ *
+ * Exposes functions to retrieve category listings and the full
+ * hierarchical tree used in dropdowns.
  */
 export async function fetchCategoryTree(params = {}) {
   const response = await axios.get('/api/categories/tree', { params })
+  return response.data
+}
+
+/**
+ * Fetch a flat list of categories with optional date and filter
+ * parameters.
+ *
+ * @param {Object} params - Query parameters such as `start_date`,
+ *   `end_date`, or search filters.
+ */
+export async function fetchCategories(params = {}) {
+  const response = await axios.get('/api/categories', { params })
   return response.data
 }

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -77,7 +77,7 @@
       <div class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
         <!-- Category Spending -->
         <div
-          class="md:col-span-2 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-yellow)] p-6 flex flex-col gap-3">
+          class="md:col-span-2 w-full bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-yellow)] p-6 flex flex-col gap-3 overflow-hidden">
           <div class="flex items-center justify-between mb-2">
             <h2 class="text-xl font-bold text-[var(--color-accent-yellow)]">Spending by Category</h2>
             <ChartWidgetTopBar>
@@ -88,7 +88,7 @@
                   class="btn btn-outline hover-lift ml-2"
                   @click="groupOthers = !groupOthers"
                 >
-                  {{ groupOthers ? 'Show All' : 'Group Others' }}
+                  {{ groupOthers ? 'Expand All' : 'Consolidate Minor Categories' }}
                 </button>
               </template>
             </ChartWidgetTopBar>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -6,15 +6,24 @@
   <AppLayout>
     <BasePageLayout gap="gap-8">
       <!-- WELCOME HEADER CARD -->
-      <div class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
       <div
-        class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-2xl p-8 flex flex-col items-center gap-2">
-        <h1 class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow">Welcome, <span
-            class="username">{{ userName }}</span>!</h1>
+        class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
+      ></div>
+      <div
+        class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-2xl p-8 flex flex-col items-center gap-2"
+      >
+        <h1
+          class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow"
+        >
+          Welcome, <span class="username">{{ userName }}</span
+          >!
+        </h1>
         <p class="text-lg text-muted">Today is {{ currentDate }}</p>
         <p class="italic text-muted">{{ netWorthMessage }}</p>
       </div>
-      <div class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
+      <div
+        class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
+      ></div>
       <div class="flex justify-end mb-4">
         <DateRangeSelector
           v-model:start-date="dateRange.start"
@@ -26,8 +35,11 @@
       <div class="grid grid-cols-1 gap-6 md:grid-cols-4 items-stretch">
         <!-- Top Accounts Snapshot Card -->
         <div
-          class="col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-green)] p-6 flex flex-col justify-between">
-          <h2 class="text-2xl font-bold mb-4 text-[var(--color-accent-green)] text-center">Top Accounts</h2>
+          class="col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-green)] p-6 flex flex-col justify-between"
+        >
+          <h2 class="text-2xl font-bold mb-4 text-[var(--color-accent-green)] text-center">
+            Top Accounts
+          </h2>
           <TopAccountSnapshot use-spectrum />
         </div>
         <!-- Recent Transactions Card -->
@@ -36,7 +48,8 @@
         </div>
         <!-- Net Income Summary Card -->
         <div
-          class="md:col-span-2 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3">
+          class="md:col-span-2 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3"
+        >
           <div class="flex items-center justify-center mb-4">
             <h2 class="daily-net-chart-title">
               <span class="title-text">Net Income</span>
@@ -65,76 +78,100 @@
       </div>
 
       <!-- FINANCIAL SUMMARY ROW -->
-      <div class="bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6">
-        <FinancialSummary
-          :summary="netSummary"
-          :chart-data="chartData"
-          :zoomed-out="zoomedOut"
-        />
+      <div
+        class="bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6"
+      >
+        <FinancialSummary :summary="netSummary" :chart-data="chartData" :zoomed-out="zoomedOut" />
       </div>
 
       <!-- SPENDING ROW: Category Chart & Insights -->
       <div class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
         <!-- Category Spending -->
         <div
-          class="md:col-span-2 w-full bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-yellow)] p-6 flex flex-col gap-3 overflow-hidden">
+          class="md:col-span-2 w-full bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-yellow)] p-6 flex flex-col gap-3 overflow-hidden"
+        >
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-xl font-bold text-[var(--color-accent-yellow)]">Spending by Category</h2>
+            <h2 class="text-xl font-bold text-[var(--color-accent-yellow)]">
+              Spending by Category
+            </h2>
             <ChartWidgetTopBar>
               <template #controls>
-                <GroupedCategoryDropdown :groups="categoryGroups" :modelValue="catSelected"
-                  @update:modelValue="onCatSelected" class="ml-2 w-full md:w-64" />
-                <button
-                  class="btn btn-outline hover-lift ml-2"
-                  @click="groupOthers = !groupOthers"
-                >
+                <GroupedCategoryDropdown
+                  :groups="categoryGroups"
+                  :modelValue="catSelected"
+                  @update:modelValue="onCatSelected"
+                  class="ml-2 w-full md:w-64"
+                />
+                <button class="btn btn-outline hover-lift ml-2" @click="groupOthers = !groupOthers">
                   {{ groupOthers ? 'Expand All' : 'Consolidate Minor Categories' }}
                 </button>
               </template>
             </ChartWidgetTopBar>
           </div>
-          <CategoryBreakdownChart :start-date="dateRange.start" :end-date="dateRange.end"
-            :selected-category-ids="catSelected" :group-others="groupOthers"
-            @summary-change="catSummary = $event" @categories-change="allCategoryIds = $event"
-            @bar-click="onCategoryBarClick" />
+          <CategoryBreakdownChart
+            :start-date="dateRange.start"
+            :end-date="dateRange.end"
+            :selected-category-ids="catSelected"
+            :group-others="groupOthers"
+            @summary-change="catSummary = $event"
+            @categories-change="allCategoryIds = $event"
+            @bar-click="onCategoryBarClick"
+          />
           <div class="mt-1">
             <span class="font-bold">Total:</span>
-              <span class="ml-1 text-[var(--color-accent-cyan)] font-bold">{{ formatAmount(catSummary.total) }}</span>
+            <span class="ml-1 text-[var(--color-accent-cyan)] font-bold">{{
+              formatAmount(catSummary.total)
+            }}</span>
           </div>
         </div>
         <!-- Spending Insights Placeholder -->
         <div
-          class="md:col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-magenta)] p-6 flex flex-col items-center justify-center">
-          <h2 class="text-xl font-bold text-[var(--color-accent-magenta)] mb-4">Spending Insights</h2>
+          class="md:col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-magenta)] p-6 flex flex-col items-center justify-center"
+        >
+          <h2 class="text-xl font-bold text-[var(--color-accent-magenta)] mb-4">
+            Spending Insights
+          </h2>
           <p class="italic text-muted text-center">More detailed insights coming soon...</p>
         </div>
       </div>
 
       <!-- RESERVED TABLES PANEL -->
-        <div
-          class="relative min-h-[440px] bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-xl flex flex-col justify-center items-stretch overflow-hidden">
+      <div
+        class="relative min-h-[440px] bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-xl flex flex-col justify-center items-stretch overflow-hidden"
+      >
         <!-- Button row: Show only if neither table is expanded -->
         <transition name="accordion">
-          <div v-if="!accountsExpanded && !transactionsExpanded"
-            class="flex flex-row justify-between items-center gap-8 w-full h-full p-12">
-            <button @click="expandAccounts"
-              class="flex-1 text-2xl font-bold px-8 py-8 rounded-2xl border-2 border-[var(--color-accent-cyan)] bg-[var(--color-bg-sec)] shadow-lg hover:bg-[var(--color-accent-cyan)] hover:text-[var(--color-bg-sec)] transition">
+          <div
+            v-if="!accountsExpanded && !transactionsExpanded"
+            class="flex flex-row justify-between items-center gap-8 w-full h-full p-12"
+          >
+            <button
+              @click="expandAccounts"
+              class="flex-1 text-2xl font-bold px-8 py-8 rounded-2xl border-2 border-[var(--color-accent-cyan)] bg-[var(--color-bg-sec)] shadow-lg hover:bg-[var(--color-accent-cyan)] hover:text-[var(--color-bg-sec)] transition"
+            >
               Expand Accounts Table
             </button>
             <div class="mx-8 text-lg font-light text-muted select-none">or</div>
-            <button @click="expandTransactions"
-              class="flex-1 text-2xl font-bold px-8 py-8 rounded-2xl border-2 border-[var(--color-accent-red)] bg-[var(--color-bg-sec)] shadow-lg hover:bg-[var(--color-accent-red)] hover:text-[var(--color-bg-sec)] transition">
+            <button
+              @click="expandTransactions"
+              class="flex-1 text-2xl font-bold px-8 py-8 rounded-2xl border-2 border-[var(--color-accent-red)] bg-[var(--color-bg-sec)] shadow-lg hover:bg-[var(--color-accent-red)] hover:text-[var(--color-bg-sec)] transition"
+            >
               Expand Transactions Table
             </button>
           </div>
         </transition>
         <!-- Expanded Accounts Table -->
         <transition name="modal-fade-slide">
-          <div v-if="accountsExpanded" class="absolute inset-0 p-8 flex flex-col bg-[var(--color-bg-sec)]">
+          <div
+            v-if="accountsExpanded"
+            class="absolute inset-0 p-8 flex flex-col bg-[var(--color-bg-sec)]"
+          >
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-2xl font-bold text-[var(--color-accent-cyan)]">Accounts Table</h2>
-              <button @click="collapseTables"
-                  class="px-4 py-2 rounded bg-[var(--color-accent-cyan)] text-[var(--color-bg-sec)] font-bold text-lg shadow hover:brightness-105">
+              <h2 class="text-2xl font-bold text-[var(--color-accent-cyan)]">Accounts Table</h2>
+              <button
+                @click="collapseTables"
+                class="px-4 py-2 rounded bg-[var(--color-accent-cyan)] text-[var(--color-bg-sec)] font-bold text-lg shadow hover:brightness-105"
+              >
                 Close
               </button>
             </div>
@@ -145,39 +182,51 @@
         </transition>
         <!-- Expanded Transactions Table -->
         <transition name="modal-fade-slide">
-          <div v-if="transactionsExpanded" class="absolute inset-0 p-8 flex flex-col bg-[var(--color-bg-sec)]">
+          <div
+            v-if="transactionsExpanded"
+            class="absolute inset-0 p-8 flex flex-col bg-[var(--color-bg-sec)]"
+          >
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-2xl font-bold text-[var(--color-accent-red)]">Transactions Table</h2>
-                <button @click="collapseTables"
-                  class="px-4 py-2 rounded bg-[var(--color-accent-red)] text-[var(--color-bg-sec)] font-bold text-lg shadow hover:brightness-105">
+              <h2 class="text-2xl font-bold text-[var(--color-accent-red)]">Transactions Table</h2>
+              <button
+                @click="collapseTables"
+                class="px-4 py-2 rounded bg-[var(--color-accent-red)] text-[var(--color-bg-sec)] font-bold text-lg shadow hover:brightness-105"
+              >
                 Close
               </button>
             </div>
             <div class="flex-1 min-h-[300px]">
-              <TransactionsTable :transactions="filteredTransactions" :sort-key="sortKey" :sort-order="sortOrder"
-                :search="searchQuery" @sort="setSort" :current-page="currentPage" :total-pages="totalPages"
-                @change-page="changePage" />
-              <PaginationControls :current-page="currentPage" :total-pages="totalPages" @change-page="changePage" />
+              <TransactionsTable
+                :transactions="filteredTransactions"
+                :sort-key="sortKey"
+                :sort-order="sortOrder"
+                :search="searchQuery"
+                @sort="setSort"
+                :current-page="currentPage"
+                :total-pages="totalPages"
+                @change-page="changePage"
+              />
+              <PaginationControls
+                :current-page="currentPage"
+                :total-pages="totalPages"
+                @change-page="changePage"
+              />
             </div>
           </div>
         </transition>
       </div>
 
-    <TransactionModal
-      :show="showModal"
-      :subtitle="modalSubtitle"
-      :transactions="modalTransactions"
-      @close="showModal = false"
-    />
+      <TransactionModal
+        :show="showModal"
+        :subtitle="modalSubtitle"
+        :transactions="modalTransactions"
+        @close="showModal = false"
+      />
     </BasePageLayout>
 
-    <template #footer>
-      &copy; {{ new Date().getFullYear() }} braydio • pyNance.
-    </template>
+    <template #footer> &copy; {{ new Date().getFullYear() }} braydio • pyNance. </template>
   </AppLayout>
 </template>
-
-
 
 <script setup>
 // Dashboard view showing financial charts and transaction tables.
@@ -212,18 +261,22 @@ const {
   sortKey,
   sortOrder,
   setSort,
-  changePage
+  changePage,
 } = useTransactions(15)
 const showModal = ref(false)
 const modalTransactions = ref([])
 const modalSubtitle = ref('')
 const userName = import.meta.env.VITE_USER_ID_PLAID || 'Guest'
-const currentDate = new Date().toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })
+const currentDate = new Date().toLocaleDateString(undefined, {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+})
 const netWorth = ref(0)
 const netWorthMessage = computed(() => {
-  if (netWorth.value < 0) return "... and things are looking quite bleak."
-  if (netWorth.value > 1000) return "Ahh... well in the black."
-  return "Uhh... keep up the... whatever this is."
+  if (netWorth.value < 0) return '... and things are looking quite bleak.'
+  if (netWorth.value > 1000) return 'Ahh... well in the black.'
+  return 'Uhh... keep up the... whatever this is.'
 })
 
 onMounted(async () => {
@@ -256,15 +309,17 @@ const showAvgExpenses = ref(false)
 // --- SHARED DATE RANGE STATE ---
 const today = new Date()
 const dateRange = ref({
-  start: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 30).toISOString().slice(0, 10),
-  end: today.toISOString().slice(0, 10)
+  start: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 30)
+    .toISOString()
+    .slice(0, 10),
+  end: today.toISOString().slice(0, 10),
 })
 
 const catSummary = ref({ total: 0, startDate: '', endDate: '' })
-const catSelected = ref([])           // user selected
-const allCategoryIds = ref([])        // from chart data
-const defaultSet = ref(false)         // only auto-select ONCE per data load
-const groupOthers = ref(true)         // aggregate small categories
+const catSelected = ref([]) // user selected
+const allCategoryIds = ref([]) // from chart data
+const defaultSet = ref(false) // only auto-select ONCE per data load
+const groupOthers = ref(true) // aggregate small categories
 
 // When CategoryBreakdownChart fetches, auto-select the first 5 categories once
 // per fetch. Includes "Other" when grouping is enabled and does not repopulate
@@ -297,9 +352,12 @@ function onCatSelected(newIds) {
 }
 
 // When user changes date range, let next data load re-apply auto-select
-watch(() => [dateRange.value.start, dateRange.value.end], () => {
-  defaultSet.value = false
-})
+watch(
+  () => [dateRange.value.start, dateRange.value.end],
+  () => {
+    defaultSet.value = false
+  },
+)
 
 // When grouping mode changes, allow auto-select on next fetch
 watch(groupOthers, () => {
@@ -319,10 +377,10 @@ async function loadCategoryGroups() {
     if (res.status === 'success' && Array.isArray(res.data)) {
       // res.data is confirmed to be an array, so no fallback is required
       categoryGroups.value = res.data
-        .map(root => ({
+        .map((root) => ({
           id: root.id,
           label: root.label,
-          children: (root.children || []).map(c => ({
+          children: (root.children || []).map((c) => ({
             id: c.id,
             label: c.label ?? c.name,
           })),
@@ -354,8 +412,7 @@ async function onNetBarClick(label) {
  *   the bar label and an array of category IDs.
  */
 async function onCategoryBarClick(payload) {
-  const { label, ids = [] } =
-    typeof payload === 'object' ? payload : { label: payload, ids: [] }
+  const { label, ids = [] } = typeof payload === 'object' ? payload : { label: payload, ids: [] }
 
   // Only display the modal when the clicked bar corresponds to selected categories
   if (!ids.length) return
@@ -381,7 +438,7 @@ async function onCategoryBarClick(payload) {
 </script>
 
 <style scoped>
-@import "../assets/css/main.css";
+@import '../assets/css/main.css';
 
 .dashboard-outer {
   /* Vertically and horizontally center, with a max width for the dashboard content */
@@ -390,15 +447,14 @@ async function onCategoryBarClick(payload) {
   background: var(--theme-bg);
 }
 
-  .username {
-    @apply text-[var(--color-accent-cyan)] text-lg;
-    text-shadow: 2px 6px 8px var(--bar-gradient-end);
-  }
+.username {
+  @apply text-[var(--color-accent-cyan)] text-lg;
+  text-shadow: 2px 6px 8px var(--bar-gradient-end);
+}
 
 .text-muted {
   color: var(--color-text-muted);
 }
-
 
 .fade-enter-active,
 .fade-leave-active {
@@ -449,19 +505,19 @@ async function onCategoryBarClick(payload) {
   text-align: center;
 }
 
-  .title-icon {
-    font-size: 1.2rem;
-    filter: drop-shadow(0 0 8px rgba(113, 156, 214, 0.6));
-    animation: subtle-glow 3s ease-in-out infinite alternate;
-  }
+.title-icon {
+  font-size: 1.2rem;
+  filter: drop-shadow(0 0 8px rgba(113, 156, 214, 0.6));
+  animation: subtle-glow 3s ease-in-out infinite alternate;
+}
 
-  .title-text {
-    background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-shadow: 0 0 20px rgba(113, 156, 214, 0.3);
-  }
+.title-text {
+  background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-shadow: 0 0 20px rgba(113, 156, 214, 0.3);
+}
 
 .title-subtitle {
   font-size: 0.9rem;
@@ -470,12 +526,12 @@ async function onCategoryBarClick(payload) {
   opacity: 0.8;
 }
 
-  @keyframes subtle-glow {
-    0% {
-      filter: drop-shadow(0 0 8px rgba(113, 156, 214, 0.6));
-    }
-    100% {
-      filter: drop-shadow(0 0 12px rgba(113, 156, 214, 0.8));
-    }
+@keyframes subtle-glow {
+  0% {
+    filter: drop-shadow(0 0 8px rgba(113, 156, 214, 0.6));
   }
+  100% {
+    filter: drop-shadow(0 0 12px rgba(113, 156, 214, 0.8));
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- add API helper to fetch category lists with range filters
- rebuild category breakdown chart data using ID-based datasets
- align dashboard chart controls and container styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab292f59148329bd6203c6fc6d5f35