### PR TITLE
feat(arbit): add CLI helpers and dashboard controls

### DIFF
--- a/backend/app/routes/arbit_dashboard.py
+++ b/backend/app/routes/arbit_dashboard.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
-from app.services import arbit_metrics
-from flask import Blueprint, current_app, jsonify
+from app.services import arbit_cli, arbit_metrics
+from flask import Blueprint, current_app, jsonify, request
 
 arbit_dashboard = Blueprint("arbit_dashboard", __name__)
+
+
+def _parse_threshold_fee(data: dict) -> tuple[float, float] | None:
+    """Validate and extract threshold and fee values from request data."""
+    try:
+        threshold = float(data["threshold"])
+        fee = float(data["fee"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if threshold <= 0 or fee < 0:
+        return None
+    return threshold, fee
 
 
 @arbit_dashboard.route("/status", methods=["GET"])
@@ -36,3 +48,61 @@ def opportunities():
 def trades():
     """Placeholder for trade data."""
     return jsonify([]), 200
+
+
+@arbit_dashboard.route("/start", methods=["POST"])
+def start_arbit():
+    """Start the Arbit CLI process."""
+    data = request.get_json(silent=True) or {}
+    parsed = _parse_threshold_fee(data)
+    if not parsed:
+        return jsonify({"error": "Invalid threshold or fee"}), 400
+    threshold, fee = parsed
+    result = arbit_cli.start(threshold, fee)
+    return (
+        jsonify(
+            {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.returncode,
+            }
+        ),
+        200,
+    )
+
+
+@arbit_dashboard.route("/stop", methods=["POST"])
+def stop_arbit():
+    """Stop the Arbit CLI process."""
+    result = arbit_cli.stop()
+    return (
+        jsonify(
+            {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.returncode,
+            }
+        ),
+        200,
+    )
+
+
+@arbit_dashboard.route("/config/update", methods=["POST"])
+def update_config():
+    """Update configuration for the Arbit CLI process."""
+    data = request.get_json(silent=True) or {}
+    parsed = _parse_threshold_fee(data)
+    if not parsed:
+        return jsonify({"error": "Invalid threshold or fee"}), 400
+    threshold, fee = parsed
+    result = arbit_cli.update_config(threshold, fee)
+    return (
+        jsonify(
+            {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.returncode,
+            }
+        ),
+        200,
+    )

--- a/backend/app/services/arbit_cli.py
+++ b/backend/app/services/arbit_cli.py
@@ -1,0 +1,36 @@
+"""Helpers for invoking the experimental Arbit CLI."""
+
+from __future__ import annotations
+
+import subprocess
+from subprocess import CompletedProcess
+
+ARBIT_CLI_PATH = "arbit/cli.py"
+
+
+def _run(*args: str) -> CompletedProcess[str]:
+    """Execute ``arbit/cli.py`` with the provided arguments.
+
+    Args:
+        *args: Arguments to pass to the CLI.
+
+    Returns:
+        The completed process with captured output.
+    """
+    cmd = ["python", ARBIT_CLI_PATH, *args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def start(threshold: float, fee: float) -> CompletedProcess[str]:
+    """Start the Arbit process."""
+    return _run("start", "--threshold", str(threshold), "--fee", str(fee))
+
+
+def stop() -> CompletedProcess[str]:
+    """Stop the Arbit process."""
+    return _run("stop")
+
+
+def update_config(threshold: float, fee: float) -> CompletedProcess[str]:
+    """Update the Arbit configuration."""
+    return _run("config", "update", "--threshold", str(threshold), "--fee", str(fee))


### PR DESCRIPTION
## Summary
- add `arbit_cli` service to invoke `arbit/cli.py`
- extend Arbit dashboard with start/stop/config endpoints and input validation
- test dashboard controls with mocked `subprocess.run`

## Testing
- `pytest -q`
- `pre-commit run --files backend/app/services/arbit_cli.py backend/app/routes/arbit_dashboard.py tests/test_api_arbit_dashboard.py` *(fails: Library stubs not installed, pylint import errors, bandit asserts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd06e859688329aba4e86ae545e1d1