### PR TITLE
chore: add SCIP indexing workflow

### DIFF
--- a/.github/workflows/scip-index.yml
+++ b/.github/workflows/scip-index.yml
@@ -1,0 +1,29 @@
+name: scip-index
+on: [push, workflow_dispatch]
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TypeScript/JS
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm i -g @sourcegraph/scip-typescript
+      - run: npm ci || true
+      - run: scip-typescript index
+      - run: tar -czf scip-ts.tar.gz index.scip || true
+
+      # Python
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install scip-python
+      - run: scip-python index .
+      - run: tar -czf scip-py.tar.gz index.scip || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: scip-indexes
+          path: |
+            scip-ts.tar.gz
+            scip-py.tar.gz


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to generate SCIP indexes for TypeScript and Python

## Testing
- `pre-commit run --files .github/workflows/scip-index.yml` *(fails: model-field-validation: ERROR: not found: /workspace/pyNance/.github/workflows/scip-index.yml)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4adfa4348329bb5f872156f8cbe2