### PR TITLE
feat(frontend): add arbitrage dashboard components

### DIFF
--- a/frontend/src/components/ArbitControls.vue
+++ b/frontend/src/components/ArbitControls.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <button class="start-btn" @click="start">Start</button>
+    <button class="stop-btn" @click="stop">Stop</button>
+    <div>Status: {{ status.running ? 'running' : 'stopped' }}</div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Control panel to start and stop the arbitrage engine.
+ */
+import { ref, onMounted } from 'vue'
+import { startArbit, stopArbit, fetchArbitStatus } from '@/services/arbit'
+
+const status = ref({ running: false })
+
+async function refresh() {
+  status.value = await fetchArbitStatus()
+}
+
+async function start() {
+  await startArbit()
+  await refresh()
+}
+
+async function stop() {
+  await stopArbit()
+  await refresh()
+}
+
+onMounted(refresh)
+</script>

--- a/frontend/src/components/ArbitMetrics.vue
+++ b/frontend/src/components/ArbitMetrics.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <PortfolioAllocationChart v-if="profit.length" :allocations="profit" />
+    <PortfolioAllocationChart v-if="latency.length" :allocations="latency" />
+  </div>
+</template>
+
+<script setup>
+/**
+ * Renders profit and latency metrics using existing chart components.
+ */
+import { ref, onMounted } from 'vue'
+import { fetchArbitMetrics } from '@/services/arbit'
+import PortfolioAllocationChart from '@/components/charts/PortfolioAllocationChart.vue'
+
+const profit = ref([])
+const latency = ref([])
+
+async function load() {
+  const data = await fetchArbitMetrics()
+  profit.value = data.profit || []
+  latency.value = data.latency || []
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/ArbitOpportunities.vue
+++ b/frontend/src/components/ArbitOpportunities.vue
@@ -1,0 +1,22 @@
+<template>
+  <ul data-testid="opportunity-list">
+    <li v-for="op in opportunities" :key="op.id">{{ op.symbol }} - {{ op.profit }}</li>
+  </ul>
+</template>
+
+<script setup>
+/**
+ * Lists current arbitrage opportunities.
+ */
+import { ref, onMounted } from 'vue'
+import { fetchArbitOpportunities } from '@/services/arbit'
+
+const opportunities = ref([])
+
+async function load() {
+  const data = await fetchArbitOpportunities()
+  opportunities.value = data.opportunities || []
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/ArbitStatus.vue
+++ b/frontend/src/components/ArbitStatus.vue
@@ -1,0 +1,27 @@
+<template>
+  <div data-testid="arbit-status">
+    <div v-if="loading">Loading...</div>
+    <div v-else>Engine is {{ status.running ? 'running' : 'stopped' }}</div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Displays the current arbitrage engine status.
+ */
+import { ref, onMounted } from 'vue'
+import { fetchArbitStatus } from '@/services/arbit'
+
+const status = ref({ running: false })
+const loading = ref(true)
+
+async function load() {
+  try {
+    status.value = await fetchArbitStatus()
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/ArbitTrades.vue
+++ b/frontend/src/components/ArbitTrades.vue
@@ -1,0 +1,30 @@
+<template>
+  <table data-testid="trades-table">
+    <thead>
+      <tr><th>Pair</th><th>Profit</th></tr>
+    </thead>
+    <tbody>
+      <tr v-for="t in trades" :key="t.id">
+        <td>{{ t.pair }}</td>
+        <td>{{ t.profit }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup>
+/**
+ * Displays recent arbitrage trades.
+ */
+import { ref, onMounted } from 'vue'
+import { fetchArbitTrades } from '@/services/arbit'
+
+const trades = ref([])
+
+async function load() {
+  const data = await fetchArbitTrades()
+  trades.value = data.trades || []
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/components/__tests__/ArbitControls.spec.ts
+++ b/frontend/src/components/__tests__/ArbitControls.spec.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/arbit', () => ({
+  startArbit: vi.fn().mockResolvedValue({}),
+  stopArbit: vi.fn().mockResolvedValue({}),
+  fetchArbitStatus: vi.fn().mockResolvedValue({ running: false }),
+}))
+
+import { startArbit, stopArbit } from '@/services/arbit'
+import ArbitControls from '../ArbitControls.vue'
+
+describe('ArbitControls.vue', () => {
+  it('calls start and stop services', async () => {
+    const wrapper = mount(ArbitControls)
+    await flushPromises()
+    await wrapper.find('button.start-btn').trigger('click')
+    await wrapper.find('button.stop-btn').trigger('click')
+    expect(startArbit).toHaveBeenCalled()
+    expect(stopArbit).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/__tests__/ArbitMetrics.spec.ts
+++ b/frontend/src/components/__tests__/ArbitMetrics.spec.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import ArbitMetrics from '../ArbitMetrics.vue'
+
+vi.mock('@/services/arbit', () => ({
+  fetchArbitMetrics: vi.fn().mockResolvedValue({
+    profit: [{ label: 'p', value: 1 }],
+    latency: [{ label: 'l', value: 2 }]
+  })
+}))
+
+describe('ArbitMetrics.vue', () => {
+  it('renders charts with metrics', async () => {
+    const wrapper = mount(ArbitMetrics, {
+      global: {
+        stubs: {
+          PortfolioAllocationChart: {
+            props: ['allocations'],
+            template: '<div class="chart">{{ allocations.length }}</div>'
+          }
+        }
+      }
+    })
+    await flushPromises()
+    const charts = wrapper.findAll('.chart')
+    expect(charts).toHaveLength(2)
+    expect(charts[0].text()).toBe('1')
+    expect(charts[1].text()).toBe('1')
+  })
+})

--- a/frontend/src/components/__tests__/ArbitOpportunities.spec.ts
+++ b/frontend/src/components/__tests__/ArbitOpportunities.spec.ts
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import ArbitOpportunities from '../ArbitOpportunities.vue'
+
+vi.mock('@/services/arbit', () => ({
+  fetchArbitOpportunities: vi.fn().mockResolvedValue({
+    opportunities: [{ id: 1, symbol: 'AAA', profit: 5 }]
+  })
+}))
+
+describe('ArbitOpportunities.vue', () => {
+  it('lists opportunities', async () => {
+    const wrapper = mount(ArbitOpportunities)
+    await flushPromises()
+    expect(wrapper.text()).toContain('AAA')
+  })
+})

--- a/frontend/src/components/__tests__/ArbitStatus.spec.ts
+++ b/frontend/src/components/__tests__/ArbitStatus.spec.ts
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import ArbitStatus from '../ArbitStatus.vue'
+
+vi.mock('@/services/arbit', () => ({
+  fetchArbitStatus: vi.fn().mockResolvedValue({ running: true })
+}))
+
+describe('ArbitStatus.vue', () => {
+  it('shows running status', async () => {
+    const wrapper = mount(ArbitStatus)
+    await flushPromises()
+    expect(wrapper.text()).toContain('running')
+  })
+})

--- a/frontend/src/components/__tests__/ArbitTrades.spec.ts
+++ b/frontend/src/components/__tests__/ArbitTrades.spec.ts
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import ArbitTrades from '../ArbitTrades.vue'
+
+vi.mock('@/services/arbit', () => ({
+  fetchArbitTrades: vi.fn().mockResolvedValue({
+    trades: [{ id: 1, pair: 'AAA/BBB', profit: 1 }]
+  })
+}))
+
+describe('ArbitTrades.vue', () => {
+  it('renders trades table', async () => {
+    const wrapper = mount(ArbitTrades)
+    await flushPromises()
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].text()).toContain('AAA/BBB')
+  })
+})

--- a/frontend/src/services/arbit.ts
+++ b/frontend/src/services/arbit.ts
@@ -1,0 +1,57 @@
+/**
+ * API helpers for arbitrage dashboard.
+ */
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL || '/api',
+  headers: { 'Content-Type': 'application/json' },
+})
+
+/**
+ * Fetch current arbitrage engine status.
+ */
+export async function fetchArbitStatus() {
+  const response = await apiClient.get('/arbit/status')
+  return response.data
+}
+
+/**
+ * Retrieve profit and latency metrics.
+ */
+export async function fetchArbitMetrics() {
+  const response = await apiClient.get('/arbit/metrics')
+  return response.data
+}
+
+/**
+ * Get the latest arbitrage opportunities.
+ */
+export async function fetchArbitOpportunities() {
+  const response = await apiClient.get('/arbit/opportunities')
+  return response.data
+}
+
+/**
+ * Fetch recently executed arbitrage trades.
+ */
+export async function fetchArbitTrades() {
+  const response = await apiClient.get('/arbit/trades')
+  return response.data
+}
+
+/**
+ * Start the arbitrage engine.
+ */
+export async function startArbit() {
+  const response = await apiClient.post('/arbit/start')
+  return response.data
+}
+
+/**
+ * Stop the arbitrage engine.
+ */
+export async function stopArbit() {
+  const response = await apiClient.post('/arbit/stop')
+  return response.data
+}


### PR DESCRIPTION
## Summary
- add arbitrage service helpers for status, metrics, opportunities, trades, start and stop
- render new Arbit* components and charts
- cover components with unit tests using mocked API responses

## Testing
- `pytest -q`
- `npm test --silent -- src/components/__tests__/Arbit*.spec.ts`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68bd0f3bc28c832998de485ffcc0b72b