### PR TITLE
test(frontend): verify account selection limit

### DIFF
--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -4,8 +4,14 @@ import { mount } from '@vue/test-utils'
 import { ref, nextTick } from 'vue'
 import TopAccountSnapshot from '../TopAccountSnapshot.vue'
 
+const sampleAccounts = Array.from({ length: 6 }, (_, i) => ({
+  id: `acc-${i + 1}`,
+  name: `Account ${i + 1}`,
+}))
+
 vi.mock('@/composables/useTopAccounts', () => ({
   useTopAccounts: () => ({
+    accounts: ref(sampleAccounts),
     allVisibleAccounts: ref([]),
     fetchAccounts: vi.fn(),
   }),
@@ -31,5 +37,26 @@ describe('TopAccountSnapshot group editing', () => {
 
     const texts = wrapper.findAll('button.bs-tab').map((b) => b.text())
     expect(texts).toContain('Test Group')
+  })
+
+  it('limits account selection to five and fades dropdown', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: {
+        stubs: { AccountSparkline: true },
+      },
+    })
+
+    wrapper.vm.addGroup()
+    await nextTick()
+
+    const boxes = wrapper.findAll('.bs-account-option input')
+    for (let i = 0; i < 5; i++) {
+      await boxes[i].setValue(true)
+    }
+    await nextTick()
+
+    expect(boxes[5].element.disabled).toBe(true)
+    const dropdown = wrapper.find('.bs-account-dropdown')
+    expect(dropdown.attributes('style')).toContain('opacity: 0.5')
   })
 })


### PR DESCRIPTION
## Summary
- add unit test covering account group editor limits and dropdown dimming

## Testing
- `npm test` *(fails: Snapshot `Transactions.vue > matches snapshot 1` mismatched)*
- `pytest -q` *(fails: 20 errors during collection)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68be79e94ea08329922b0880f2626655