### PR TITLE
docs: document account group management in frontend

### DIFF
--- a/docs/frontend/accounts-development-plan.md
+++ b/docs/frontend/accounts-development-plan.md
@@ -68,6 +68,15 @@ When a user clicks "View Details" on any account:
 - Hide/Show closed accounts
 - Download CSV/PDF report
 - Link new institution
+### 6. Account Groups
+
+- Create custom account groups to organize frequently used accounts.
+- Groups persist in `localStorage`; the last active group is restored on page
+  reload.
+- Reorder accounts within a group by dragging the handle next to each entry.
+- Double-click a group tab to edit its name and press <kbd>Enter</kbd> to save.
+- Each group can include up to **five** accounts; create another group or
+  remove one to add more.
 
 ---
 
@@ -93,3 +102,4 @@ When a user clicks "View Details" on any account:
 |   - Slate Credit     ...$330.25   [chart] [View]
 |
 | [Add Account] [Download CSV]
+```

--- a/docs/frontend/accounts-development-plan.md
+++ b/docs/frontend/accounts-development-plan.md
@@ -10,7 +10,7 @@ The **Accounts Page** provides a detailed, organized view of all user accounts g
 
 ### 1. Institution Overview
 
-- **Institution Filter/Dropdown**  
+- **Institution Filter/Dropdown**
   - Select "All" or filter by specific institution (bank, credit union, etc.)
 
 - **Institution Cards**
@@ -68,6 +68,7 @@ When a user clicks "View Details" on any account:
 - Hide/Show closed accounts
 - Download CSV/PDF report
 - Link new institution
+
 ### 6. Account Groups
 
 - Create custom account groups to organize frequently used accounts.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,6 +56,21 @@ npm run test:e2e
 npm run lint
 ```
 
+### Account Groups
+
+The dashboard lets you organize accounts into custom groups. Groups and the
+currently active selection are stored in `localStorage`, so your layout is
+restored on reload.
+
+- **Create & select** – use the group dropdown to switch groups or press the
+  **+** button to add a new one.
+- **Rename** – double-click a group tab, edit the name, then press
+  <kbd>Enter</kbd> or click away to save.
+- **Assign accounts** – choose up to five accounts for a group using the account
+  selector.
+- **Reorder accounts** – drag the handle beside an account to change its order
+  within the active group.
+
 ### Develop the Arbit Dashboard Route
 
 1. Ensure the backend Arbit endpoints are running.


### PR DESCRIPTION
## Summary
- document new account group capabilities, including persistence, renaming, drag ordering and account limits in the frontend README
- expand accounts page development plan with group creation, localStorage persistence, renaming and five-account limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbee946708329aa3b2e435cdab8cf