### PR TITLE
refactor(widgets): generalize group accent handling

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -23,7 +23,7 @@
       </button>
       <button
         class="bs-sort-btn"
-        :style="{ '--accent': expandedAccent }"
+        :style="{ '--accent': groupAccent }"
         @click="toggleSort"
         aria-label="Toggle sort order"
       >
@@ -108,7 +108,7 @@
         <li
           v-if="activeAccounts.length"
           class="bs-summary-row"
-          :style="{ '--accent': expandedAccent }"
+          :style="{ '--accent': groupAccent }"
         >
           <div></div>
           <div class="bs-summary-label">Total {{ activeGroup.name }}</div>
@@ -187,9 +187,12 @@ const spectrum = [
   'var(--color-accent-blue)',
 ]
 
-const expandedAccent = computed(() =>
-  activeGroupId.value === 'liabilities' ? 'var(--color-accent-yellow)' : 'var(--color-accent-cyan)',
-)
+// Map account group IDs to accent colors
+const groupAccents = {
+  assets: 'var(--color-accent-cyan)',
+  liabilities: 'var(--color-accent-yellow)',
+}
+const groupAccent = computed(() => groupAccents[activeGroupId.value] || 'var(--color-accent-cyan)')
 
 /** Return accent color for an account */
 function accentColor(account, index) {


### PR DESCRIPTION
## Summary
- rename `expandedAccent` to `groupAccent`
- map group IDs to accent colors for easier extension

## Testing
- `pytest -q`
- `pre-commit run --files frontend/src/components/widgets/TopAccountSnapshot.vue`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7577bc48329ae31e8a8891044dd