### PR TITLE
feat(frontend): add Arbit dashboard navigation

### DIFF
--- a/frontend/cypress/e2e/arbit.cy.js
+++ b/frontend/cypress/e2e/arbit.cy.js
@@ -1,0 +1,17 @@
+// arbit.cy.js - Arbit dashboard navigation test
+
+describe('Arbit dashboard link', () => {
+  it('navigates to dashboard when enabled', () => {
+    cy.intercept('GET', '**/api/**', {})
+    cy.intercept('GET', '**/api/arbit/status', {
+      running: true,
+      config: { enable_arbit_dashboard: true },
+    }).as('arbitStatus')
+
+    cy.visit('/')
+    cy.wait('@arbitStatus')
+    cy.contains('Arbit').click()
+    cy.url().should('include', '/arbit')
+    cy.contains('Arbit Dashboard')
+  })
+})

--- a/frontend/src/api/arbit.js
+++ b/frontend/src/api/arbit.js
@@ -1,0 +1,9 @@
+/**
+ * Arbit dashboard API helpers.
+ */
+import axios from 'axios'
+
+export const fetchArbitStatus = async () => {
+  const response = await axios.get('/api/arbit/status')
+  return response.data
+}

--- a/frontend/src/components/layout/Navbar.vue
+++ b/frontend/src/components/layout/Navbar.vue
@@ -8,6 +8,7 @@
       <router-link to="/forecast" class="nav-link">Forecasting</router-link>
       <router-link to="/planning" class="nav-link">Planning</router-link>
       <router-link to="/investments" class="nav-link">Investments</router-link>
+      <router-link v-if="showArbit" to="/arbit" class="nav-link">Arbit</router-link>
     </div>
   </nav>
 </template>
@@ -16,8 +17,21 @@
 /**
  * Primary navigation bar with links to top-level routes.
  */
+import { fetchArbitStatus } from '@/api/arbit'
+
 export default {
   name: 'Navbar',
+  data() {
+    return { showArbit: false }
+  },
+  async mounted() {
+    try {
+      const data = await fetchArbitStatus()
+      this.showArbit = Boolean(data?.running)
+    } catch (err) {
+      console.error('Failed to fetch Arbit status', err)
+    }
+  },
 }
 </script>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,6 +16,7 @@ import ForecastMock from '@/views/ForecastMock.vue'
 import FinancialSummaryDetailed from '@/views/FinancialSummaryDetailed.vue'
 
 const Investments = () => import('../views/Investments.vue')
+const ArbitDashboard = () => import('../views/ArbitDashboard.vue')
 const routes = [
   { path: '/', name: 'Dashboard', component: Dashboard },
   { path: '/accounts', name: 'Accounts', component: Accounts },
@@ -30,6 +31,7 @@ const routes = [
     component: NetYearComparisonChart,
   },
   { path: '/investments', name: 'Investments', component: Investments },
+  { path: '/arbit', name: 'Arbit', component: ArbitDashboard },
   { path: '/institutions', name: 'Institutions', component: Institutions },
   { path: '/accounts/table', name: 'AccountsTable', component: AccountsTable },
   { path: '/summary', name: 'FinancialSummaryDetailed', component: FinancialSummaryDetailed },

--- a/frontend/src/views/ArbitDashboard.vue
+++ b/frontend/src/views/ArbitDashboard.vue
@@ -12,4 +12,3 @@ export default {
   name: 'ArbitDashboard',
 }
 </script>
-

--- a/frontend/src/views/ArbitDashboard.vue
+++ b/frontend/src/views/ArbitDashboard.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container py-4">
+    <h1>Arbit Dashboard</h1>
+  </div>
+</template>
+
+<script>
+/**
+ * Displays metrics for the optional Arbit dashboard.
+ */
+export default {
+  name: 'ArbitDashboard',
+}
+</script>
+


### PR DESCRIPTION
## Summary
- add lazy-loaded Arbit dashboard route
- show Arbit nav item when enabled via API
- cover navigation with Cypress smoke test

## Testing
- `pytest -q`
- `pre-commit run --all-files`
- `npx start-server-and-test "http-server dist -p 4173" http://localhost:4173 "cypress run --e2e --spec cypress/e2e/arbit.cy.js"`


------
https://chatgpt.com/codex/tasks/task_e_68bd08f999c08329bb7a6989c20b4c91