### PR TITLE
feat(frontend): accept explicit dates for account history

### DIFF
--- a/ACCOUNTS_ROADMAP.md
+++ b/ACCOUNTS_ROADMAP.md
@@ -50,7 +50,7 @@ Use the existing `fetchAccountHistory` API and render a line chart (see `Account
 ### 3.4 Filter Controls
 
 - Add dropdown with 7d, 30d, 90d, 365d ranges.
-- Pass selected range to `fetchAccountHistory`.
+- Convert the selected range to explicit dates and call `fetchAccountHistory` with `start` and `end`.
 
 ### 3.5 Cypress Tests
 

--- a/frontend/src/composables/useAccountHistory.js
+++ b/frontend/src/composables/useAccountHistory.js
@@ -2,7 +2,7 @@
  * Composable to fetch and expose balance history for a single account.
  */
 import { ref, isRef, watch } from 'vue'
-import { fetchAccountHistory } from '@/api/accounts'
+import { fetchAccountHistory, rangeToDates } from '@/api/accounts'
 
 /**
  * Reactive helper to load recent balance history for an account.
@@ -17,7 +17,8 @@ export function useAccountHistory(accountId) {
     if (!accountIdRef.value) return
     loading.value = true
     try {
-      const response = await fetchAccountHistory(accountIdRef.value)
+      const { start, end } = rangeToDates('30d')
+      const response = await fetchAccountHistory(accountIdRef.value, start, end)
       let hist = []
       if (Array.isArray(response?.data?.history)) {
         hist = response.data.history

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -131,7 +131,12 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Wallet } from 'lucide-vue-next'
-import { fetchNetChanges, fetchRecentTransactions, fetchAccountHistory, rangeToDates } from '@/api/accounts'
+import {
+  fetchNetChanges,
+  fetchRecentTransactions,
+  fetchAccountHistory,
+  rangeToDates,
+} from '@/api/accounts'
 import { formatAmount } from '@/utils/format'
 
 // UI Components

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -131,7 +131,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Wallet } from 'lucide-vue-next'
-import { fetchNetChanges, fetchRecentTransactions, fetchAccountHistory } from '@/api/accounts'
+import { fetchNetChanges, fetchRecentTransactions, fetchAccountHistory, rangeToDates } from '@/api/accounts'
 import { formatAmount } from '@/utils/format'
 
 // UI Components
@@ -197,7 +197,8 @@ async function loadHistory() {
   historyError.value = null
   loadingHistory.value = true
   try {
-    const res = await fetchAccountHistory(accountId.value, selectedRange.value)
+    const { start, end } = rangeToDates(selectedRange.value)
+    const res = await fetchAccountHistory(accountId.value, start, end)
     accountHistory.value = res.balances || []
   } catch (e) {
     historyError.value = e

--- a/frontend/src/views/__tests__/AccountsRetry.cy.js
+++ b/frontend/src/views/__tests__/AccountsRetry.cy.js
@@ -3,6 +3,12 @@ import Accounts from '../Accounts.vue'
 function mountWithFailingHistory() {
   let call = 0
 
+  const today = new Date()
+  const end = today.toISOString().slice(0, 10)
+  const start30 = new Date(today)
+  start30.setDate(start30.getDate() - 30)
+  const start30Str = start30.toISOString().slice(0, 10)
+
   cy.intercept('GET', '/api/accounts/acc1/net_changes*', {
     statusCode: 200,
     body: { status: 'success', data: { income: 0, expense: 0, net: 0 } },
@@ -13,7 +19,7 @@ function mountWithFailingHistory() {
     body: { status: 'success', data: { transactions: [] } },
   }).as('tx')
 
-  cy.intercept('GET', '/api/accounts/acc1/history?range=30d', (req) => {
+  cy.intercept('GET', `/api/accounts/acc1/history?start_date=${start30Str}&end_date=${end}`, (req) => {
     call += 1
     if (call === 1) {
       req.reply({ statusCode: 500, body: {} })

--- a/frontend/src/views/__tests__/AccountsRetry.cy.js
+++ b/frontend/src/views/__tests__/AccountsRetry.cy.js
@@ -19,17 +19,21 @@ function mountWithFailingHistory() {
     body: { status: 'success', data: { transactions: [] } },
   }).as('tx')
 
-  cy.intercept('GET', `/api/accounts/acc1/history?start_date=${start30Str}&end_date=${end}`, (req) => {
-    call += 1
-    if (call === 1) {
-      req.reply({ statusCode: 500, body: {} })
-    } else {
-      req.reply({
-        statusCode: 200,
-        body: { accountId: 'acc1', asOfDate: '2025-08-03', balances: [] },
-      })
-    }
-  }).as('hist')
+  cy.intercept(
+    'GET',
+    `/api/accounts/acc1/history?start_date=${start30Str}&end_date=${end}`,
+    (req) => {
+      call += 1
+      if (call === 1) {
+        req.reply({ statusCode: 500, body: {} })
+      } else {
+        req.reply({
+          statusCode: 200,
+          body: { accountId: 'acc1', asOfDate: '2025-08-03', balances: [] },
+        })
+      }
+    },
+  ).as('hist')
 
   cy.mount(Accounts, {
     global: {

--- a/frontend/src/views/__tests__/AccountsSummary.cy.js
+++ b/frontend/src/views/__tests__/AccountsSummary.cy.js
@@ -1,12 +1,23 @@
 import Accounts from '../Accounts.vue'
 
 function mountPage() {
+  const today = new Date()
+  const end = today.toISOString().slice(0, 10)
+
+  const start30 = new Date(today)
+  start30.setDate(start30.getDate() - 30)
+  const start30Str = start30.toISOString().slice(0, 10)
+
+  const start90 = new Date(today)
+  start90.setDate(start90.getDate() - 90)
+  const start90Str = start90.toISOString().slice(0, 10)
+
   cy.intercept('GET', '/api/accounts/acc1/net_changes*', {
     statusCode: 200,
     body: { status: 'success', data: { income: 1000, expense: -400, net: 600 } },
   }).as('net')
 
-  cy.intercept('GET', '/api/accounts/acc1/history?range=30d', {
+  cy.intercept('GET', `/api/accounts/acc1/history?start_date=${start30Str}&end_date=${end}`, {
     statusCode: 200,
     body: {
       accountId: 'acc1',
@@ -18,7 +29,7 @@ function mountPage() {
     },
   }).as('hist30')
 
-  cy.intercept('GET', '/api/accounts/acc1/history?range=90d', {
+  cy.intercept('GET', `/api/accounts/acc1/history?start_date=${start90Str}&end_date=${end}`, {
     statusCode: 200,
     body: { accountId: 'acc1', asOfDate: '2025-08-03', balances: [] },
   }).as('hist90')


### PR DESCRIPTION
## Summary
- refactor account history API to accept explicit start/end dates
- update account history composable and Accounts view to use start/end params
- adjust Cypress tests and roadmap docs for new signature

## Testing
- `pre-commit run --files ACCOUNTS_ROADMAP.md frontend/src/api/accounts.js frontend/src/composables/useAccountHistory.js frontend/src/views/Accounts.vue frontend/src/views/__tests__/AccountsRetry.cy.js frontend/src/views/__tests__/AccountsSummary.cy.js`
- `pytest tests/test_api_account_history.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem' from 'app.models')*

------
https://chatgpt.com/codex/tasks/task_e_68c6503b3a30832998a9e6be9a750ed9