### PR TITLE
feat(frontend): allow renaming account groups

### DIFF
--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import TopAccountSnapshot from '../TopAccountSnapshot.vue'
+
+vi.mock('@/composables/useTopAccounts', () => ({
+  useTopAccounts: () => ({
+    allVisibleAccounts: ref([]),
+    fetchAccounts: vi.fn(),
+  }),
+}))
+
+describe('TopAccountSnapshot group editing', () => {
+  it('renders input for new group and saves name on blur', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: {
+        stubs: { AccountSparkline: true },
+      },
+    })
+
+    wrapper.vm.addGroup()
+    await nextTick()
+
+    const input = wrapper.find('input.bs-tab')
+    expect(input.exists()).toBe(true)
+
+    await input.setValue('Test Group')
+    await input.trigger('blur')
+    await nextTick()
+
+    const texts = wrapper.findAll('button.bs-tab').map((b) => b.text())
+    expect(texts).toContain('Test Group')
+  })
+})


### PR DESCRIPTION
## Summary
- enable inline editing for account group tabs
- style editable tabs and add group name editing functions
- test group name editing behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test -- src/components/widgets/__tests__/TopAccountSnapshot.spec.js`
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68bde04ee8888329b36cc294cf6801ee