### PR TITLE
feat(arbit): add dashboard blueprint

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -64,6 +64,11 @@ def create_app():
     app.register_blueprint(institutions, url_prefix="/api/institutions")
     app.register_blueprint(summary, url_prefix="/api/summary")
 
+    if ENABLE_ARBIT_DASHBOARD:
+        from app.routes.arbit_dashboard import arbit_dashboard
+
+        app.register_blueprint(arbit_dashboard, url_prefix="/api/arbit")
+
     if TELLER_WEBHOOK_SECRET:
         app.register_blueprint(webhooks, url_prefix="/api/webhooks")
     else:

--- a/backend/app/routes/arbit_dashboard.py
+++ b/backend/app/routes/arbit_dashboard.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, current_app, jsonify
-
 from app.services import arbit_metrics
+from flask import Blueprint, current_app, jsonify
 
 arbit_dashboard = Blueprint("arbit_dashboard", __name__)
 

--- a/backend/app/routes/arbit_dashboard.py
+++ b/backend/app/routes/arbit_dashboard.py
@@ -1,0 +1,39 @@
+"""Endpoints for the experimental Arbit dashboard."""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify
+
+from app.services import arbit_metrics
+
+arbit_dashboard = Blueprint("arbit_dashboard", __name__)
+
+
+@arbit_dashboard.route("/status", methods=["GET"])
+def get_status():
+    """Return whether the dashboard is running and its config."""
+    enabled = current_app.config.get("ENABLE_ARBIT_DASHBOARD", False)
+    config = {
+        "arbit_exporter_url": current_app.config.get("ARBIT_EXPORTER_URL"),
+        "enable_arbit_dashboard": enabled,
+    }
+    return jsonify({"running": enabled, "config": config}), 200
+
+
+@arbit_dashboard.route("/metrics", methods=["GET"])
+def metrics():
+    """Return metrics from the Arbit exporter."""
+    data = arbit_metrics.get_metrics()
+    return jsonify(data), 200
+
+
+@arbit_dashboard.route("/opportunities", methods=["GET"])
+def opportunities():
+    """Placeholder for opportunity data."""
+    return jsonify([]), 200
+
+
+@arbit_dashboard.route("/trades", methods=["GET"])
+def trades():
+    """Placeholder for trade data."""
+    return jsonify([]), 200

--- a/backend/app/services/arbit_metrics.py
+++ b/backend/app/services/arbit_metrics.py
@@ -29,6 +29,11 @@ def fetch_metrics() -> Dict[str, float | int]:
     return parse_metrics(response.text)
 
 
+def get_metrics() -> Dict[str, float | int]:
+    """Public wrapper to retrieve exporter metrics."""
+    return fetch_metrics()
+
+
 def parse_metrics(prom_text: str) -> Dict[str, float | int]:
     """Parse Prometheus metrics text into a dictionary.
 

--- a/docs/backend/app/routes/arbit_dashboard.md
+++ b/docs/backend/app/routes/arbit_dashboard.md
@@ -1,0 +1,10 @@
+# `arbit_dashboard.py`
+
+Endpoints for the experimental Arbit dashboard.
+
+## Endpoints
+
+- `GET /api/arbit/status` – returns running status and relevant config.
+- `GET /api/arbit/metrics` – returns metrics from `arbit_metrics.get_metrics`.
+- `GET /api/arbit/opportunities` – placeholder returning an empty list.
+- `GET /api/arbit/trades` – placeholder returning an empty list.

--- a/docs/backend/app/routes/index.md
+++ b/docs/backend/app/routes/index.md
@@ -5,6 +5,7 @@
 ## Table of Contents
 
 - [`accounts.py`](#accounts-route)
+- [`arbit_dashboard.py`](#arbit-dashboard-route)
 - [`categories.py`](#categories-route)
 - [`GET /categories/tree`](categories.md)
 - [`charts.py`](#charts-route)

--- a/docs/backend/app/services/arbit_metrics.md
+++ b/docs/backend/app/services/arbit_metrics.md
@@ -11,7 +11,7 @@ Fetch metrics from the Arbit exporter and parse key values for dashboard use.
 ## Usage
 
 ```python
-from app.services.arbit_metrics import fetch_metrics
+from app.services.arbit_metrics import get_metrics
 
-metrics = fetch_metrics()
+metrics = get_metrics()
 ```

--- a/tests/test_api_arbit_dashboard.py
+++ b/tests/test_api_arbit_dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+
 from flask import Flask
 
 BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
@@ -13,7 +14,11 @@ if BASE_BACKEND not in sys.path:
 
 def make_app(flag: bool) -> Flask:
     """Create a Flask app with the arbit dashboard optionally registered."""
-    for mod in ["app.routes.arbit_dashboard", "app.services", "app.services.arbit_metrics"]:
+    for mod in [
+        "app.routes.arbit_dashboard",
+        "app.services",
+        "app.services.arbit_metrics",
+    ]:
         sys.modules.pop(mod, None)
     from app.routes import arbit_dashboard as arbit_module
 

--- a/tests/test_api_arbit_dashboard.py
+++ b/tests/test_api_arbit_dashboard.py
@@ -1,0 +1,74 @@
+"""Tests for the `/api/arbit` dashboard routes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+if BASE_BACKEND not in sys.path:
+    sys.path.insert(0, BASE_BACKEND)
+
+
+def make_app(flag: bool) -> Flask:
+    """Create a Flask app with the arbit dashboard optionally registered."""
+    for mod in ["app.routes.arbit_dashboard", "app.services", "app.services.arbit_metrics"]:
+        sys.modules.pop(mod, None)
+    from app.routes import arbit_dashboard as arbit_module
+
+    app = Flask(__name__)
+    app.config["ENABLE_ARBIT_DASHBOARD"] = flag
+    app.config["ARBIT_EXPORTER_URL"] = "http://localhost:8000"
+    if flag:
+        app.register_blueprint(arbit_module.arbit_dashboard, url_prefix="/api/arbit")
+    return app
+
+
+def test_endpoints_disabled():
+    """Endpoints return 404 when the dashboard is disabled."""
+    app = make_app(False)
+    client = app.test_client()
+    for path in (
+        "/api/arbit/status",
+        "/api/arbit/metrics",
+        "/api/arbit/opportunities",
+        "/api/arbit/trades",
+    ):
+        assert client.get(path).status_code == 404
+
+
+def test_status_enabled():
+    """`/status` reports running state and config when enabled."""
+    app = make_app(True)
+    client = app.test_client()
+    resp = client.get("/api/arbit/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["running"] is True
+    assert data["config"]["enable_arbit_dashboard"] is True
+
+
+def test_metrics_endpoint(monkeypatch):
+    """`/metrics` proxies results from `arbit_metrics.get_metrics`."""
+    app = make_app(True)
+    sample = {"profit_total": 1}
+    monkeypatch.setattr(
+        "app.routes.arbit_dashboard.arbit_metrics.get_metrics", lambda: sample
+    )
+    with app.test_client() as client:
+        resp = client.get("/api/arbit/metrics")
+        assert resp.status_code == 200
+        assert resp.get_json() == sample
+
+
+def test_stub_endpoints():
+    """`/opportunities` and `/trades` return empty lists."""
+    app = make_app(True)
+    client = app.test_client()
+    resp = client.get("/api/arbit/opportunities")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+    resp = client.get("/api/arbit/trades")
+    assert resp.status_code == 200
+    assert resp.get_json() == []

--- a/tests/test_arbit_metrics_service.py
+++ b/tests/test_arbit_metrics_service.py
@@ -55,3 +55,17 @@ cycle_latency 0.3
         "skips_total": 2,
         "cycle_latency": 0.3,
     }
+
+
+def test_get_metrics(monkeypatch):
+    """`get_metrics` delegates to `fetch_metrics`."""
+    called = {}
+
+    def fake_fetch() -> dict:
+        called["used"] = True
+        return {"profit_total": 0}
+
+    monkeypatch.setattr(arbit_metrics, "fetch_metrics", fake_fetch)
+
+    assert arbit_metrics.get_metrics() == {"profit_total": 0}
+    assert called["used"] is True


### PR DESCRIPTION
## Summary
- add optional arbit dashboard blueprint with status, metrics, opportunities, and trades endpoints
- expose `get_metrics` wrapper in `arbit_metrics` service
- document new routes and service usage

## Testing
- `pytest -q`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68bd01a89f0483298736cc5bfade917d