### PR TITLE
feat(arbitrage): add Arbit metrics service

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -11,12 +11,13 @@ from flask_migrate import Migrate
 
 def create_app():
     """Configure and return the Flask application instance."""
-    from app.config import ENABLE_ARBIT_DASHBOARD
+    from app.config import ARBIT_EXPORTER_URL, ENABLE_ARBIT_DASHBOARD
 
     app = Flask(__name__)
     CORS(app)
     app.config.from_object("app.config")
     app.config["ENABLE_ARBIT_DASHBOARD"] = ENABLE_ARBIT_DASHBOARD
+    app.config["ARBIT_EXPORTER_URL"] = ARBIT_EXPORTER_URL
     db.init_app(app)
     Migrate(app, db)
     # Always register routes (for all environments)

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -4,6 +4,7 @@
 
 from .constants import DATABASE_NAME, FILES, SQLALCHEMY_DATABASE_URI
 from .environment import (
+    ARBIT_EXPORTER_URL,
     CLIENT_NAME,
     ENABLE_ARBIT_DASHBOARD,
     FLASK_ENV,
@@ -32,6 +33,7 @@ __all__ = [
     "PLAID_SECRET",
     "PLAID_ENV",
     "ENABLE_ARBIT_DASHBOARD",
+    "ARBIT_EXPORTER_URL",
     "TELLER_API_BASE_URL",
     "TELLER_APP_ID",
     "TELLER_CERTIFICATE",
@@ -62,5 +64,5 @@ logger.debug(f"Initialized main database as {DATABASE_NAME}")
 logger.debug(f"SQLAlchemy Database URI: {SQLALCHEMY_DATABASE_URI}")
 logger.debug(f"Starting dashboard in Plaid {PLAID_ENV} Environment.")
 logger.debug(
-    f"Base URLs: \n\nPlaid: {PLAID_BASE_URL} \nTeller: {TELLER_API_BASE_URL}\n\n"
+    f"Base URLs: \n\nPlaid: {PLAID_BASE_URL} \nTeller: {TELLER_API_BASE_URL} \nArbit: {ARBIT_EXPORTER_URL}\n\n"
 )

--- a/backend/app/config/environment.py
+++ b/backend/app/config/environment.py
@@ -37,6 +37,9 @@ TELLER_PRIVATE_KEY = DIRECTORIES["CERTS_DIR"] / "private_key.pem"
 # Webhook for product update notifications
 TELLER_WEBHOOK_SECRET = os.getenv("TELLER_WEBHOOK_SECRET", "No Teller Webhook in .env")
 
+# Base URL for Arbit metrics exporter
+ARBIT_EXPORTER_URL = os.getenv("ARBIT_EXPORTER_URL", "http://localhost:8000")
+
 # Feature toggles
 # Enable optional arbitrage dashboard
 ENABLE_ARBIT_DASHBOARD = os.getenv("ENABLE_ARBIT_DASHBOARD", "false").lower() in {

--- a/backend/app/services/arbit_metrics.py
+++ b/backend/app/services/arbit_metrics.py
@@ -1,0 +1,58 @@
+"""Retrieve and parse metrics from the Arbit exporter."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import requests
+from flask import current_app
+
+METRIC_NAMES = (
+    "profit_total",
+    "orders_total",
+    "fills_total",
+    "errors_total",
+    "skips_total",
+    "cycle_latency",
+)
+
+
+def fetch_metrics() -> Dict[str, float | int]:
+    """Fetch the `/metrics` endpoint and parse select values.
+
+    Returns:
+        Mapping of metric names to numeric values.
+    """
+    base_url: str = current_app.config["ARBIT_EXPORTER_URL"]
+    response = requests.get(f"{base_url}/metrics", timeout=5)
+    response.raise_for_status()
+    return parse_metrics(response.text)
+
+
+def parse_metrics(prom_text: str) -> Dict[str, float | int]:
+    """Parse Prometheus metrics text into a dictionary.
+
+    Args:
+        prom_text: Raw text from a Prometheus metrics endpoint.
+
+    Returns:
+        JSON-serializable mapping containing the selected metric values.
+        Missing metrics default to 0.
+    """
+    metrics: Dict[str, float | int] = {name: 0 for name in METRIC_NAMES}
+
+    for line in prom_text.splitlines():
+        if line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        name, value = parts
+        if name not in metrics:
+            continue
+        if name in {"profit_total", "cycle_latency"}:
+            metrics[name] = float(value)
+        else:
+            metrics[name] = int(float(value))
+
+    return metrics

--- a/docs/backend/app/services/arbit_metrics.md
+++ b/docs/backend/app/services/arbit_metrics.md
@@ -1,0 +1,17 @@
+# `arbit_metrics.py`
+
+Fetch metrics from the Arbit exporter and parse key values for dashboard use.
+
+## Responsibilities
+
+- Call the configured exporter's `/metrics` endpoint.
+- Extract `profit_total`, `orders_total`, `fills_total`, `errors_total`, `skips_total`, and `cycle_latency` from the Prometheus text.
+- Return a JSON-ready dictionary of these metrics.
+
+## Usage
+
+```python
+from app.services.arbit_metrics import fetch_metrics
+
+metrics = fetch_metrics()
+```

--- a/docs/backend/app/services/index.md
+++ b/docs/backend/app/services/index.md
@@ -21,6 +21,10 @@
 - [`sync_service.py`](#sync-service): Orchestrates transaction ingestion from APIs or files.
 - [`transactions.py`](#transactions-service): Core logic for interacting with transaction data.
 
+### Arbitrage
+
+- [`arbit_metrics.py`](#arbit-metrics-service): Retrieves metrics from the Arbit exporter.
+
 ---
 
 ## 📘 `transactions.py`

--- a/docs/backend/app/services/index.md
+++ b/docs/backend/app/services/index.md
@@ -46,15 +46,12 @@ Provides core logic for managing user transactions. Supports listing, filtering,
 ## Primary Functions
 
 - `get_transactions(user_id, filters)`
-
   - Returns a filtered list of transactions for the user
 
 - `create_transaction(user_id, data)`
-
   - Inserts a new user-defined transaction (manual or imported)
 
 - `update_transaction(transaction_id, updates)`
-
   - Modifies editable fields like category, description
 
 - `delete_transaction(transaction_id)`

--- a/tests/test_arbit_metrics_service.py
+++ b/tests/test_arbit_metrics_service.py
@@ -1,0 +1,57 @@
+"""Tests for the Arbit metrics service."""
+
+import importlib.util
+import os
+
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+spec = importlib.util.spec_from_file_location(
+    "arbit_metrics",
+    os.path.join(BASE_BACKEND, "app", "services", "arbit_metrics.py"),
+)
+arbit_metrics = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(arbit_metrics)
+fetch_metrics = arbit_metrics.fetch_metrics
+
+
+class DummyResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple dummy
+        pass
+
+
+def test_fetch_metrics(monkeypatch):
+    """`fetch_metrics` returns parsed values from the exporter."""
+    sample = """\
+# HELP profit_total Total profit
+profit_total 1.5
+orders_total 10
+fills_total 8
+errors_total 1
+skips_total 2
+cycle_latency 0.3
+"""
+
+    def mock_get(url: str, timeout: int):
+        assert url == "http://exporter/metrics"
+        return DummyResponse(sample)
+
+    monkeypatch.setattr(arbit_metrics.requests, "get", mock_get)
+
+    app = Flask(__name__)
+    app.config["ARBIT_EXPORTER_URL"] = "http://exporter"
+
+    with app.app_context():
+        metrics = fetch_metrics()
+
+    assert metrics == {
+        "profit_total": 1.5,
+        "orders_total": 10,
+        "fills_total": 8,
+        "errors_total": 1,
+        "skips_total": 2,
+        "cycle_latency": 0.3,
+    }


### PR DESCRIPTION
## Summary
- add service to fetch & parse Arbit exporter Prometheus metrics
- expose ARBIT_EXPORTER_URL config and inject into app config
- document service and cover parsing logic with unit test

## Testing
- `pytest -q`
- `pre-commit run --files backend/app/__init__.py backend/app/config/__init__.py backend/app/config/environment.py backend/app/services/arbit_metrics.py docs/backend/app/services/index.md docs/backend/app/services/arbit_metrics.md tests/test_arbit_metrics_service.py` *(fails: mypy: multiple missing stubs and typing errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd1aab3e883298fa044ffbc819b0e