### PR TITLE
refactor(recurring_bridge): clarify deferred imports

### DIFF
--- a/backend/app/services/recurring_bridge.py
+++ b/backend/app/services/recurring_bridge.py
@@ -1,3 +1,10 @@
+"""Database bridge for recurring transaction detection.
+
+This module links recurring transaction patterns detected in raw
+transactions with database persistence utilities. Imports are deferred
+until synchronization to avoid loading heavy dependencies at import time.
+"""
+
 from datetime import timedelta
 from importlib import import_module
 
@@ -19,8 +26,8 @@ class RecurringBridge:
         # Import DB session and models only when syncing to avoid heavy
         # dependencies during module import. This also ensures models are
         # registered with the SQLAlchemy instance used by tests.
-        import_module("app.extensions").db  # noqa: F401
-        import_module("app.models").RecurringTransaction  # noqa: F401
+        _ = import_module("app.extensions")
+        _ = import_module("app.models")
 
         candidates = self.detector.detect()
         actions = []


### PR DESCRIPTION
## Summary
- add module docstring for `recurring_bridge`
- assign deferred `import_module` calls to `_` to avoid unused expression warnings

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: isort modified unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bce9f89dd083298bee440280c28f6f