### PR TITLE
fix(layout): center routed views with padding

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,8 @@
 <script setup>
 /**
  * Root application shell.
- * Renders the navigation bar and centers all routed views.
+ * Renders the navigation bar and centers all routed views with
+ * consistent horizontal margins and vertical padding.
  */
 import Navbar from '@/components/layout/Navbar.vue'
 import { RouterView } from 'vue-router'
@@ -19,9 +20,7 @@ const isDev = import.meta.env.VITE_SESSION_MODE === 'development'
     <Navbar />
   </header>
 
-  <main>
-    <div class="container">
-      <RouterView />
-    </div>
+  <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+    <RouterView />
   </main>
 </template>


### PR DESCRIPTION
## Summary
- center routed views within a max-width layout
- apply consistent horizontal and vertical padding for pages

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f6105048329a63901915394adb0