### PR TITLE
feat(accounts): horizontal filters align control bar

### DIFF
--- a/frontend/cypress/e2e/accounts.cy.js
+++ b/frontend/cypress/e2e/accounts.cy.js
@@ -3,7 +3,7 @@
 
 describe('Accounts control bar', () => {
   it('aligns with the table header', () => {
-    cy.visit('/accounts/table')
+    cy.visit('/accounts')
     cy.get('[data-testid="accounts-control-bar"]').then(($bar) => {
       const barRight = $bar[0].getBoundingClientRect().right
       cy.get('table thead').then(($head) => {

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -6,10 +6,7 @@
       Accounts
     </h2>
     <!-- Controls/Filters -->
-    <div
-      class="mb-4 flex flex-wrap items-center gap-2"
-      data-testid="accounts-control-bar"
-    >
+    <div class="mb-4 flex flex-wrap items-center gap-2" data-testid="accounts-control-bar">
       <div class="flex items-center gap-2 flex-wrap flex-1">
         <input
           v-model="searchQuery"

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -1,3 +1,4 @@
+<!-- AccountsTable.vue - Table of linked accounts with filter controls. -->
 <template>
   <div class="card bg-neutral-950 border border-neutral-800 shadow-xl rounded-2xl p-4 md:p-6">
     <h2 class="font-bold text-xl mb-6 text-left tracking-wide text-blue-300 flex items-center">
@@ -6,10 +7,10 @@
     </h2>
     <!-- Controls/Filters -->
     <div
-      class="mb-4 flex items-center justify-between flex-wrap gap-2"
+      class="mb-4 flex flex-wrap items-center gap-2"
       data-testid="accounts-control-bar"
     >
-      <div class="flex items-center gap-2 flex-wrap">
+      <div class="flex items-center gap-2 flex-wrap flex-1">
         <input
           v-model="searchQuery"
           class="filter-input"
@@ -33,7 +34,7 @@
         </template>
       </div>
       <!-- Maintain width alignment with sparkline column -->
-      <div class="w-[60px]"></div>
+      <div class="flex-none w-[60px]"></div>
     </div>
     <div class="type-filter-row" :class="{ 'slide-in': showTypeFilter }">
       <select multiple v-model="typeFilters" class="filter-input">

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -60,10 +60,7 @@
             v-for="range in ranges"
             :key="range"
             @click="selectedRange = range"
-            :class="[
-              'btn btn-sm',
-              selectedRange === range ? '' : 'btn-outline',
-            ]"
+            :class="['btn btn-sm', selectedRange === range ? '' : 'btn-outline']"
           >
             {{ range }}
           </button>

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -55,12 +55,19 @@
     <Card class="p-6 space-y-4">
       <div class="flex justify-between items-center">
         <h2 class="text-xl font-semibold">Balance History</h2>
-        <select v-model="selectedRange" data-testid="filter-dropdown" class="border rounded p-1">
-          <option value="7d">7d</option>
-          <option value="30d">30d</option>
-          <option value="90d">90d</option>
-          <option value="365d">365d</option>
-        </select>
+        <div class="flex gap-2" data-testid="history-range-controls">
+          <button
+            v-for="range in ranges"
+            :key="range"
+            @click="selectedRange = range"
+            :class="[
+              'btn btn-sm',
+              selectedRange === range ? '' : 'btn-outline',
+            ]"
+          >
+            {{ range }}
+          </button>
+        </div>
       </div>
       <div v-if="loadingHistory" class="text-center py-4 text-muted">Loading...</div>
       <div v-else-if="historyError" class="text-center py-4 text-error">Failed to load history</div>
@@ -162,6 +169,7 @@ const netSummary = ref({ income: 0, expense: 0, net: 0 })
 const recentTransactions = ref([])
 const accountHistory = ref([])
 const selectedRange = ref('30d')
+const ranges = ['7d', '30d', '90d', '365d']
 
 // Loading/Error States
 const loadingSummary = ref(false)


### PR DESCRIPTION
## Summary
- switch balance history range dropdown to horizontal button controls
- flex-align accounts table control bar with sparkline column
- test control bar alignment on accounts page

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e -- --spec cypress/e2e/accounts.cy.js` *(fails: server started but Cypress run did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68abe15d790c83299ab342a6cc011163