### PR TITLE
docs: add Arbit Dashboard guide and route notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - fix: enable primary category filtering on transactions page.
 - feat: add SkeletonCard and RetryError components and integrate into Accounts view.
 - feat: unify theme palette and enable chart legends and tooltips.
+- docs: add Arbit Dashboard guide and frontend route notes.

--- a/docs/arbit_dashboard.md
+++ b/docs/arbit_dashboard.md
@@ -1,0 +1,18 @@
+# Arbit Dashboard
+
+The Arbit dashboard surfaces key arbitrage metrics from backend services to the frontend.
+
+## Configuration
+- Set `ARBIT_API_BASE` in `backend/.env` to point at the Arbit service.
+- Ensure `frontend/.env` contains matching `VITE_ARBIT_API_BASE` for proxying.
+
+## Endpoints
+- `GET /api/arbit/positions`: current open positions.
+- `GET /api/arbit/stats`: aggregated statistics.
+- `POST /api/arbit/refresh`: trigger manual refresh.
+
+## UI
+Visit `/arbit` in the frontend to access the dashboard. The view polls the above endpoints and displays charts for active positions and performance over time.
+
+> TODO: add screenshots or GIFs once the UI stabilizes.
+

--- a/docs/arbit_dashboard.md
+++ b/docs/arbit_dashboard.md
@@ -3,16 +3,18 @@
 The Arbit dashboard surfaces key arbitrage metrics from backend services to the frontend.
 
 ## Configuration
+
 - Set `ARBIT_API_BASE` in `backend/.env` to point at the Arbit service.
 - Ensure `frontend/.env` contains matching `VITE_ARBIT_API_BASE` for proxying.
 
 ## Endpoints
+
 - `GET /api/arbit/positions`: current open positions.
 - `GET /api/arbit/stats`: aggregated statistics.
 - `POST /api/arbit/refresh`: trigger manual refresh.
 
 ## UI
+
 Visit `/arbit` in the frontend to access the dashboard. The view polls the above endpoints and displays charts for active positions and performance over time.
 
 > TODO: add screenshots or GIFs once the UI stabilizes.
-

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -17,3 +17,4 @@
 - [Internal](../internal/) – internal notes
 - [Codex](../codex/) – exploratory reports
 - [Latest](../latest/) – recent drafts and experiments
+- [Arbit Dashboard](../arbit_dashboard.md) – configuration, endpoints, and UI

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,3 +55,14 @@ npm run test:e2e
 ```sh
 npm run lint
 ```
+
+### Develop the Arbit Dashboard Route
+
+1. Ensure the backend Arbit endpoints are running.
+2. Start the frontend development server:
+
+   ```sh
+   npm run dev
+   ```
+
+3. Navigate to `http://localhost:5173/arbit` to view the dashboard.


### PR DESCRIPTION
## Summary
- document Arbit Dashboard configuration, endpoints, and UI
- link guide in docs index and add frontend route development instructions
- record change in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pre-commit run --all-files` *(command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1ab826f0832987b469c44c551ae7