### PR TITLE
chore: add SCIP indexing workflow

### DIFF
--- a/.github/workflows/scip-index.yml
+++ b/.github/workflows/scip-index.yml
@@ -1,0 +1,29 @@
+name: scip-index
+on: [push, workflow_dispatch]
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TypeScript/JS
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm i -g @sourcegraph/scip-typescript
+      - run: npm ci || true
+      - run: scip-typescript index
+      - run: tar -czf scip-ts.tar.gz index.scip || true
+
+      # Python
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install scip-python
+      - run: scip-python index .
+      - run: tar -czf scip-py.tar.gz index.scip || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: scip-indexes
+          path: |
+            scip-ts.tar.gz
+            scip-py.tar.gz

--- a/tests/test_investments_logic.py
+++ b/tests/test_investments_logic.py
@@ -1,3 +1,5 @@
+"""Unit tests for investment account logic."""
+
 import importlib.util
 import os
 import sys
@@ -47,6 +49,10 @@ def setup_app(tmp_path):
 
 @pytest.fixture()
 def db_ctx(tmp_path):
+    # Ensure no stubbed modules leak from other tests
+    sys.modules.pop("app.extensions", None)
+    sys.modules.pop("app.models", None)
+    sys.modules.pop("app.sql", None)
     app, extensions = setup_app(tmp_path)
     with app.app_context():
         models = load_module(

--- a/tests/test_recurring_bridge.py
+++ b/tests/test_recurring_bridge.py
@@ -1,6 +1,8 @@
 # tests/test_recurring_bridge.py
 import importlib.util
 import logging
+"""Tests for recurring bridge database sync."""
+
 import os
 import sys
 import types
@@ -52,6 +54,10 @@ def setup_sqlite_app(tmp_path):
 
 @pytest.fixture
 def db_ctx(tmp_path):
+    # Clear potentially stubbed modules
+    sys.modules.pop("app.extensions", None)
+    sys.modules.pop("app.models", None)
+    sys.modules.pop("app.sql", None)
     app, extensions = setup_sqlite_app(tmp_path)
     with app.app_context():
         try:

--- a/tests/test_recurring_bridge.py
+++ b/tests/test_recurring_bridge.py
@@ -1,6 +1,7 @@
 # tests/test_recurring_bridge.py
 import importlib.util
 import logging
+
 """Tests for recurring bridge database sync."""
 
 import os

--- a/tests/test_save_plaid_account.py
+++ b/tests/test_save_plaid_account.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
 import sys
+"""Tests for saving Plaid account records."""
+
 import types
 
 import pytest
@@ -76,6 +78,9 @@ def setup_app(tmp_path):
 
 @pytest.fixture()
 def db_ctx(tmp_path):
+    sys.modules.pop("app.extensions", None)
+    sys.modules.pop("app.models", None)
+    sys.modules.pop("app.sql", None)
     app, extensions = setup_app(tmp_path)
     with app.app_context():
         models = load_module(

--- a/tests/test_save_plaid_account.py
+++ b/tests/test_save_plaid_account.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import sys
+
 """Tests for saving Plaid account records."""
 
 import types


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to generate SCIP indexes for TypeScript and Python
- isolate test fixtures to avoid leaking stubbed modules between tests

## Testing
- `python -m pre_commit run --files tests/test_api_account_history.py tests/test_investments_logic.py tests/test_recurring_bridge.py tests/test_save_plaid_account.py` *(fails: sqlalchemy.exc.OperationalError: no such table: accounts)*
- `pytest` *(fails: sqlalchemy.exc.OperationalError: no such table: accounts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4adfa4348329bb5f872156f8cbe2