### PR TITLE
feat: add dev watcher script for auto-pull updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ This script creates a virtual environment, installs backend and frontend depende
    npm run dev
    ```
 
+For automatic updates when new commits are pushed to the repository, use the
+watcher script from the project root:
+
+```bash
+./scripts/dev-watcher.sh
+```
+
+It starts the frontend development server and periodically performs a
+`git pull --rebase` when the tracked branch receives new commits, ensuring Git
+hooks run and the server restarts with the latest changes.
+
 ## Testing
 
 - Backend tests:

--- a/scripts/dev-watcher.sh
+++ b/scripts/dev-watcher.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# dev-watcher.sh - Run the frontend dev server and auto-pull repo updates.
+#
+# Starts `npm run dev` for the frontend and periodically checks the remote Git
+# repository for updates. When new commits are detected on the tracked branch,
+# the script pulls the changes (triggering any Git hooks) and restarts the dev
+# server.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="${REPO_DIR}/frontend"
+BRANCH="${1:-$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)}"
+INTERVAL="${INTERVAL:-60}"
+
+declare DEV_PID=0
+
+start_dev() {
+  echo "Starting npm dev server..."
+  cd "${FRONTEND_DIR}"
+  npm run dev &
+  DEV_PID=$!
+  cd "${REPO_DIR}"
+}
+
+stop_dev() {
+  if [ "${DEV_PID}" -ne 0 ] && kill -0 "${DEV_PID}" 2>/dev/null; then
+    echo "Stopping npm dev server (PID: ${DEV_PID})"
+    kill "${DEV_PID}"
+    wait "${DEV_PID}" || true
+  fi
+}
+
+trap stop_dev EXIT
+
+cd "${REPO_DIR}"
+start_dev
+
+while true; do
+  git fetch origin "${BRANCH}"
+  LOCAL=$(git rev-parse "${BRANCH}")
+  REMOTE=$(git rev-parse "origin/${BRANCH}")
+  if [ "${LOCAL}" != "${REMOTE}" ]; then
+    echo "Changes detected on origin/${BRANCH}. Pulling updates..."
+    stop_dev
+    git pull --rebase
+    start_dev
+  fi
+  sleep "${INTERVAL}"
+
+done


### PR DESCRIPTION
## Summary
- add `scripts/dev-watcher.sh` to run frontend dev server and auto-pull repo updates
- document dev watcher usage in README

## Testing
- `pytest` *(fails: Module import errors / missing tables)*
- `npm run test:unit` *(fails: Xvfb dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a1572808329966140e5f94e86d9