### PR TITLE
feat(config): add arbitrage dashboard toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ It starts the frontend development server and periodically performs a
 `git pull --rebase` when the tracked branch receives new commits, ensuring Git
 hooks run and the server restarts with the latest changes.
 
+## Configuration
+
+- `ENABLE_ARBIT_DASHBOARD` – set to `true` to enable the experimental arbitrage dashboard.
+
 ## Testing
 
 - Backend tests:

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-# File: app/__init__.py
+"""Application factory for the Flask backend."""
 
 from app.cli.sync import sync_accounts
 from app.config import logger, plaid_client
@@ -10,9 +10,13 @@ from flask_migrate import Migrate
 
 
 def create_app():
+    """Configure and return the Flask application instance."""
+    from app.config import ENABLE_ARBIT_DASHBOARD
+
     app = Flask(__name__)
     CORS(app)
     app.config.from_object("app.config")
+    app.config["ENABLE_ARBIT_DASHBOARD"] = ENABLE_ARBIT_DASHBOARD
     db.init_app(app)
     Migrate(app, db)
     # Always register routes (for all environments)

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -5,6 +5,7 @@
 from .constants import DATABASE_NAME, FILES, SQLALCHEMY_DATABASE_URI
 from .environment import (
     CLIENT_NAME,
+    ENABLE_ARBIT_DASHBOARD,
     FLASK_ENV,
     PLAID_CLIENT_ID,
     PLAID_CLIENT_NAME,
@@ -30,6 +31,7 @@ __all__ = [
     "PLAID_CLIENT_ID",
     "PLAID_SECRET",
     "PLAID_ENV",
+    "ENABLE_ARBIT_DASHBOARD",
     "TELLER_API_BASE_URL",
     "TELLER_APP_ID",
     "TELLER_CERTIFICATE",

--- a/backend/app/config/environment.py
+++ b/backend/app/config/environment.py
@@ -37,6 +37,15 @@ TELLER_PRIVATE_KEY = DIRECTORIES["CERTS_DIR"] / "private_key.pem"
 # Webhook for product update notifications
 TELLER_WEBHOOK_SECRET = os.getenv("TELLER_WEBHOOK_SECRET", "No Teller Webhook in .env")
 
+# Feature toggles
+# Enable optional arbitrage dashboard
+ENABLE_ARBIT_DASHBOARD = os.getenv("ENABLE_ARBIT_DASHBOARD", "false").lower() in {
+    "1",
+    "true",
+    "t",
+    "yes",
+}
+
 # Misc. Dev. Variables for testing
 VARIABLE_ENV_TOKEN = os.getenv("VARIABLE_ENV_TOKEN")
 VARIABLE_ENV_ID = os.getenv("VARIABLE_ENV_ID")

--- a/docs/backend/app/config/environment.md
+++ b/docs/backend/app/config/environment.md
@@ -14,6 +14,7 @@ all environment lookups so the rest of the code can import settings directly.
   in `environment.py` via `os.getenv("PRODUCTS", "transactions").split(",")`.
 - `PLAID_ENV` – target Plaid environment (`sandbox`, `development`, `production`).
 - `CLIENT_NAME` – display name passed to Plaid Link.
+- `ENABLE_ARBIT_DASHBOARD` – set to `true` to expose the experimental arbitrage dashboard.
 
 Specify multiple products (e.g., `transactions,investments`) to generate Link
 tokens that cover more than one product. Each product still needs a separate

--- a/tests/test_enable_arbit_dashboard.py
+++ b/tests/test_enable_arbit_dashboard.py
@@ -1,0 +1,39 @@
+"""Tests for the ENABLE_ARBIT_DASHBOARD configuration flag."""
+
+import importlib
+import os
+import sys
+
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+
+
+def reload_config():
+    """Reload configuration modules to pick up environment changes."""
+    sys.modules.pop("app.config.environment", None)
+    sys.modules.pop("app.config", None)
+    import app.config as config
+    import app.config.environment  # noqa: F401  # re-import to apply env vars
+
+    importlib.reload(config)
+    return config
+
+
+def test_default_disabled(monkeypatch):
+    """Flag defaults to False when the environment variable is unset."""
+    monkeypatch.delenv("ENABLE_ARBIT_DASHBOARD", raising=False)
+    reload_config()
+    app = Flask(__name__)
+    app.config.from_object("app.config")
+    assert app.config["ENABLE_ARBIT_DASHBOARD"] is False
+
+
+def test_override_enabled(monkeypatch):
+    """Flag is True when the environment variable is truthy."""
+    monkeypatch.setenv("ENABLE_ARBIT_DASHBOARD", "true")
+    reload_config()
+    app = Flask(__name__)
+    app.config.from_object("app.config")
+    assert app.config["ENABLE_ARBIT_DASHBOARD"] is True


### PR DESCRIPTION
## Summary
- add `ENABLE_ARBIT_DASHBOARD` env flag
- expose flag via Flask app config
- document arbitrage toggle in README and environment guide
- cover default/override behavior with unit tests

## Testing
- `pre-commit run --files README.md backend/app/__init__.py backend/app/config/__init__.py backend/app/config/environment.py docs/backend/app/config/environment.md tests/test_enable_arbit_dashboard.py`
- `pytest -q`
- `python scripts/doc_cleaner.py` *(fails: UnicodeDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bb83981fd08329a8ce91756d12c1f3