### PR TITLE
fix(dashboard): reset category selection after date change

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -345,10 +345,11 @@ function onCatSelected(newIds) {
   catSelected.value = Array.isArray(newIds) ? newIds : [newIds]
 }
 
-// When user changes date range, let next data load re-apply auto-select
+// When user changes date range, clear selections so next data load re-applies auto-select
 watch(
   () => [dateRange.value.start, dateRange.value.end],
   () => {
+    catSelected.value = []
     defaultSet.value = false
   },
 )

--- a/frontend/src/views/__tests__/Dashboard.spec.js
+++ b/frontend/src/views/__tests__/Dashboard.spec.js
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import Dashboard from '../Dashboard.vue'
+
+// Mock modules used by Dashboard.vue
+vi.mock('@/services/api', () => ({
+  default: { fetchNetAssets: vi.fn().mockResolvedValue({ status: 'success', data: [] }) },
+}))
+
+vi.mock('@/api/categories', () => ({
+  fetchCategoryTree: vi.fn().mockResolvedValue({ status: 'success', data: [] }),
+}))
+
+vi.mock('@/composables/useTransactions.js', () => ({
+  useTransactions: () => ({
+    searchQuery: ref(''),
+    currentPage: ref(1),
+    totalPages: ref(1),
+    filteredTransactions: ref([]),
+    sortKey: ref(null),
+    sortOrder: ref(1),
+    setSort: vi.fn(),
+    changePage: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api/transactions', () => ({
+  fetchTransactions: vi.fn().mockResolvedValue({ transactions: [] }),
+}))
+
+// Tests for Dashboard.vue date range behavior
+
+describe('Dashboard.vue', () => {
+  it('clears selected categories when date range changes', async () => {
+    const wrapper = shallowMount(Dashboard, {
+      global: {
+        stubs: {
+          AppLayout: true,
+          BasePageLayout: true,
+          DailyNetChart: true,
+          CategoryBreakdownChart: true,
+          ChartWidgetTopBar: true,
+          ChartControls: true,
+          DateRangeSelector: true,
+          AccountsTable: true,
+          TransactionsTable: true,
+          PaginationControls: true,
+          TransactionModal: true,
+          TopAccountSnapshot: true,
+          GroupedCategoryDropdown: true,
+          FinancialSummary: true,
+          SpendingInsights: true,
+        },
+      },
+    })
+
+    wrapper.vm.allCategoryIds = ['a', 'b', 'c', 'd', 'e', 'f']
+    await nextTick()
+    expect(wrapper.vm.catSelected).toEqual(['a', 'b', 'c', 'd', 'e'])
+
+    wrapper.vm.dateRange.start = '2024-01-01'
+    wrapper.vm.dateRange.end = '2024-01-31'
+    await nextTick()
+    expect(wrapper.vm.catSelected).toEqual([])
+
+    wrapper.vm.allCategoryIds = ['x', 'y', 'z']
+    await nextTick()
+    expect(wrapper.vm.catSelected).toEqual(['x', 'y', 'z'])
+  })
+})


### PR DESCRIPTION
## Summary
- clear previously selected categories when date range updates so charts repopulate
- add unit test ensuring auto-selection re-triggers on date range change

## Testing
- `npx vitest --run src/views/__tests__/Dashboard.spec.js`
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68ba8934fed88329886c113ac5c81aa9