### PR TITLE
feat(charts): highlight above-average days with color

### DIFF
--- a/frontend/src/components/charts/DailyNetChart.vue
+++ b/frontend/src/components/charts/DailyNetChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="daily-net-chart">
-    <div style="height: 400px;">
-      <canvas ref="chartCanvas" style="width: 100%; height: 100%;"></canvas>
+    <div style="height: 400px">
+      <canvas ref="chartCanvas" style="width: 100%; height: 100%"></canvas>
     </div>
   </div>
 </template>
@@ -13,7 +13,7 @@
 import { fetchDailyNet } from '@/api/charts'
 import { ref, onMounted, onUnmounted, nextTick, watch, toRefs } from 'vue'
 import { Chart } from 'chart.js/auto'
-import { formatAmount } from "@/utils/format"
+import { formatAmount } from '@/utils/format'
 
 const props = defineProps({
   startDate: { type: String, required: true },
@@ -22,7 +22,7 @@ const props = defineProps({
   show7Day: { type: Boolean, default: false },
   show30Day: { type: Boolean, default: false },
   showAvgIncome: { type: Boolean, default: false },
-  showAvgExpenses: { type: Boolean, default: false }
+  showAvgExpenses: { type: Boolean, default: false },
 })
 const { show7Day, show30Day, showAvgIncome, showAvgExpenses } = toRefs(props)
 // Emits "bar-click" when a bar is selected, "summary-change" when data totals change, and "data-change" when chart data updates
@@ -45,12 +45,12 @@ function filterDataByRange(data) {
   } else {
     start = props.startDate ? new Date(props.startDate) : null
     const end = props.endDate ? new Date(props.endDate) : now
-    return (data || []).filter(item => {
+    return (data || []).filter((item) => {
       const d = new Date(item.date)
       return (!start || d >= start) && d <= end
     })
   }
-  return (data || []).filter(item => {
+  return (data || []).filter((item) => {
     const d = new Date(item.date)
     return d >= start && d <= now
   })
@@ -59,7 +59,12 @@ function filterDataByRange(data) {
 // Emit the selected date when a bar is clicked
 function handleBarClick(evt) {
   if (!chartInstance.value) return
-  const points = chartInstance.value.getElementsAtEventForMode(evt, 'nearest', { intersect: true }, false)
+  const points = chartInstance.value.getElementsAtEventForMode(
+    evt,
+    'nearest',
+    { intersect: true },
+    false,
+  )
   if (points.length) {
     const index = points[0].index
     const date = chartInstance.value.data.labels[index]
@@ -71,33 +76,36 @@ function handleBarClick(evt) {
 const netLinePlugin = {
   id: 'netLinePlugin',
   afterDatasetsDraw(chart) {
-    const { ctx } = chart;
+    const { ctx } = chart
     chart.data.datasets.forEach((dataset, idx) => {
       if (dataset.label === 'Net') {
-        const meta = chart.getDatasetMeta(idx);
-        meta.data.forEach(bar => {
-          const y = bar.y;
-          const x = bar.x;
+        const meta = chart.getDatasetMeta(idx)
+        meta.data.forEach((bar) => {
+          const y = bar.y
+          const x = bar.x
           // use configured barThickness for width
-          const width = dataset.barThickness || 0;
-          ctx.save();
-          ctx.strokeStyle = getStyle('--color-accent-yellow');
-          ctx.lineWidth = 2;
-          ctx.beginPath();
-          ctx.moveTo(x - width / 2, y);
-          ctx.lineTo(x + width / 2, y);
-          ctx.stroke();
-          ctx.restore();
-        });
+          const width = dataset.barThickness || 0
+          ctx.save()
+          ctx.strokeStyle = getStyle('--color-accent-yellow')
+          ctx.lineWidth = 2
+          ctx.beginPath()
+          ctx.moveTo(x - width / 2, y)
+          ctx.lineTo(x + width / 2, y)
+          ctx.stroke()
+          ctx.restore()
+        })
       }
-    });
-  }
-};
-
+    })
+  },
+}
 
 function emphasizeColor(hex, channel) {
   let c = hex.replace('#', '')
-  if (c.length === 3) c = c.split('').map(ch => ch + ch).join('')
+  if (c.length === 3)
+    c = c
+      .split('')
+      .map((ch) => ch + ch)
+      .join('')
   const num = parseInt(c, 16)
   let r = (num >> 16) & 0xff
   let g = (num >> 8) & 0xff
@@ -148,20 +156,28 @@ async function renderChart() {
 
   const filtered = filterDataByRange(chartData.value)
 
-  const labels = filtered.length ? filtered.map(item => item.date) : [' ']
+  const labels = filtered.length ? filtered.map((item) => item.date) : [' ']
   // Extract numeric values from response objects
-  const netValues = filtered.length ? filtered.map(item => item.net.parsedValue) : [0]
-  const incomeValues = filtered.length ? filtered.map(item => item.income.parsedValue) : [0]
-  const expenseValues = filtered.length ? filtered.map(item => item.expenses.parsedValue) : [0]
+  const netValues = filtered.length ? filtered.map((item) => item.net.parsedValue) : [0]
+  const incomeValues = filtered.length ? filtered.map((item) => item.income.parsedValue) : [0]
+  const expenseValues = filtered.length ? filtered.map((item) => item.expenses.parsedValue) : [0]
   // Expenses are already negative (parsedValue); use as is for chart
 
-  const avgIncome = incomeValues.length ? incomeValues.reduce((a, b) => a + b, 0) / incomeValues.length : 0
-  const avgExpenses = expenseValues.length ? expenseValues.reduce((a, b) => a + b, 0) / expenseValues.length : 0
+  const avgIncome = incomeValues.length
+    ? incomeValues.reduce((a, b) => a + b, 0) / incomeValues.length
+    : 0
+  const avgExpenses = expenseValues.length
+    ? expenseValues.reduce((a, b) => a + b, 0) / expenseValues.length
+    : 0
 
   const incomeBase = getStyle('--color-accent-green')
   const expenseBase = getStyle('--color-accent-red')
-  const incomeColors = incomeValues.map(v => (v > avgIncome ? emphasizeColor(incomeBase, 'g') : incomeBase))
-  const expenseColors = expenseValues.map(v => (Math.abs(v) > Math.abs(avgExpenses) ? emphasizeColor(expenseBase, 'r') : expenseBase))
+  const incomeColors = incomeValues.map((v) =>
+    v > avgIncome ? emphasizeColor(incomeBase, 'g') : incomeBase,
+  )
+  const expenseColors = expenseValues.map((v) =>
+    Math.abs(v) > Math.abs(avgExpenses) ? emphasizeColor(expenseBase, 'r') : expenseBase,
+  )
 
   const datasets = [
     {
@@ -254,22 +270,22 @@ async function renderChart() {
           callbacks: {
             // Show the date as title
             title: (tooltipItems) => {
-              const idx = tooltipItems[0].dataIndex;
-              return filtered[idx]?.date || tooltipItems[0].label;
+              const idx = tooltipItems[0].dataIndex
+              return filtered[idx]?.date || tooltipItems[0].label
             },
             // Suppress default per-dataset labels
             label: () => null,
             // After title, display income, expenses, net, and transactions
             afterBody: (tooltipItems) => {
-              const idx = tooltipItems[0].dataIndex;
-              const rec = filtered[idx];
-              if (!rec) return [];
+              const idx = tooltipItems[0].dataIndex
+              const rec = filtered[idx]
+              if (!rec) return []
               return [
                 `Income: ${formatAmount(rec.income.parsedValue)}`,
                 `Expenses: ${formatAmount(rec.expenses.parsedValue)}`,
                 `Net: ${formatAmount(rec.net.parsedValue)}`,
                 `Transactions: ${rec.transaction_count}`,
-              ];
+              ]
             },
           },
           backgroundColor: getStyle('--theme-bg'),
@@ -287,7 +303,7 @@ async function renderChart() {
           max: Math.max(...incomeValues, 0),
           grid: { display: true, color: getStyle('--divider') },
           ticks: {
-            callback: value => formatAmount(value),
+            callback: (value) => formatAmount(value),
             color: getStyle('--color-text-muted'),
             font: { family: "'Fira Code', monospace", size: 14 },
           },
@@ -302,14 +318,14 @@ async function renderChart() {
             // Show one label per week, formatted as Mon DD
             callback: (value, index) => {
               // Only show one label per week
-              if (index % 7 !== 0) return '';
+              if (index % 7 !== 0) return ''
               // Use the original label (YYYY-MM-DD) for accurate parsing
-              const raw = labels[index];
-              if (!raw) return '';
-              const dt = new Date(raw);
-              if (isNaN(dt)) return raw;
+              const raw = labels[index]
+              if (!raw) return ''
+              const dt = new Date(raw)
+              if (isNaN(dt)) return raw
               // Format e.g. "Jul 05"
-              return dt.toLocaleDateString(undefined, { month: 'short', day: '2-digit' });
+              return dt.toLocaleDateString(undefined, { month: 'short', day: '2-digit' })
             },
             color: getStyle('--color-text-muted'),
             font: { family: "'Fira Code', monospace", size: 14 },
@@ -359,11 +375,22 @@ function updateSummary() {
   emit('data-change', filtered)
 }
 
-
-watch([chartData, () => props.zoomedOut, () => props.startDate, () => props.endDate, show7Day, show30Day, showAvgIncome, showAvgExpenses], async () => {
-  updateSummary()
-  await renderChart()
-})
+watch(
+  [
+    chartData,
+    () => props.zoomedOut,
+    () => props.startDate,
+    () => props.endDate,
+    show7Day,
+    show30Day,
+    showAvgIncome,
+    showAvgExpenses,
+  ],
+  async () => {
+    updateSummary()
+    await renderChart()
+  },
+)
 
 watch(() => [props.startDate, props.endDate, props.zoomedOut], fetchData)
 
@@ -378,4 +405,3 @@ onUnmounted(() => {
   }
 })
 </script>
-

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -102,7 +102,6 @@
               <span class="stat-value">{{ extendedStats.outlierDates.length }}</span>
             </div>
           </div>
-
         </div>
       </div>
     </Transition>
@@ -151,70 +150,70 @@ const netClass = computed(() => ({
 }))
 
 // Extended statistics calculations
-  const extendedStats = computed(() => {
-    const data = props.chartData
-    if (!data.length) {
-      return {
-        avgDailyIncome: 0,
-        avgDailyExpenses: 0,
-        avgDailyNet: 0,
-        movingAverage7: 0,
-        movingAverage30: 0,
-        trend: 0,
-        volatility: 0,
-        highestIncomeDay: null,
-        highestExpenseDay: null,
-        outlierDates: [],
-      }
-    }
-
-    const days = data.length
-
-    // Daily aggregates
-    const incomeValues = data.map((d) => d.income?.parsedValue || 0)
-    const expenseValues = data.map((d) => Math.abs(d.expenses?.parsedValue || 0))
-    const netValues = data.map((d) => d.net?.parsedValue || 0)
-
-    const avgDailyIncome = props.summary.totalIncome / days
-    const avgDailyExpenses = props.summary.totalExpenses / days
-    const avgDailyNet = props.summary.totalNet / days
-
-    const movingAverage7 = calculateMovingAverage(netValues, 7)
-    const movingAverage30 = calculateMovingAverage(netValues, 30)
-
-    const trend = calculateTrend(netValues)
-    const volatility = calculateVolatility(netValues)
-
-    // Highest income/expense days
-    const maxIncomeIdx = incomeValues.indexOf(Math.max(...incomeValues))
-    const maxExpenseIdx = expenseValues.indexOf(Math.max(...expenseValues))
-    const highestIncomeDay = data[maxIncomeIdx]
-      ? { date: data[maxIncomeIdx].date, amount: incomeValues[maxIncomeIdx] }
-      : null
-    const highestExpenseDay = data[maxExpenseIdx]
-      ? { date: data[maxExpenseIdx].date, amount: expenseValues[maxExpenseIdx] }
-      : null
-
-    // Basic outlier detection using 2 standard deviations
-    const mean = netValues.reduce((a, b) => a + b, 0) / days
-    const threshold = 2 * volatility
-    const outlierDates = data
-      .filter((d, i) => Math.abs(netValues[i] - mean) > threshold)
-      .map((d) => d.date)
-
+const extendedStats = computed(() => {
+  const data = props.chartData
+  if (!data.length) {
     return {
-      avgDailyIncome,
-      avgDailyExpenses,
-      avgDailyNet,
-      movingAverage7,
-      movingAverage30,
-      trend,
-      volatility,
-      highestIncomeDay,
-      highestExpenseDay,
-      outlierDates,
+      avgDailyIncome: 0,
+      avgDailyExpenses: 0,
+      avgDailyNet: 0,
+      movingAverage7: 0,
+      movingAverage30: 0,
+      trend: 0,
+      volatility: 0,
+      highestIncomeDay: null,
+      highestExpenseDay: null,
+      outlierDates: [],
     }
-  })
+  }
+
+  const days = data.length
+
+  // Daily aggregates
+  const incomeValues = data.map((d) => d.income?.parsedValue || 0)
+  const expenseValues = data.map((d) => Math.abs(d.expenses?.parsedValue || 0))
+  const netValues = data.map((d) => d.net?.parsedValue || 0)
+
+  const avgDailyIncome = props.summary.totalIncome / days
+  const avgDailyExpenses = props.summary.totalExpenses / days
+  const avgDailyNet = props.summary.totalNet / days
+
+  const movingAverage7 = calculateMovingAverage(netValues, 7)
+  const movingAverage30 = calculateMovingAverage(netValues, 30)
+
+  const trend = calculateTrend(netValues)
+  const volatility = calculateVolatility(netValues)
+
+  // Highest income/expense days
+  const maxIncomeIdx = incomeValues.indexOf(Math.max(...incomeValues))
+  const maxExpenseIdx = expenseValues.indexOf(Math.max(...expenseValues))
+  const highestIncomeDay = data[maxIncomeIdx]
+    ? { date: data[maxIncomeIdx].date, amount: incomeValues[maxIncomeIdx] }
+    : null
+  const highestExpenseDay = data[maxExpenseIdx]
+    ? { date: data[maxExpenseIdx].date, amount: expenseValues[maxExpenseIdx] }
+    : null
+
+  // Basic outlier detection using 2 standard deviations
+  const mean = netValues.reduce((a, b) => a + b, 0) / days
+  const threshold = 2 * volatility
+  const outlierDates = data
+    .filter((d, i) => Math.abs(netValues[i] - mean) > threshold)
+    .map((d) => d.date)
+
+  return {
+    avgDailyIncome,
+    avgDailyExpenses,
+    avgDailyNet,
+    movingAverage7,
+    movingAverage30,
+    trend,
+    volatility,
+    highestIncomeDay,
+    highestExpenseDay,
+    outlierDates,
+  }
+})
 
 // Trend display
 const trendClass = computed(() => ({
@@ -230,22 +229,22 @@ const trendLabel = computed(() => {
   return '→ Stable'
 })
 
-  const volatilityLabel = computed(() => {
-    const vol = extendedStats.value.volatility
-    if (vol < 50) return 'Low'
-    if (vol < 200) return 'Medium'
-    return 'High'
-  })
+const volatilityLabel = computed(() => {
+  const vol = extendedStats.value.volatility
+  if (vol < 50) return 'Low'
+  if (vol < 200) return 'Medium'
+  return 'High'
+})
 
-  const highestIncomeLabel = computed(() => {
-    const hi = extendedStats.value.highestIncomeDay
-    return hi ? `${hi.date} (${formatAmount(hi.amount)})` : 'N/A'
-  })
+const highestIncomeLabel = computed(() => {
+  const hi = extendedStats.value.highestIncomeDay
+  return hi ? `${hi.date} (${formatAmount(hi.amount)})` : 'N/A'
+})
 
-  const highestExpenseLabel = computed(() => {
-    const he = extendedStats.value.highestExpenseDay
-    return he ? `${he.date} (${formatAmount(he.amount)})` : 'N/A'
-  })
+const highestExpenseLabel = computed(() => {
+  const he = extendedStats.value.highestExpenseDay
+  return he ? `${he.date} (${formatAmount(he.amount)})` : 'N/A'
+})
 
 // Statistical calculation functions
 function calculateMovingAverage(values, period) {

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -103,18 +103,6 @@
             </div>
           </div>
 
-          <!-- Above Average Days -->
-          <div class="stat-group">
-            <h4 class="group-title">Above Avg Days</h4>
-            <div class="stat-item">
-              <span class="stat-label">Income:</span>
-              <span class="stat-value">{{ summary.aboveAvgIncomeDays }}</span>
-            </div>
-            <div class="stat-item">
-              <span class="stat-label">Expenses:</span>
-              <span class="stat-value">{{ summary.aboveAvgExpenseDays }}</span>
-            </div>
-          </div>
         </div>
       </div>
     </Transition>
@@ -132,8 +120,6 @@ const props = defineProps({
       totalIncome: 0,
       totalExpenses: 0,
       totalNet: 0,
-      aboveAvgIncomeDays: 0,
-      aboveAvgExpenseDays: 0,
       highestIncomeDay: null,
       highestExpenseDay: null,
       trend: 0,

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -296,8 +296,6 @@ const netSummary = ref({
   totalIncome: 0,
   totalExpenses: 0,
   totalNet: 0,
-  aboveAvgIncomeDays: 0,
-  aboveAvgExpenseDays: 0,
 })
 const chartData = ref([])
 const zoomedOut = ref(false)


### PR DESCRIPTION
## Summary
- tint income/expense bars when values exceed daily averages
- drop above-average day counts from summary and dashboard
- standardize currency formatting with `formatAmount`

## Testing
- `npm run lint`
- `npm test` *(fails: Waiting for file changes, tests in watch mode)*
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68abd052f2fc83298c4dc76b538a2569