### PR TITLE
fix(frontend): destructure account composables

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -241,7 +241,7 @@
 <script setup>
 import { ref, reactive, computed, watch } from 'vue'
 import draggable from 'vuedraggable'
-import { GripVertical, X, Plus } from 'lucide-vue-next'
+import { GripVertical, X, Plus, Check } from 'lucide-vue-next'
 import { useTopAccounts } from '@/composables/useTopAccounts'
 import { useAccountGroups } from '@/composables/useAccountGroups'
 import AccountSparkline from './AccountSparkline.vue'
@@ -253,8 +253,14 @@ const props = defineProps({
 })
 
 // fetch accounts generically for potential group management
-useTopAccounts()
-const { groups, activeGroupId, removeGroup } = useAccountGroups()
+const { allVisibleAccounts } = useTopAccounts()
+const {
+  groups,
+  activeGroupId,
+  removeGroup,
+  addAccountToGroup,
+  removeAccountFromGroup,
+} = useAccountGroups()
 
 // Details dropdown state
 const openAccountId = ref(null)

--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -254,13 +254,8 @@ const props = defineProps({
 
 // fetch accounts generically for potential group management
 const { allVisibleAccounts } = useTopAccounts()
-const {
-  groups,
-  activeGroupId,
-  removeGroup,
-  addAccountToGroup,
-  removeAccountFromGroup,
-} = useAccountGroups()
+const { groups, activeGroupId, removeGroup, addAccountToGroup, removeAccountFromGroup } =
+  useAccountGroups()
 
 // Details dropdown state
 const openAccountId = ref(null)


### PR DESCRIPTION
## Summary
- expose additional composable helpers in TopAccountSnapshot
- import Check icon for active group indicator

## Testing
- `npm test`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem' from 'app.models')*
- `pre-commit run --all-files` *(fails: ruff undefined names, mypy duplicate module)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bfc5d5948329a33a2bb7451a60cc