### PR TITLE
feat: add tree-sitter symbol map tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,9 @@ repos:
     rev: v3.1.0
     hooks:
       - id: pylint
+        additional_dependencies:
+          - tree-sitter==0.20.2
+          - tree-sitter-languages==1.10.2
 
   # Enforce bandit
   - repo: https://github.com/PyCQA/bandit
@@ -44,6 +47,7 @@ repos:
     hooks:
       - id: bandit
         args: ["-r", "backend/app/routes"]
+        additional_dependencies: ["pbr"]
 
   - repo: local
     hooks:
@@ -51,3 +55,4 @@ repos:
         name: Validate model fields
         entry: pytest tests/test_model_field_validation.py
         language: system
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
   # Black: A Python code formatter
   - repo: https://github.com/psf/black
-    rev: 23.1.0  # Specify the version of Black to use
+    rev: 23.1.0 # Specify the version of Black to use
     hooks:
       - id: black
-        language_version: python3  # Ensure the Python version matches your project requirements
+        language_version: python3 # Ensure the Python version matches your project requirements
 
   # isort: A Python import sorter
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1  # Use the latest version of isort
+    rev: v5.10.1 # Use the latest version of isort
     hooks:
       - id: isort
         args:
           - "--profile"
-          - "black"  # Align isort with Black's formatting rules
+          - "black" # Align isort with Black's formatting rules
 
   # Ruff: An extremely fast Python linter and code formatter
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.287  # Specify the version of Ruff to use
+    rev: v0.0.287 # Specify the version of Ruff to use
     hooks:
       - id: ruff
         args:
-          - "--fix"  # Automatically fix issues found by Ruff
-          - "--line-length=120"  # Set the maximum line length
-          - "--ignore=E501,E203,E402"  # Ignore specific error codes (adjust as needed)
+          - "--fix" # Automatically fix issues found by Ruff
+          - "--line-length=120" # Set the maximum line length
+          - "--ignore=E501,E203,E402" # Ignore specific error codes (adjust as needed)
 
   # Static type checking with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/docs/maintenance/symbol_map.md
+++ b/docs/maintenance/symbol_map.md
@@ -1,0 +1,23 @@
+# Symbol Map Tool
+
+`tools/symbol_map.py` builds a JSON index of top-level functions,
+classes and methods for Python and TypeScript code. The output helps
+maintenance agents quickly gather context about the codebase.
+
+## Usage
+
+Install development dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Generate a symbol map for the repository:
+
+```bash
+python tools/symbol_map.py . > symbols.json
+```
+
+The resulting `symbols.json` maps each source file to a list of symbols
+with their type, name, location and a truncated snippet of the source
+code.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ chromadb==1.0.12
 qdrant-client
 sentence-transformers
 playwright==1.43.0
+tree-sitter==0.20.2
+tree-sitter-languages==1.10.2

--- a/tools.yaml
+++ b/tools.yaml
@@ -51,3 +51,30 @@ dependencies:
   - sentence-transformers
   - Python 3.8+
   - (optional) OS environment variables: CHROMA_COLLECTION, CHROMA_RESULT_COUNT, CHROMA_HOST, CHROMA_PORT, CHROMA_MODEL
+
+---
+name: symbol_map
+description: |
+  Generate a JSON map of functions, classes and methods for Python and TypeScript
+  sources using Tree-sitter. Useful for maintaining an up-to-date view of the
+  codebase for agentic workflows.
+entrypoint: python tools/symbol_map.py
+arguments:
+  - name: repo
+    type: string
+    default: "."
+    description: "Repository root to scan."
+usage_examples:
+  - command: |
+      python tools/symbol_map.py . > symbols.json
+    description: |
+      Create a symbol map for the current repository and save it to a file.
+outputs:
+  - name: symbols
+    description: "JSON mapping of file paths to discovered symbols."
+agent_guidance: |
+  Run this after significant code changes to refresh context used by
+  maintenance agents.
+dependencies:
+  - tree-sitter
+  - tree-sitter-languages

--- a/tools/symbol_map.py
+++ b/tools/symbol_map.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate a symbol map for source files using Tree-sitter.
+
+This utility scans Python, TypeScript, JavaScript and TSX files in a
+repository and outputs a JSON structure describing the top-level
+functions, classes and methods found in each file. The symbol map helps
+agents maintain context about the codebase for refactoring and
+navigation tasks.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from tree_sitter import Parser
+from tree_sitter_languages import get_language
+
+LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".js": "javascript",
+    ".tsx": "tsx",
+}
+
+TARGET_TYPES = {"function_definition", "class_definition", "method_definition"}
+
+
+def sym_map(path: Path) -> List[Dict[str, Any]]:
+    """Return a list of symbol metadata for ``path``.
+
+    Parameters
+    ----------
+    path:
+        Source file to inspect.
+
+    Returns
+    -------
+    list of dict
+        Each item describes a discovered symbol with its kind, name,
+        location and a snippet limited to 4,000 characters.
+    """
+
+    lang_name = LANGUAGE_BY_SUFFIX.get(path.suffix)
+    if lang_name is None:
+        return []
+
+    parser = Parser()
+    parser.set_language(get_language(lang_name))
+
+    src = path.read_bytes()
+    tree = parser.parse(src)
+    out: List[Dict[str, Any]] = []
+
+    def walk(node: Any) -> None:
+        if node.type in TARGET_TYPES:
+            snippet = src[node.start_byte : node.end_byte].decode("utf-8", "ignore")
+            ident = next(
+                (c.text.decode() for c in node.children if c.type == "identifier"),
+                "",
+            )
+            out.append(
+                {
+                    "kind": node.type,
+                    "name": ident,
+                    "start": node.start_point,
+                    "end": node.end_point,
+                    "snippet": snippet[:4000],
+                }
+            )
+        for child in node.children:
+            walk(child)
+
+    walk(tree.root_node)
+    return out
+
+
+def build_map(repo: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Construct a symbol map for all supported files under ``repo``."""
+    files = [p for p in repo.rglob("*") if p.suffix in LANGUAGE_BY_SUFFIX]
+    return {str(p.relative_to(repo)): sym_map(p) for p in files}
+
+
+def main() -> None:
+    """Entry point for command-line usage."""
+    repo = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    data = build_map(repo.resolve())
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/symbol_map.py
+++ b/tools/symbol_map.py
@@ -7,6 +7,7 @@ functions, classes and methods found in each file. The symbol map helps
 agents maintain context about the codebase for refactoring and
 navigation tasks.
 """
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- add `symbol_map.py` utility for generating Tree-sitter based symbol maps
- document usage and dependencies for continuous codebase context
- expose new tool via `tools.yaml` and update development dependencies

## Testing
- `pre-commit run --files tools/symbol_map.py requirements-dev.txt tools.yaml docs/maintenance/symbol_map.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'plaid')*

------
https://chatgpt.com/codex/tasks/task_e_68ad6550c88c8329967bb69d5bcc7e83