### PR TITLE
docs: correct backend database type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyNance
 
-pyNance is a full-stack personal finance dashboard that combines a Flask API, a Vue 3 client, and a PostgreSQL database. It connects to financial institutions through Plaid and Teller to aggregate accounts and transactions.
+pyNance is a full-stack personal finance dashboard that combines a Flask API, a Vue 3 client, and a SQLite database. It connects to financial institutions through Plaid and Teller to aggregate accounts and transactions.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- fix README to state backend uses SQLite instead of PostgreSQL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad89ce6638832980f821ca7bea32a3