### PR TITLE
docs: document product configuration and multi-product linking

### DIFF
--- a/docs/backend/app/config/environment.md
+++ b/docs/backend/app/config/environment.md
@@ -5,4 +5,16 @@
 Loads `.env` values using `python-dotenv`. Defines keys for Plaid and Teller,
 application mode (`FLASK_ENV`), and other runtime settings. This module centralizes
 all environment lookups so the rest of the code can import settings directly.
+
+### Key Variables
+
+- `PRODUCTS` – comma-separated list of Plaid products enabled for linking.
+  Defaults to `"transactions"` when unset. Values are consumed as a Python list
+  in `environment.py` via `os.getenv("PRODUCTS", "transactions").split(",")`.
+- `PLAID_ENV` – target Plaid environment (`sandbox`, `development`, `production`).
+- `CLIENT_NAME` – display name passed to Plaid Link.
+
+Specify multiple products (e.g., `transactions,investments`) to generate Link
+tokens that cover more than one product. Each product still needs a separate
+token exchange on the backend to persist its credentials.
 ```

--- a/docs/backend/app/config/environment.md
+++ b/docs/backend/app/config/environment.md
@@ -1,4 +1,5 @@
 ## 📘 `environment.py`
+
 ```markdown
 # Environment Variables
 

--- a/docs/backend/app/routes/plaid.md
+++ b/docs/backend/app/routes/plaid.md
@@ -13,8 +13,10 @@ Handles authentication and data integration with the Plaid API. Supports institu
 
 ## Key Endpoints
 
-- `POST /plaid/link-token`: Initiates a link token generation.
-- `POST /plaid/exchange`: Exchanges public token for access token.
+- `POST /plaid/link-token`: Initiates link token generation. Accepts optional
+  `products` array to enable multiple Plaid products in a single Link flow.
+- `POST /plaid/exchange`: Exchanges public token for access token. Requires a
+  `product` field to tag the resulting credentials.
 - `GET /plaid/accounts`: Retrieves linked account metadata.
 - `GET /plaid/transactions`: Fetches Plaid-synced transactions.
 - `POST /plaid/sync`: Forces a manual sync with Plaid.
@@ -22,12 +24,12 @@ Handles authentication and data integration with the Plaid API. Supports institu
 ## Inputs & Outputs
 
 - **POST /plaid/link-token**
-  - **Input:** `{}`
+  - **Input:** `{ user_id: str, products?: [str, ...] }`
   - **Output:** `{ link_token: str }`
 
 - **POST /plaid/exchange**
-  - **Input:** `{ public_token: str }`
-  - **Output:** `{ access_token: str, item_id: str }`
+  - **Input:** `{ public_token: str, product: str }`
+  - **Output:** `{ access_token: str, item_id: str, product: str }`
 
 - **GET /plaid/accounts**
   - **Output:**
@@ -50,6 +52,10 @@ Handles authentication and data integration with the Plaid API. Supports institu
 - Uses client-side link flow for Plaid integration
 - Triggers webhook registration post-link
 - Syncs occur automatically and can be forced
+- When multiple products are requested, Plaid generates a single link token
+  covering each product. The client must call `/plaid/exchange` separately for
+  every selected product so the backend can persist credentials with a
+  product tag.
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary
- document `PRODUCTS` env var for selecting Plaid products
- clarify Plaid link/exchange endpoints when multiple products are requested

## Testing
- `pytest -q`
- `pre-commit run --files docs/backend/app/config/environment.md docs/backend/app/routes/plaid.md`

------
https://chatgpt.com/codex/tasks/task_e_68b913dfa3a0832996f31801288975cd