### PR TITLE
feat(arbit): add ccxt adapter with legacy order support

### DIFF
--- a/arbit/__init__.py
+++ b/arbit/__init__.py
@@ -1,0 +1,1 @@
+"""Arbitrage trading utilities."""

--- a/arbit/adapters/__init__.py
+++ b/arbit/adapters/__init__.py
@@ -1,4 +1,5 @@
 """Exchange adapters for interacting with markets."""
+
 from .base import ExchangeAdapter
 from .ccxt_adapter import CCXTAdapter
 

--- a/arbit/adapters/__init__.py
+++ b/arbit/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Exchange adapters for interacting with markets."""
+from .base import ExchangeAdapter
+from .ccxt_adapter import CCXTAdapter
+
+__all__ = ["ExchangeAdapter", "CCXTAdapter"]

--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -1,4 +1,5 @@
 """Base classes and legacy models for exchange adapters."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -1,0 +1,24 @@
+"""Base classes and legacy models for exchange adapters."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+
+@dataclass(frozen=True)
+class OrderSpec:
+    """Legacy order specification using ``qty`` instead of ``quantity``."""
+
+    symbol: str
+    side: Literal["buy", "sell"]
+    qty: float
+    price: Optional[float] = None
+    type: Literal["limit", "market"] = "limit"
+
+
+class ExchangeAdapter:
+    """Base adapter providing a consistent client interface."""
+
+    def __init__(self, client: Any | None = None) -> None:
+        self.client = client
+        self.ex = client

--- a/arbit/adapters/ccxt_adapter.py
+++ b/arbit/adapters/ccxt_adapter.py
@@ -1,0 +1,109 @@
+"""Adapter implementation using the `ccxt` library."""
+from __future__ import annotations
+
+from typing import Any
+
+from arbit.config import settings
+from arbit.models import Fill, OrderSpec
+from .base import ExchangeAdapter
+
+try:  # pragma: no cover - used only when ``ccxt`` is missing
+    import ccxt  # type: ignore
+except ImportError:  # pragma: no cover - graceful fallback for linting
+    ccxt = None
+
+
+class CCXTAdapter(ExchangeAdapter):
+    """Adapter for exchanges supported by the `ccxt` library."""
+
+    def __init__(self, exchange: str, api_key: str, api_secret: str) -> None:
+        if ccxt is None:  # pragma: no cover - will be skipped in tests
+            raise RuntimeError("ccxt library is required")
+        client = getattr(ccxt, exchange)({"apiKey": api_key, "secret": api_secret})
+        super().__init__(client)
+        self._fee: dict[str, tuple[float, float]] = {}
+
+    # Basic exchange API wrappers -------------------------------------------------------------
+    def fetch_orderbook(self, symbol: str, depth: int = 10) -> dict:
+        """Retrieve the order book for ``symbol`` up to ``depth`` levels."""
+
+        return self.ex.fetch_order_book(symbol, depth)
+
+    # Compatibility wrappers expected by tests -------------------------------------------------
+    def fetch_order_book(self, symbol: str, depth: int = 10) -> dict:
+        """Alias for :meth:`fetch_orderbook` using snake-case name."""
+
+        return self.fetch_orderbook(symbol, depth)
+
+    def fetch_fees(self, symbol: str) -> tuple[float, float]:
+        """Return ``(maker, taker)`` fees for ``symbol``, caching results."""
+
+        if symbol in self._fee:
+            return self._fee[symbol]
+        m = self.ex.market(symbol)
+        maker = m.get("maker", self.ex.fees.get("trading", {}).get("maker", 0.001))
+        taker = m.get("taker", self.ex.fees.get("trading", {}).get("taker", 0.001))
+        self._fee[symbol] = (maker, taker)
+        return maker, taker
+
+    def min_notional(self, symbol: str) -> float:
+        """Return exchange-imposed minimum notional for ``symbol``."""
+
+        m = self.ex.market(symbol)
+        return float(m.get("limits", {}).get("cost", {}).get("min", 1.0))
+
+    def create_order(self, spec: OrderSpec) -> Fill:
+        """Place an order described by ``spec`` and return a :class:`Fill`."""
+
+        qty = getattr(spec, "qty", None)
+        if qty is None:
+            qty = getattr(spec, "quantity")
+
+        order_type = getattr(spec, "type", None)
+        if order_type is None:
+            order_type = getattr(spec, "order_type", "market")
+
+        if settings.dry_run:
+            ob = self.fetch_orderbook(spec.symbol, 1)
+            price = ob["asks"][0][0] if spec.side == "buy" else ob["bids"][0][0]
+            fee = self.fetch_fees(spec.symbol)[1] * price * qty
+            return Fill(
+                order_id="dryrun",
+                symbol=spec.symbol,
+                side=spec.side,
+                price=price,
+                quantity=qty,
+                fee=fee,
+            )
+
+        price = getattr(spec, "price", None)
+        o = self.client.create_order(spec.symbol, order_type, spec.side, qty, price)
+        filled = float(o.get("filled", qty))
+        price = float(o.get("average") or o.get("price") or 0.0)
+        fee_cost = sum(float(f.get("cost") or 0) for f in o.get("fees", []))
+        return Fill(
+            order_id=o["id"],
+            symbol=spec.symbol,
+            side=spec.side,
+            price=price,
+            quantity=filled,
+            fee=fee_cost,
+        )
+
+    def balances(self) -> dict[str, float]:
+        """Return assets with non-zero balances."""
+
+        b = self.ex.fetch_balance()
+        return {k: float(v) for k, v in b.get("total", {}).items() if float(v or 0) > 0}
+
+    # Additional convenience methods expected by tests ----------------------------------------
+    def cancel_order(self, order_id: str, symbol: str) -> None:
+        """Cancel order ``order_id`` for ``symbol`` on the exchange."""
+
+        self.ex.cancel_order(order_id, symbol)
+
+    def fetch_balance(self, asset: str) -> float:
+        """Return free balance for ``asset``."""
+
+        b = self.ex.fetch_balance()
+        return float(b.get("free", {}).get(asset, 0.0))

--- a/arbit/adapters/ccxt_adapter.py
+++ b/arbit/adapters/ccxt_adapter.py
@@ -1,10 +1,12 @@
 """Adapter implementation using the `ccxt` library."""
+
 from __future__ import annotations
 
 from typing import Any
 
 from arbit.config import settings
 from arbit.models import Fill, OrderSpec
+
 from .base import ExchangeAdapter
 
 try:  # pragma: no cover - used only when ``ccxt`` is missing

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -1,4 +1,5 @@
 """Configuration settings for the arbit package."""
+
 from types import SimpleNamespace
 
 # Default settings used by adapters. Projects may override these values.

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -1,0 +1,5 @@
+"""Configuration settings for the arbit package."""
+from types import SimpleNamespace
+
+# Default settings used by adapters. Projects may override these values.
+settings = SimpleNamespace(dry_run=True)

--- a/arbit/models.py
+++ b/arbit/models.py
@@ -1,0 +1,43 @@
+"""Core data models for exchange interactions."""
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Optional
+
+
+@dataclass(frozen=True)
+class Triangle:
+    """Represents a triangular arbitrage opportunity."""
+
+    leg_ab: str
+    leg_bc: str
+    leg_ac: str
+
+
+@dataclass(frozen=True)
+class OrderSpec:
+    """Specification for placing an order on an exchange."""
+
+    symbol: str
+    side: Literal["buy", "sell"]
+    quantity: float
+    price: Optional[float] = None
+    order_type: Literal["limit", "market"] = "limit"
+
+
+@dataclass(frozen=True)
+class Fill:
+    """Execution details of a completed order."""
+
+    order_id: str
+    symbol: str
+    side: Literal["buy", "sell"]
+    price: float
+    quantity: float
+    fee: float
+    timestamp: datetime | None = None
+
+    def __getitem__(self, key: str):
+        """Provide dict-style access for backward compatibility."""
+        if key == "qty":
+            return self.quantity
+        return getattr(self, key)

--- a/arbit/models.py
+++ b/arbit/models.py
@@ -1,4 +1,5 @@
 """Core data models for exchange interactions."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, Optional

--- a/tests/test_ccxt_adapter.py
+++ b/tests/test_ccxt_adapter.py
@@ -1,0 +1,101 @@
+"""Tests for the CCXT exchange adapter implementation."""
+
+import pytest
+
+ccxt = pytest.importorskip("ccxt")
+
+from arbit.adapters import CCXTAdapter, ExchangeAdapter
+from arbit.adapters.base import OrderSpec as LegacyOrderSpec
+from arbit.config import settings
+from arbit.models import OrderSpec
+
+
+def test_initialization() -> None:
+    """Adapter initialization returns a configured client."""
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    assert isinstance(adapter, ExchangeAdapter)
+    assert adapter.client.id == "alpaca"
+
+
+def test_fetch_order_book(monkeypatch) -> None:
+    """Order books are retrieved via the underlying ccxt client."""
+    adapter = CCXTAdapter("kraken", "k", "s")
+
+    def fake_fetch_order_book(symbol: str, *args, **kwargs) -> dict:
+        assert symbol == "BTC/USD"
+        return {"bids": [], "asks": []}
+
+    monkeypatch.setattr(adapter.client, "fetch_order_book", fake_fetch_order_book)
+    order_book = adapter.fetch_order_book("BTC/USD")
+    assert order_book == {"bids": [], "asks": []}
+
+
+def test_create_order(monkeypatch) -> None:
+    """Order creation passes through to the ccxt client."""
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    monkeypatch.setattr(settings, "dry_run", False)
+
+    def fake_create_order(symbol, order_type, side, amount, price):
+        return {
+            "id": "1",
+            "price": price,
+            "amount": amount,
+            "fees": [{"cost": 0.1}],
+        }
+
+    monkeypatch.setattr(adapter.client, "create_order", fake_create_order)
+    order = OrderSpec(symbol="ETH/USDT", side="buy", quantity=1.0, price=1000.0)
+    fill = adapter.create_order(order)
+    assert fill.order_id == "1"
+    assert fill.quantity == 1.0
+    assert fill.fee == 0.1
+    assert fill["qty"] == 1.0
+
+
+def test_create_order_accepts_legacy_spec(monkeypatch) -> None:
+    """Legacy OrderSpec dataclasses remain supported."""
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    monkeypatch.setattr(settings, "dry_run", False)
+
+    def fake_create_order(symbol, order_type, side, amount, price):
+        assert amount == 1.0
+        assert price is None
+        return {
+            "id": "1",
+            "price": 1000.0,
+            "amount": amount,
+            "fees": [{"cost": 0.1}],
+        }
+
+    monkeypatch.setattr(adapter.client, "create_order", fake_create_order)
+    order = LegacyOrderSpec(symbol="ETH/USDT", side="buy", qty=1.0)
+    fill = adapter.create_order(order)
+    assert fill["qty"] == 1.0
+    assert fill["price"] == 1000.0
+    assert fill["fee"] == 0.1
+
+
+def test_cancel_order(monkeypatch) -> None:
+    """Cancellation requests are forwarded to the client."""
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    called: dict[str, str] = {}
+
+    def fake_cancel_order(order_id: str, symbol: str) -> None:
+        called["order_id"] = order_id
+        called["symbol"] = symbol
+
+    monkeypatch.setattr(adapter.client, "cancel_order", fake_cancel_order)
+    adapter.cancel_order("1", "ETH/USDT")
+    assert called == {"order_id": "1", "symbol": "ETH/USDT"}
+
+
+def test_fetch_balance(monkeypatch) -> None:
+    """Balance retrieval uses the underlying client API."""
+    adapter = CCXTAdapter("kraken", "k", "s")
+
+    def fake_fetch_balance() -> dict:
+        return {"free": {"USD": 10.0}}
+
+    monkeypatch.setattr(adapter.client, "fetch_balance", fake_fetch_balance)
+    balance = adapter.fetch_balance("USD")
+    assert balance == 10.0


### PR DESCRIPTION
## Summary
- add `arbit` package with ccxt-based exchange adapter
- support legacy `OrderSpec` and dict-style access on `Fill`
- add tests for adapter behavior

## Testing
- `pre-commit run --all-files` *(fails: backend/app/services/balance_history.py:292:73 F821 Undefined name `_tz`; backend/migrations/env.py duplicate module; pylint failure)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac93f86b8832996cead1e1f49acd2