### PR TITLE
feat(frontend): add income and expense trend deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- feat: display income and expense trend deltas in dashboard financial summary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ## Unreleased
+
 - feat: display income and expense trend deltas in dashboard financial summary.

--- a/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
+++ b/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FinancialSummary from '../FinancialSummary.vue'
+
+describe('FinancialSummary trends', () => {
+  it('shows income and expense trend deltas', async () => {
+    const wrapper = mount(FinancialSummary, {
+      props: {
+        summary: { totalIncome: 300, totalExpenses: 200, totalNet: 100 },
+        chartData: [
+          {
+            date: '2024-01-01',
+            income: { parsedValue: 100 },
+            expenses: { parsedValue: -50 },
+            net: { parsedValue: 50 },
+          },
+          {
+            date: '2024-01-02',
+            income: { parsedValue: 200 },
+            expenses: { parsedValue: -150 },
+            net: { parsedValue: 50 },
+          },
+        ],
+      },
+    })
+
+    await wrapper.find('.stats-toggle-btn').trigger('click')
+    const html = wrapper.html()
+    expect(html).toContain('Income Trend')
+    expect(html).toContain('+$100.00')
+    expect(html).toContain('Expense Trend')
+    expect(html).toContain('+$100.00')
+  })
+})


### PR DESCRIPTION
## Summary
- extend FinancialSummary to show net, income, and expense trends with signed deltas
- cover FinancialSummary trend display with a component test
- initialize project CHANGELOG

## Testing
- `pytest`
- `npm run lint`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57af8c7248329a03b0fdfd4302902