### PR TITLE
feat(planning): add planning summary component

### DIFF
--- a/frontend/src/components/planning/PlanningSummary.vue
+++ b/frontend/src/components/planning/PlanningSummary.vue
@@ -37,9 +37,7 @@ const { state } = usePlanning()
  *
  * @returns {string} formatted total of all bills
  */
-const totalBills = computed(() =>
-  formatAmount(selectTotalBillsCents(state) / 100),
-)
+const totalBills = computed(() => formatAmount(selectTotalBillsCents(state) / 100))
 
 /**
  * Remaining unallocated cash for the active scenario formatted as
@@ -56,4 +54,3 @@ const remainingCash = computed(() => {
 <style scoped>
 /* Basic styling placeholder for PlanningSummary */
 </style>
-

--- a/frontend/src/components/planning/PlanningSummary.vue
+++ b/frontend/src/components/planning/PlanningSummary.vue
@@ -1,0 +1,59 @@
+<!--
+  PlanningSummary.vue
+  -------------------
+  Display a summary of total bills and remaining cash.
+-->
+
+<template>
+  <div class="planning-summary">
+    <h3>Planning Summary</h3>
+    <p>Total Bills: {{ totalBills }}</p>
+    <p>Remaining Cash: {{ remainingCash }}</p>
+  </div>
+</template>
+
+<script setup>
+/**
+ * PlanningSummary component.
+ *
+ * Shows the total amount of all bills and the remaining unallocated
+ * cash for the active scenario using shared planning state and
+ * selectors.
+ */
+import { computed } from 'vue'
+import { usePlanning } from '@/composables/usePlanning'
+import {
+  selectActiveScenario,
+  selectRemainingCents,
+  selectTotalBillsCents,
+} from '@/selectors/planning'
+import { formatAmount } from '@/utils/format'
+
+/** Access reactive planning state. */
+const { state } = usePlanning()
+
+/**
+ * Total amount across all bills formatted as currency.
+ *
+ * @returns {string} formatted total of all bills
+ */
+const totalBills = computed(() =>
+  formatAmount(selectTotalBillsCents(state) / 100),
+)
+
+/**
+ * Remaining unallocated cash for the active scenario formatted as
+ * currency.
+ *
+ * @returns {string} formatted remaining cash
+ */
+const remainingCash = computed(() => {
+  const scenario = selectActiveScenario(state)
+  return formatAmount(selectRemainingCents(scenario) / 100)
+})
+</script>
+
+<style scoped>
+/* Basic styling placeholder for PlanningSummary */
+</style>
+


### PR DESCRIPTION
## Summary
- add PlanningSummary.vue to show total bills and remaining cash
- document usage of planning state selectors and formatting

## Testing
- `pre-commit run --files frontend/src/components/planning/PlanningSummary.vue`
- `pytest -q` *(fails: cannot import name 'PlaidItem' from 'app.models')*


------
https://chatgpt.com/codex/tasks/task_e_68c596ffa9ac83298c37ace216af2673