### PR TITLE
docs: clarify Arbit Discord setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ hooks run and the server restarts with the latest changes.
 
 - `ENABLE_ARBIT_DASHBOARD` – set to `true` to enable the experimental arbitrage dashboard.
 
+### Discord arbitrage feed
+
+To surface live R/S arbitrage data in the UI, add the dashboard flag and run the Discord bot that publishes snapshots:
+
+1. In `backend/.env` set `ENABLE_ARBIT_DASHBOARD=true`.
+2. Run your Arbit Discord bot so it writes JSON updates to `backend/app/logs/rs_arbitrage.json`.
+   The API reads this file and serves it at `/api/arbitrage/current`.
+3. Start the backend and frontend, then visit `/arbitrage` in the browser to view the feed.
+
 ## Testing
 
 - Backend tests:


### PR DESCRIPTION
## Summary
- document steps to enable the Arbit Discord feed in README

## Testing
- `pre-commit run --files README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.services.plaid_sync'; 'app.services' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c59549d4832996978f8172711138