### PR TITLE
feat(frontend): add reusable footer component

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -15,6 +15,7 @@ declare module 'vue' {
     AccountSparkline: typeof import('./components/widgets/AccountSparkline.vue')['default']
     AccountsReorderChart: typeof import('./components/charts/AccountsReorderChart.vue')['default']
     AccountsTable: typeof import('./components/tables/AccountsTable.vue')['default']
+    AppFooter: typeof import('./components/layout/AppFooter.vue')['default']
     AppLayout: typeof import('./components/layout/AppLayout.vue')['default']
     AssetsBarTrended: typeof import('./components/charts/AssetsBarTrended.vue')['default']
     BaseCard: typeof import('./components/base/BaseCard.vue')['default']

--- a/frontend/src/components/layout/AppFooter.vue
+++ b/frontend/src/components/layout/AppFooter.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex justify-center gap-4 text-sm text-gray-600" data-testid="app-footer">
+    <RouterLink to="/settings">Settings</RouterLink>
+    <a href="/docs" target="_blank" rel="noopener">Docs</a>
+    <a href="/support" target="_blank" rel="noopener">Support</a>
+    <span>v{{ appVersion }}</span>
+  </div>
+</template>
+
+<script setup>
+/**
+ * AppFooter
+ * Reusable footer displaying navigation links and the app version.
+ */
+import { RouterLink } from 'vue-router'
+import pkg from '../../../package.json' with { type: 'json' }
+
+const appVersion = pkg.version
+</script>
+
+<style scoped>
+/* No additional styling */
+</style>

--- a/frontend/src/components/layout/__tests__/AppFooter.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppFooter.spec.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { RouterLink } from 'vue-router'
+import AppFooter from '../AppFooter.vue'
+import pkg from '../../../../package.json' with { type: 'json' }
+
+describe('AppFooter', () => {
+  it('renders footer links and version', () => {
+    const wrapper = mount(AppFooter, {
+      global: {
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+        },
+      },
+    })
+    const links = wrapper.findAll('a')
+    expect(links).toHaveLength(3)
+    expect(links[0].text()).toBe('Settings')
+    expect(links[1].text()).toBe('Docs')
+    expect(links[2].text()).toBe('Support')
+    expect(wrapper.text()).toContain(`v${pkg.version}`)
+  })
+})

--- a/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Accounts.vue > matches snapshot 1`] = `"<tabbed-page-layout-stub class=\"accounts-page\" tabs=\"Summary,Transactions,Charts,Accounts\" modelvalue=\"Summary\"></tabbed-page-layout-stub>"`;
+exports[`Accounts.vue > matches snapshot 1`] = `"<app-layout-stub></app-layout-stub>"`;


### PR DESCRIPTION
## Summary
- add AppFooter component with Settings, Docs, Support links and version display
- wrap Accounts view with AppLayout and new AppFooter slot
- verify footer links via unit test

## Testing
- `npm test` *(fails: expected length 3 but got 1 in useTransactions.spec.js)*
- `pytest -q` *(errors: ModuleNotFoundError for flask_sqlalchemy)*
- `pre-commit run --files frontend/src/components.d.ts frontend/src/views/Accounts.vue frontend/src/views/__tests__/__snapshots__/Accounts.spec.js.snap frontend/src/components/layout/AppFooter.vue frontend/src/components/layout/__tests__/AppFooter.spec.ts` *(errors: ModuleNotFoundError for flask_sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e31042483298d811d8408bb411b