### PR TITLE
feat(frontend): enable account group editing

### DIFF
--- a/frontend/src/composables/__tests__/useAccountGroups.spec.js
+++ b/frontend/src/composables/__tests__/useAccountGroups.spec.js
@@ -65,4 +65,17 @@ describe('useAccountGroups', () => {
     expect(addAccountToGroup(id, 'acc-5')).toBe(false)
     expect(groups.value[0].accounts.length).toBe(5)
   })
+
+  it('removes accounts from groups and persists', async () => {
+    const { addAccountToGroup, removeAccountFromGroup, groups } = useAccountGroups()
+    const id = groups.value[0].id
+    addAccountToGroup(id, { id: 'acc-1' })
+    await nextTick()
+    expect(groups.value[0].accounts.length).toBe(1)
+    expect(removeAccountFromGroup(id, 'acc-1')).toBe(true)
+    await nextTick()
+    expect(groups.value[0].accounts.length).toBe(0)
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY))
+    expect(stored.groups[0].accounts.length).toBe(0)
+  })
 })

--- a/frontend/src/composables/useAccountGroups.js
+++ b/frontend/src/composables/useAccountGroups.js
@@ -105,6 +105,23 @@ export function useAccountGroups() {
     return true
   }
 
+  /**
+   * Remove an account from a group by identifier.
+   * @param {string} groupId
+   * @param {string} accountId
+   * @returns {boolean} true if the account was removed
+   */
+  function removeAccountFromGroup(groupId, accountId) {
+    const group = groups.value.find((g) => g.id === groupId)
+    if (!group) return false
+    const idx = group.accounts.findIndex(
+      (a) => a.id === accountId || a.account_id === accountId,
+    )
+    if (idx === -1) return false
+    group.accounts.splice(idx, 1)
+    return true
+  }
+
   watch(
     groups,
     () => {
@@ -117,5 +134,13 @@ export function useAccountGroups() {
   ensureActive()
   persist()
 
-  return { groups, activeGroupId, addGroup, setActiveGroup, removeGroup, addAccountToGroup }
+  return {
+    groups,
+    activeGroupId,
+    addGroup,
+    setActiveGroup,
+    removeGroup,
+    addAccountToGroup,
+    removeAccountFromGroup,
+  }
 }


### PR DESCRIPTION
## Summary
- allow deleting accounts from a group when editing
- add "+ Add Account" row with account selector and limit styling
- persist account removals via useAccountGroups helper

## Testing
- `npm test -- --run`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08b68d4008329bd360d075f2bbe36