### PR TITLE
fix(top-account-snapshot): enforce 30-char limit on group names

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -22,6 +22,7 @@
               <input
                 v-model="g.name"
                 class="bs-tab-input"
+                maxlength="30"
                 @blur="finishEdit(g)"
                 @keyup.enter="finishEdit(g)"
               />
@@ -50,6 +51,7 @@
                 'bs-tab-' + g.id,
                 'bs-tab-input',
               ]"
+              maxlength="30"
               @blur="finishEdit(g)"
               @keyup.enter="finishEdit(g)"
             />
@@ -389,10 +391,19 @@ function startEdit(id) {
 }
 
 /** Disable editing and persist the group name */
+/**
+ * Disable editing and persist the group name.
+ * Truncates names longer than 30 characters and appends an ellipsis.
+ */
 function finishEdit(group) {
   editingGroupId.value = null
   if (!group.name) {
     editingGroupId.value = group.id
+    return
+  }
+  const MAX_LEN = 30
+  if (group.name.length > MAX_LEN) {
+    group.name = group.name.slice(0, MAX_LEN) + '…'
   }
 }
 

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -201,6 +201,23 @@ describe('TopAccountSnapshot', () => {
     expect(stored.groups[0].name).toBe('AA')
   })
 
+  it('truncates group names longer than 30 characters with ellipsis', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: { stubs: { AccountSparkline: true } },
+    })
+
+    await nextTick()
+    const group = wrapper.vm.groups[0]
+    wrapper.vm.startEdit(group.id)
+    group.name = 'A'.repeat(35)
+    wrapper.vm.finishEdit(group)
+    await nextTick()
+    const expected = 'A'.repeat(30) + '…'
+    expect(wrapper.find('button.bs-tab').text()).toBe(expected)
+    const stored = JSON.parse(localStorage.getItem('accountGroups'))
+    expect(stored.groups[0].name).toBe(expected)
+  })
+
   it('persists group order changes when dragged', async () => {
     localStorage.setItem(
       'accountGroups',


### PR DESCRIPTION
## Summary
- limit account group name inputs to 30 characters
- truncate long group names with ellipsis on save
- test group name truncation behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --prefix frontend` *(fails: Dashboard.vue test assertion error)*
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f74fe9248329a9800e7c470d0831