### PR TITLE
fix(frontend): sanitize console log input

### DIFF
--- a/frontend/src/components/recurring/NotificationsBar.vue
+++ b/frontend/src/components/recurring/NotificationsBar.vue
@@ -20,7 +20,9 @@
 
 <script>
 import axios from "axios";
+import { sanitizeForLog } from "../../utils/sanitize.js";
 
+// Component to display account notifications and manage recurring transactions.
 export default {
   props: ["accountId", "currentApr"],
   data() {
@@ -30,27 +32,39 @@ export default {
     };
   },
   methods: {
+    /**
+     * Save the recurring transaction amount and refresh the reminder list.
+     */
     async saveRecurring() {
       try {
         const resp = await axios.put(`/api/accounts/${this.accountId}/recurringTx`, {
           amount: this.txRecur
         });
-        console.log("Recurring transaction updated:", resp.data);
+        console.log("Recurring transaction updated:", sanitizeForLog(resp.data));
         await this.fetchRecurringTransactions();
       } catch (err) {
-        console.error("Error updating recurring transaction:", err);
+        console.error(
+          "Error updating recurring transaction:",
+          sanitizeForLog(err.message || err)
+        );
       }
     },
+    /**
+     * Load existing recurring transaction reminders for the account.
+     */
     async fetchRecurringTransactions() {
-  try {
-    const resp = await axios.get(`/api/accounts/${this.accountId}/recurring`);
-    if (resp.data.status === "success") {
-      this.notifications = resp.data.reminders;
+      try {
+        const resp = await axios.get(`/api/accounts/${this.accountId}/recurring`);
+        if (resp.data.status === "success") {
+          this.notifications = resp.data.reminders;
+        }
+      } catch (err) {
+        console.error(
+          "Error fetching recurring transactions:",
+          sanitizeForLog(err.message || err)
+        );
+      }
     }
-  } catch (err) {
-    console.error("Error fetching recurring transactions:", err);
-  }
-}
   },
   created() {
     this.fetchRecurringTransactions();

--- a/frontend/src/components/recurring/NotificationsBar.vue
+++ b/frontend/src/components/recurring/NotificationsBar.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
     <div class="bg-[#333] text-white p-4 mb-4 rounded-[6px]">
-      <p 
-        v-for="(notif, idx) in notifications" 
-        :key="idx" 
-        class="my-1"
-      >
+      <p v-for="(notif, idx) in notifications" :key="idx" class="my-1">
         {{ notif }}
       </p>
     </div>
@@ -19,17 +15,17 @@
 </template>
 
 <script>
-import axios from "axios";
-import { sanitizeForLog } from "../../utils/sanitize.js";
+import axios from 'axios'
+import { sanitizeForLog } from '../../utils/sanitize.js'
 
 // Component to display account notifications and manage recurring transactions.
 export default {
-  props: ["accountId", "currentApr"],
+  props: ['accountId', 'currentApr'],
   data() {
     return {
       notifications: [],
-      txRecur: this.currentApr || 0
-    };
+      txRecur: this.currentApr || 0,
+    }
   },
   methods: {
     /**
@@ -38,15 +34,12 @@ export default {
     async saveRecurring() {
       try {
         const resp = await axios.put(`/api/accounts/${this.accountId}/recurringTx`, {
-          amount: this.txRecur
-        });
-        console.log("Recurring transaction updated:", sanitizeForLog(resp.data));
-        await this.fetchRecurringTransactions();
+          amount: this.txRecur,
+        })
+        console.log('Recurring transaction updated:', sanitizeForLog(resp.data))
+        await this.fetchRecurringTransactions()
       } catch (err) {
-        console.error(
-          "Error updating recurring transaction:",
-          sanitizeForLog(err.message || err)
-        );
+        console.error('Error updating recurring transaction:', sanitizeForLog(err.message || err))
       }
     },
     /**
@@ -54,20 +47,17 @@ export default {
      */
     async fetchRecurringTransactions() {
       try {
-        const resp = await axios.get(`/api/accounts/${this.accountId}/recurring`);
-        if (resp.data.status === "success") {
-          this.notifications = resp.data.reminders;
+        const resp = await axios.get(`/api/accounts/${this.accountId}/recurring`)
+        if (resp.data.status === 'success') {
+          this.notifications = resp.data.reminders
         }
       } catch (err) {
-        console.error(
-          "Error fetching recurring transactions:",
-          sanitizeForLog(err.message || err)
-        );
+        console.error('Error fetching recurring transactions:', sanitizeForLog(err.message || err))
       }
-    }
+    },
   },
   created() {
-    this.fetchRecurringTransactions();
+    this.fetchRecurringTransactions()
   },
-};
+}
 </script>

--- a/frontend/src/composables/useAccountSelector.js
+++ b/frontend/src/composables/useAccountSelector.js
@@ -11,12 +11,12 @@ export function useAccountSelector() {
   const error = ref(null)
 
   // Computed properties
-  const selectedAccounts = computed(() => 
-    allAccounts.value.filter(account => selectedAccountIds.value.includes(account.account_id))
+  const selectedAccounts = computed(() =>
+    allAccounts.value.filter((account) => selectedAccountIds.value.includes(account.account_id)),
   )
 
-  const availableAccounts = computed(() => 
-    allAccounts.value.map(account => ({
+  const availableAccounts = computed(() =>
+    allAccounts.value.map((account) => ({
       id: account.account_id,
       name: account.name,
       type: account.type,
@@ -24,8 +24,8 @@ export function useAccountSelector() {
       institution_name: account.institution_name,
       mask: account.mask,
       balance: account.adjusted_balance || account.balance || 0,
-      institution_icon_url: account.institution_icon_url
-    }))
+      institution_icon_url: account.institution_icon_url,
+    })),
   )
 
   const hasSelection = computed(() => selectedAccountIds.value.length > 0)
@@ -38,11 +38,11 @@ export function useAccountSelector() {
   async function fetchAccounts() {
     loading.value = true
     error.value = null
-    
+
     try {
       const response = await fetch('/api/accounts/get_accounts')
       const data = await response.json()
-      
+
       if (data.status === 'success' && data.accounts) {
         allAccounts.value = data.accounts
         console.log(`Loaded ${sanitizeForLog(data.accounts.length)} accounts for selector`)
@@ -64,7 +64,7 @@ export function useAccountSelector() {
   }
 
   function deselectAccount(accountId) {
-    selectedAccountIds.value = selectedAccountIds.value.filter(id => id !== accountId)
+    selectedAccountIds.value = selectedAccountIds.value.filter((id) => id !== accountId)
   }
 
   function toggleAccount(accountId) {
@@ -76,7 +76,7 @@ export function useAccountSelector() {
   }
 
   function selectAll() {
-    selectedAccountIds.value = allAccounts.value.map(account => account.account_id)
+    selectedAccountIds.value = allAccounts.value.map((account) => account.account_id)
   }
 
   function deselectAll() {
@@ -85,9 +85,9 @@ export function useAccountSelector() {
 
   function selectAccountsByType(type) {
     const accountIds = allAccounts.value
-      .filter(account => account.type === type)
-      .map(account => account.account_id)
-    
+      .filter((account) => account.type === type)
+      .map((account) => account.account_id)
+
     selectedAccountIds.value = [...new Set([...selectedAccountIds.value, ...accountIds])]
   }
 
@@ -102,12 +102,12 @@ export function useAccountSelector() {
     selectedAccountIds,
     loading,
     error,
-    
+
     // Computed
     selectedAccounts,
     availableAccounts,
     hasSelection,
-    
+
     // Methods
     fetchAccounts,
     selectAccount,
@@ -115,6 +115,6 @@ export function useAccountSelector() {
     toggleAccount,
     selectAll,
     deselectAll,
-    selectAccountsByType
+    selectAccountsByType,
   }
 }

--- a/frontend/src/composables/useAccountSelector.js
+++ b/frontend/src/composables/useAccountSelector.js
@@ -1,4 +1,8 @@
+/**
+ * Composable for selecting accounts with sanitized logging.
+ */
 import { ref, computed, onMounted } from 'vue'
+import { sanitizeForLog } from '../utils/sanitize.js'
 
 export function useAccountSelector() {
   const allAccounts = ref([])
@@ -27,6 +31,10 @@ export function useAccountSelector() {
   const hasSelection = computed(() => selectedAccountIds.value.length > 0)
 
   // Methods
+  /**
+   * Retrieve accounts from API and update state.
+   * Logs sanitized account count on success.
+   */
   async function fetchAccounts() {
     loading.value = true
     error.value = null
@@ -37,12 +45,12 @@ export function useAccountSelector() {
       
       if (data.status === 'success' && data.accounts) {
         allAccounts.value = data.accounts
-        console.log(`Loaded ${data.accounts.length} accounts for selector`)
+        console.log(`Loaded ${sanitizeForLog(data.accounts.length)} accounts for selector`)
       } else {
         throw new Error(data.message || 'Failed to fetch accounts')
       }
     } catch (e) {
-      console.error('Error fetching accounts:', e)
+      console.error('Error fetching accounts:', sanitizeForLog(e.message || e))
       error.value = e.message || 'Failed to fetch accounts'
     } finally {
       loading.value = false

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -5,9 +5,6 @@
  * @returns {string} A sanitized string safe for console output.
  */
 export function sanitizeForLog(input) {
-  const json = typeof input === 'string' ? input : JSON.stringify(input);
-  return json
-    .replace(/</g, '\\u003C')
-    .replace(/>/g, '\\u003E')
-    .replace(/&/g, '\\u0026');
+  const json = typeof input === 'string' ? input : JSON.stringify(input)
+  return json.replace(/</g, '\\u003C').replace(/>/g, '\\u003E').replace(/&/g, '\\u0026')
 }

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -1,0 +1,13 @@
+/**
+ * Utility functions for sanitizing values before logging.
+ * Escapes HTML-sensitive characters to prevent log injection.
+ * @param {unknown} input - The value to sanitize.
+ * @returns {string} A sanitized string safe for console output.
+ */
+export function sanitizeForLog(input) {
+  const json = typeof input === 'string' ? input : JSON.stringify(input);
+  return json
+    .replace(/</g, '\\u003C')
+    .replace(/>/g, '\\u003E')
+    .replace(/&/g, '\\u0026');
+}


### PR DESCRIPTION
## Summary
- add sanitizeForLog utility to escape log output
- sanitize account selector and recurring notifications console messages

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef8e950408329b1f407658ae4b5db