### PR TITLE
feat(frontend): add spending insights widget

### DIFF
--- a/frontend/src/api/transactions.js
+++ b/frontend/src/api/transactions.js
@@ -33,7 +33,7 @@ export const fetchTransactions = async (params = {}) => {
   }
 
   const response = await axios.get('/api/transactions/get_transactions', { params: query })
-  return (response.data?.status === 'success') ? response.data.data : { transactions: [] }
+  return response.data?.status === 'success' ? response.data.data : { transactions: [] }
 }
 
 /**
@@ -52,18 +52,12 @@ export const updateTransaction = async (transactionData) => {
 
 export const fetchRecentTransactions = async (accountId, limit = 10) => {
   const params = { recent: true, limit }
-  const response = await axios.get(
-    `/api/transactions/${accountId}/transactions`,
-    { params }
-  )
+  const response = await axios.get(`/api/transactions/${accountId}/transactions`, { params })
   return response.data
 }
 
 export const fetchNetChanges = async (accountId, params = {}) => {
-  const response = await axios.get(
-    `/api/accounts/${accountId}/net_changes`,
-    { params }
-  )
+  const response = await axios.get(`/api/accounts/${accountId}/net_changes`, { params })
   return response.data
 }
 

--- a/frontend/src/api/transactions.js
+++ b/frontend/src/api/transactions.js
@@ -9,6 +9,8 @@
  * - `updateTransaction(transactionData)` - modify a transaction
  * - `fetchRecentTransactions(accountId, limit?)` - newest transactions for an account
  * - `fetchNetChanges(accountId, params?)` - income/expense totals for an account
+ * - `fetchTopMerchants(params?)` - highest spending merchants
+ * - `fetchTopCategories(params?)` - highest spending categories
  */
 import axios from 'axios'
 
@@ -63,4 +65,26 @@ export const fetchNetChanges = async (accountId, params = {}) => {
     { params }
   )
   return response.data
+}
+
+/**
+ * Fetch top merchants by spending.
+ *
+ * @param {Object} params - Optional query params like `start_date` and `end_date`.
+ * @returns {Promise<Array>} Array of merchant summaries.
+ */
+export const fetchTopMerchants = async (params = {}) => {
+  const response = await axios.get('/api/transactions/top_merchants', { params })
+  return response.data?.data || []
+}
+
+/**
+ * Fetch top categories by spending.
+ *
+ * @param {Object} params - Optional query params like `start_date` and `end_date`.
+ * @returns {Promise<Array>} Array of category summaries.
+ */
+export const fetchTopCategories = async (params = {}) => {
+  const response = await axios.get('/api/transactions/top_categories', { params })
+  return response.data?.data || []
 }

--- a/frontend/src/components/SpendingInsights.vue
+++ b/frontend/src/components/SpendingInsights.vue
@@ -11,11 +11,7 @@
       <section>
         <h3 class="font-semibold mb-2">Top Merchants</h3>
         <div class="flex flex-col gap-2 overflow-x-scroll">
-          <div
-            v-for="m in topMerchants"
-            :key="m.name"
-            class="flex items-center gap-2"
-          >
+          <div v-for="m in topMerchants" :key="m.name" class="flex items-center gap-2">
             <span class="flex-1 truncate whitespace-nowrap">{{ m.name }}</span>
             <span class="text-sm text-muted whitespace-nowrap">{{ formatCurrency(m.total) }}</span>
             <Line
@@ -30,11 +26,7 @@
       <section>
         <h3 class="font-semibold mb-2">Top Categories</h3>
         <div class="flex flex-col gap-2 overflow-x-scroll">
-          <div
-            v-for="c in topCategories"
-            :key="c.name"
-            class="flex items-center gap-2"
-          >
+          <div v-for="c in topCategories" :key="c.name" class="flex items-center gap-2">
             <span class="flex-1 truncate whitespace-nowrap">{{ c.name }}</span>
             <span class="text-sm text-muted whitespace-nowrap">{{ formatCurrency(c.total) }}</span>
             <Line
@@ -53,13 +45,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { Line } from 'vue-chartjs'
-import {
-  Chart,
-  LineElement,
-  PointElement,
-  LinearScale,
-  CategoryScale
-} from 'chart.js'
+import { Chart, LineElement, PointElement, LinearScale, CategoryScale } from 'chart.js'
 import { fetchTopMerchants, fetchTopCategories } from '@/api/transactions'
 import { formatCurrency } from '@/utils/currency'
 
@@ -73,16 +59,16 @@ const chartOptions = {
   maintainAspectRatio: false,
   scales: {
     x: { display: false },
-    y: { display: false }
+    y: { display: false },
   },
   elements: {
     line: { borderWidth: 1, tension: 0.3 },
-    point: { radius: 0 }
+    point: { radius: 0 },
   },
   plugins: {
     legend: { display: false },
-    tooltip: { enabled: false }
-  }
+    tooltip: { enabled: false },
+  },
 }
 
 function sparklineData(trend = []) {
@@ -92,9 +78,9 @@ function sparklineData(trend = []) {
       {
         data: trend,
         borderColor: 'var(--color-accent-magenta)',
-        fill: false
-      }
-    ]
+        fill: false,
+      },
+    ],
   }
 }
 

--- a/frontend/src/components/SpendingInsights.vue
+++ b/frontend/src/components/SpendingInsights.vue
@@ -1,0 +1,105 @@
+<!--
+  SpendingInsights.vue
+  Displays top merchants and spending categories with mini trend charts.
+-->
+<template>
+  <div
+    class="md:col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-magenta)] p-6 flex flex-col gap-4"
+  >
+    <h2 class="text-xl font-bold text-[var(--color-accent-magenta)]">Spending Insights</h2>
+    <div class="flex flex-col gap-6">
+      <section>
+        <h3 class="font-semibold mb-2">Top Merchants</h3>
+        <div class="flex flex-col gap-2 overflow-x-scroll">
+          <div
+            v-for="m in topMerchants"
+            :key="m.name"
+            class="flex items-center gap-2"
+          >
+            <span class="flex-1 truncate whitespace-nowrap">{{ m.name }}</span>
+            <span class="text-sm text-muted whitespace-nowrap">{{ formatCurrency(m.total) }}</span>
+            <Line
+              v-if="m.trend && m.trend.length"
+              :data="sparklineData(m.trend)"
+              :options="chartOptions"
+              class="w-16 h-6"
+            />
+          </div>
+        </div>
+      </section>
+      <section>
+        <h3 class="font-semibold mb-2">Top Categories</h3>
+        <div class="flex flex-col gap-2 overflow-x-scroll">
+          <div
+            v-for="c in topCategories"
+            :key="c.name"
+            class="flex items-center gap-2"
+          >
+            <span class="flex-1 truncate whitespace-nowrap">{{ c.name }}</span>
+            <span class="text-sm text-muted whitespace-nowrap">{{ formatCurrency(c.total) }}</span>
+            <Line
+              v-if="c.trend && c.trend.length"
+              :data="sparklineData(c.trend)"
+              :options="chartOptions"
+              class="w-16 h-6"
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { Line } from 'vue-chartjs'
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale
+} from 'chart.js'
+import { fetchTopMerchants, fetchTopCategories } from '@/api/transactions'
+import { formatCurrency } from '@/utils/currency'
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale)
+
+const topMerchants = ref([])
+const topCategories = ref([])
+
+const chartOptions = {
+  responsive: false,
+  maintainAspectRatio: false,
+  scales: {
+    x: { display: false },
+    y: { display: false }
+  },
+  elements: {
+    line: { borderWidth: 1, tension: 0.3 },
+    point: { radius: 0 }
+  },
+  plugins: {
+    legend: { display: false },
+    tooltip: { enabled: false }
+  }
+}
+
+function sparklineData(trend = []) {
+  return {
+    labels: trend.map((_, i) => i),
+    datasets: [
+      {
+        data: trend,
+        borderColor: 'var(--color-accent-magenta)',
+        fill: false
+      }
+    ]
+  }
+}
+
+onMounted(async () => {
+  topMerchants.value = await fetchTopMerchants()
+  topCategories.value = await fetchTopCategories()
+})
+</script>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -124,15 +124,7 @@
             }}</span>
           </div>
         </div>
-        <!-- Spending Insights Placeholder -->
-        <div
-          class="md:col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-magenta)] p-6 flex flex-col items-center justify-center"
-        >
-          <h2 class="text-xl font-bold text-[var(--color-accent-magenta)] mb-4">
-            Spending Insights
-          </h2>
-          <p class="italic text-muted text-center">More detailed insights coming soon...</p>
-        </div>
+        <SpendingInsights />
       </div>
 
       <!-- RESERVED TABLES PANEL -->
@@ -245,6 +237,7 @@ import TopAccountSnapshot from '@/components/widgets/TopAccountSnapshot.vue'
 import RecentTransactions from '@/components/widgets/RecentTransactions.vue'
 import GroupedCategoryDropdown from '@/components/ui/GroupedCategoryDropdown.vue'
 import FinancialSummary from '@/components/statistics/FinancialSummary.vue'
+import SpendingInsights from '@/components/SpendingInsights.vue'
 import { formatAmount } from '@/utils/format'
 import { ref, computed, onMounted, watch } from 'vue'
 import api from '@/services/api'


### PR DESCRIPTION
## Summary
- add API helpers to fetch top merchants and categories
- display new SpendingInsights component with sparkline trends
- replace dashboard placeholder with SpendingInsights widget

## Testing
- `npx eslint src/api/transactions.js src/components/SpendingInsights.vue src/views/Dashboard.vue`
- `npm test`
- `pre-commit run --files frontend/src/api/transactions.js frontend/src/components/SpendingInsights.vue frontend/src/views/Dashboard.vue`

------
https://chatgpt.com/codex/tasks/task_e_68abd20e68cc832992d79328828978df