### PR TITLE
fix: remove deprecated use-spectrum prop from dashboard

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -40,7 +40,7 @@
           <h2 class="text-2xl font-bold text-[var(--color-accent-green)] text-center">
             Top Accounts
           </h2>
-          <TopAccountSnapshot use-spectrum :groups="groups" v-model:active-group="activeGroupId" />
+          <TopAccountSnapshot :groups="groups" v-model:active-group="activeGroupId" />
         </div>
         <!-- Net Income Summary Card -->
         <div


### PR DESCRIPTION
## Summary
- remove `use-spectrum` prop from `TopAccountSnapshot`
- clean up asset/liability and sort-toggle remnants

## Testing
- `pre-commit run --files frontend/src/views/Dashboard.vue`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe8aa53e48329a0eeaa70ec981f9f