### PR TITLE
feat(frontend): enable account drag ordering

### DIFF
--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -59,4 +59,26 @@ describe('TopAccountSnapshot group editing', () => {
     const dropdown = wrapper.find('.bs-account-dropdown')
     expect(dropdown.attributes('style')).toContain('opacity: 0.5')
   })
+
+  it('renders drag handles and updates account order', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: {
+        stubs: { AccountSparkline: true },
+      },
+    })
+
+    // populate active group with accounts
+    wrapper.vm.groups[0].accounts = [...sampleAccounts]
+    await nextTick()
+
+    const handles = wrapper.findAll('.bs-drag-handle')
+    expect(handles.length).toBe(sampleAccounts.length)
+
+    // simulate reordering
+    wrapper.vm.groups[0].accounts = [...wrapper.vm.groups[0].accounts].reverse()
+    await nextTick()
+
+    const firstName = wrapper.findAll('.bs-name')[0].text()
+    expect(firstName).toContain('Account 6')
+  })
 })


### PR DESCRIPTION
## Summary
- allow reordering of account snapshot rows via drag handles
- preserve group account order instead of sorting
- cover drag handle behavior with unit tests

## Testing
- `pre-commit run --all-files`
- `npm test` *(fails: Snapshot `Transactions.vue > matches snapshot 1` mismatched)*
- `npm test src/components/widgets/__tests__/TopAccountSnapshot.spec.js`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plaid')*


------
https://chatgpt.com/codex/tasks/task_e_68befbc117bc832985a56cff010b4ead