### PR TITLE
fix: stabilize TopAccountSnapshot account list

### DIFF
--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -98,6 +98,8 @@ describe('TopAccountSnapshot', () => {
 
     await nextTick()
 
+    expect(Array.isArray(wrapper.vm.accounts.value)).toBe(true)
+
     const names = wrapper.findAll('button.bs-tab').map((b) => b.text())
     expect(names).toContain('Group')
 
@@ -126,7 +128,7 @@ describe('TopAccountSnapshot', () => {
 
     await nextTick()
     const firstBefore = wrapper.findAll('.bs-name')[0].text()
-    wrapper.vm.groups[0].accounts.reverse()
+    wrapper.vm.accounts.value.reverse()
     await nextTick()
     const firstAfter = wrapper.findAll('.bs-name')[0].text()
     expect(firstAfter).not.toBe(firstBefore)


### PR DESCRIPTION
## Summary
- keep TopAccountSnapshot account list in a dedicated ref and sync with active group via watchers
- update draggable binding and tests for new account list ref

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68c6399a6f648329821b2da445c83697