### PR TITLE
feat(accounts): support date-bounded history

### DIFF
--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -125,9 +125,9 @@ def refresh_all_accounts():
                         # Add remediation info for ITEM_LOGIN_REQUIRED
                         if err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
                             error_map[key]["requires_reauth"] = True
-                            error_map[key]["update_link_token_endpoint"] = (
-                                "/api/plaid/transactions/generate_update_link_token"
-                            )
+                            error_map[key][
+                                "update_link_token_endpoint"
+                            ] = "/api/plaid/transactions/generate_update_link_token"
                             error_map[key]["affected_account_ids"] = [
                                 account.account_id
                             ]
@@ -585,8 +585,9 @@ def get_account_history(account_id):
     The calculation starts from the account's current balance and walks
     backwards through transaction deltas to derive prior day balances.
     A ``range`` query parameter like ``7d`` or ``30d`` limits how many
-    days are returned. Both the external ``account_id`` and internal numeric
-    ``id`` are accepted in the path segment.
+    days are returned when explicit ``start_date`` and ``end_date``
+    parameters are not provided. Both the external ``account_id`` and
+    internal numeric ``id`` are accepted in the path segment.
     """
     from datetime import timedelta
 
@@ -597,14 +598,45 @@ def get_account_history(account_id):
         range_param = request.args.get("range", "30d")
         days = int(range_param.rstrip("d")) if range_param.endswith("d") else 30
 
+        start_date_str = request.args.get("start_date")
+        end_date_str = request.args.get("end_date")
+
+        now_date = datetime.now(timezone.utc).date()
+        start_date = None
+        end_date = None
+
+        if start_date_str:
+            try:
+                start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+            except ValueError:
+                return (
+                    jsonify({"error": "Invalid start_date format. Use YYYY-MM-DD"}),
+                    400,
+                )
+        if end_date_str:
+            try:
+                end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+            except ValueError:
+                return (
+                    jsonify({"error": "Invalid end_date format. Use YYYY-MM-DD"}),
+                    400,
+                )
+
+        if start_date and end_date:
+            pass
+        elif start_date and not end_date:
+            end_date = start_date + timedelta(days=days - 1)
+        elif end_date and not start_date:
+            start_date = end_date - timedelta(days=days - 1)
+        else:
+            end_date = now_date
+            start_date = end_date - timedelta(days=days - 1)
+
         # Use the robust account resolver
         account = resolve_account_by_any_id(account_id)
         if not account:
             logger.warning(f"Account history request for unknown account: {account_id}")
             return jsonify({"error": "Account not found"}), 404
-
-        end_date = datetime.now(timezone.utc).date()
-        start_date = end_date - timedelta(days=days - 1)
 
         tx_rows = (
             db.session.query(func.date(Transaction.date), func.sum(Transaction.amount))

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -125,9 +125,9 @@ def refresh_all_accounts():
                         # Add remediation info for ITEM_LOGIN_REQUIRED
                         if err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
                             error_map[key]["requires_reauth"] = True
-                            error_map[key][
-                                "update_link_token_endpoint"
-                            ] = "/api/plaid/transactions/generate_update_link_token"
+                            error_map[key]["update_link_token_endpoint"] = (
+                                "/api/plaid/transactions/generate_update_link_token"
+                            )
                             error_map[key]["affected_account_ids"] = [
                                 account.account_id
                             ]

--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -7,19 +7,13 @@
 import axios from 'axios'
 
 export const fetchNetChanges = async (accountId, params = {}) => {
-  const response = await axios.get(
-    `/api/accounts/${accountId}/net_changes`,
-    { params }
-  )
+  const response = await axios.get(`/api/accounts/${accountId}/net_changes`, { params })
   return response.data
 }
 
 export const fetchRecentTransactions = async (accountId, limit = 10) => {
   const params = { recent: true, limit }
-  const response = await axios.get(
-    `/api/transactions/${accountId}/transactions`,
-    { params }
-  )
+  const response = await axios.get(`/api/transactions/${accountId}/transactions`, { params })
   return response.data
 }
 
@@ -31,14 +25,8 @@ export const fetchRecentTransactions = async (accountId, limit = 10) => {
  *   options object with `range`, `start_date`, and `end_date`.
  */
 export const fetchAccountHistory = async (accountId, options = {}) => {
-  const params =
-    typeof options === 'string'
-      ? { range: options }
-      : { range: '30d', ...options }
-  const response = await axios.get(
-    `/api/accounts/${accountId}/history`,
-    { params }
-  )
+  const params = typeof options === 'string' ? { range: options } : { range: '30d', ...options }
+  const response = await axios.get(`/api/accounts/${accountId}/history`, { params })
   return response.data
 }
 
@@ -50,9 +38,6 @@ export const fetchAccountHistory = async (accountId, options = {}) => {
  * @param {object} params
  */
 export const fetchAccountTransactionHistory = async (accountId, params = {}) => {
-  const response = await axios.get(
-    `/api/accounts/${accountId}/transaction_history`,
-    { params }
-  )
+  const response = await axios.get(`/api/accounts/${accountId}/transaction_history`, { params })
   return response.data
 }

--- a/frontend/src/api/accounts.js
+++ b/frontend/src/api/accounts.js
@@ -27,10 +27,14 @@ export const fetchRecentTransactions = async (accountId, limit = 10) => {
  * Fetch recent balance history for an account.
  *
  * @param {string} accountId
- * @param {string} [range='30d'] - Range of days (e.g. '7d', '30d').
+ * @param {object|string} [options] - Either a range string (e.g. '30d') or an
+ *   options object with `range`, `start_date`, and `end_date`.
  */
-export const fetchAccountHistory = async (accountId, range = '30d') => {
-  const params = { range }
+export const fetchAccountHistory = async (accountId, options = {}) => {
+  const params =
+    typeof options === 'string'
+      ? { range: options }
+      : { range: '30d', ...options }
   const response = await axios.get(
     `/api/accounts/${accountId}/history`,
     { params }


### PR DESCRIPTION
## Summary
- allow optional `start_date` and `end_date` to bound account history queries
- forward history date params from frontend API helper
- test exact and open-ended date ranges plus empty history response

## Testing
- `pytest tests/test_api_account_history.py -q`
- `pre-commit run --files backend/app/routes/accounts.py frontend/src/api/accounts.js tests/test_api_account_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5f48b3ce883299f98d026f8835d5d