### PR TITLE
feat(frontend): cache account history by range

### DIFF
--- a/frontend/src/components/widgets/AccountSparkline.vue
+++ b/frontend/src/components/widgets/AccountSparkline.vue
@@ -26,7 +26,11 @@ const props = defineProps({
 const dataType = ref('balance')
 
 // Fetch both types of data
-const { history: balanceHistory } = useAccountHistory(toRef(props, 'accountId'))
+const range = ref('30d')
+const { history: balanceHistory } = useAccountHistory(
+  toRef(props, 'accountId'),
+  range
+)
 
 // Only fetch transaction history if the composable is available
 // For now, fall back to balance data to ensure functionality

--- a/frontend/src/components/widgets/AccountSparkline.vue
+++ b/frontend/src/components/widgets/AccountSparkline.vue
@@ -5,7 +5,13 @@
 -->
 <template>
   <div class="sparkline-container" @click="toggleDataType" :title="toggleTitle">
-    <svg v-if="points" viewBox="0 0 100 100" class="bs-sparkline" role="img" :aria-label="ariaLabel">
+    <svg
+      v-if="points"
+      viewBox="0 0 100 100"
+      class="bs-sparkline"
+      role="img"
+      :aria-label="ariaLabel"
+    >
       <polyline :points="points" :class="sparklineClass" />
     </svg>
     <span v-else class="bs-sparkline-placeholder" role="img" :aria-label="noDataLabel"></span>
@@ -19,7 +25,7 @@ import { useAccountHistory } from '@/composables/useAccountHistory'
 import { useAccountTransactionHistory } from '@/composables/useAccountTransactionHistory'
 
 const props = defineProps({
-  accountId: { type: String, required: true }
+  accountId: { type: String, required: true },
 })
 
 // Data type: 'balance' or 'transactions'
@@ -27,10 +33,7 @@ const dataType = ref('balance')
 
 // Fetch both types of data
 const range = ref('30d')
-const { history: balanceHistory } = useAccountHistory(
-  toRef(props, 'accountId'),
-  range
-)
+const { history: balanceHistory } = useAccountHistory(toRef(props, 'accountId'), range)
 
 // Only fetch transaction history if the composable is available
 // For now, fall back to balance data to ensure functionality
@@ -50,54 +53,48 @@ function toggleDataType() {
 }
 
 // Computed properties for UI
-const toggleTitle = computed(() => 
-  `Click to toggle to ${dataType.value === 'balance' ? 'transaction' : 'balance'} view`
+const toggleTitle = computed(
+  () => `Click to toggle to ${dataType.value === 'balance' ? 'transaction' : 'balance'} view`,
 )
 
-const dataTypeIndicator = computed(() => 
-  dataType.value === 'balance' ? 'B' : 'T'
-)
+const dataTypeIndicator = computed(() => (dataType.value === 'balance' ? 'B' : 'T'))
 
 const indicatorClass = computed(() => ({
   'indicator-balance': dataType.value === 'balance',
-  'indicator-transactions': dataType.value === 'transactions'
+  'indicator-transactions': dataType.value === 'transactions',
 }))
 
 const sparklineClass = computed(() => ({
   'sparkline-balance': dataType.value === 'balance',
-  'sparkline-transactions': dataType.value === 'transactions'
+  'sparkline-transactions': dataType.value === 'transactions',
 }))
 
-const ariaLabel = computed(() => 
-  `Recent ${dataType.value} history for account ${props.accountId}`
-)
+const ariaLabel = computed(() => `Recent ${dataType.value} history for account ${props.accountId}`)
 
-const noDataLabel = computed(() => 
-  `No ${dataType.value} history available`
-)
+const noDataLabel = computed(() => `No ${dataType.value} history available`)
 
 // Current data based on selected type
-const currentData = computed(() => 
-  dataType.value === 'balance' ? balanceHistory.value : transactionHistory.value
+const currentData = computed(() =>
+  dataType.value === 'balance' ? balanceHistory.value : transactionHistory.value,
 )
 
 // Generate sparkline points
 const points = computed(() => {
   const data = currentData.value
   if (!data.length) return ''
-  
+
   let values
   if (dataType.value === 'balance') {
-    values = data.map(d => d.balance)
+    values = data.map((d) => d.balance)
   } else {
     // For transactions, use net amounts or transaction counts
-    values = data.map(d => d.net_amount || d.transaction_count || 0)
+    values = data.map((d) => d.net_amount || d.transaction_count || 0)
   }
-  
+
   const max = Math.max(...values)
   const min = Math.min(...values)
   const range = max - min || 1
-  
+
   return data
     .map((d, idx) => {
       const x = (idx / (data.length - 1)) * 100

--- a/frontend/src/composables/__tests__/useAccountHistory.cy.js
+++ b/frontend/src/composables/__tests__/useAccountHistory.cy.js
@@ -7,7 +7,7 @@ const TestComponent = defineComponent({
   setup(props) {
     const { history } = useAccountHistory(toRef(props, 'id'), toRef(props, 'range'))
     return { history }
-  }
+  },
 })
 
 describe('useAccountHistory', () => {
@@ -19,9 +19,9 @@ describe('useAccountHistory', () => {
         status: 'success',
         history: [
           { date: '2024-01-01', balance: 100 },
-          { date: '2024-01-02', balance: 110 }
-        ]
-      }
+          { date: '2024-01-02', balance: 110 },
+        ],
+      },
     }).as('getHistory')
 
     cy.mount(TestComponent, { props: { id: '123', range: '30d' } })
@@ -32,7 +32,7 @@ describe('useAccountHistory', () => {
   it('memoizes history per account and range', () => {
     cy.intercept('GET', '/api/accounts/123/history*', {
       statusCode: 200,
-      body: { history: [] }
+      body: { history: [] },
     }).as('getHistory')
 
     cy.mount(TestComponent, { props: { id: '123', range: '30d' } })
@@ -51,12 +51,13 @@ describe('useAccountHistory', () => {
         const range = ref('30d')
         const { history } = useAccountHistory(toRef(props, 'id'), range)
         return { history, range }
-      }
+      },
     })
 
-    cy.intercept('GET', '/api/accounts/123/history*', { statusCode: 200, body: { history: [] } }).as(
-      'getHistory'
-    )
+    cy.intercept('GET', '/api/accounts/123/history*', {
+      statusCode: 200,
+      body: { history: [] },
+    }).as('getHistory')
 
     cy.mount(RangeComponent, { props: { id: '123' } })
     cy.wait('@getHistory').its('request.url').should('include', 'range=30d')

--- a/frontend/src/composables/__tests__/useAccountHistory.cy.js
+++ b/frontend/src/composables/__tests__/useAccountHistory.cy.js
@@ -1,11 +1,11 @@
-import { defineComponent, toRef } from 'vue'
+import { defineComponent, ref, toRef } from 'vue'
 import { useAccountHistory } from '../useAccountHistory'
 
 const TestComponent = defineComponent({
-  props: { id: String },
+  props: { id: String, range: String },
   template: '<ul><li v-for="pt in history" :key="pt.date">{{ pt.balance }}</li></ul>',
   setup(props) {
-    const { history } = useAccountHistory(toRef(props, 'id'))
+    const { history } = useAccountHistory(toRef(props, 'id'), toRef(props, 'range'))
     return { history }
   }
 })
@@ -24,8 +24,43 @@ describe('useAccountHistory', () => {
       }
     }).as('getHistory')
 
-    cy.mount(TestComponent, { props: { id: '123' } })
+    cy.mount(TestComponent, { props: { id: '123', range: '30d' } })
     cy.wait('@getHistory')
     cy.get('li').should('have.length', 2).last().should('contain', '110')
+  })
+
+  it('memoizes history per account and range', () => {
+    cy.intercept('GET', '/api/accounts/123/history*', {
+      statusCode: 200,
+      body: { history: [] }
+    }).as('getHistory')
+
+    cy.mount(TestComponent, { props: { id: '123', range: '30d' } })
+    cy.wait('@getHistory')
+
+    cy.mount(TestComponent, { props: { id: '123', range: '30d' } })
+    cy.wait(100)
+    cy.get('@getHistory.all').should('have.length', 1)
+  })
+
+  it('fetches new data when range changes', () => {
+    const RangeComponent = defineComponent({
+      props: { id: String },
+      template: `<div><button id="change" @click="range='60d'"></button><ul><li v-for="pt in history" :key="pt.date">{{ pt.balance }}</li></ul></div>`,
+      setup(props) {
+        const range = ref('30d')
+        const { history } = useAccountHistory(toRef(props, 'id'), range)
+        return { history, range }
+      }
+    })
+
+    cy.intercept('GET', '/api/accounts/123/history*', { statusCode: 200, body: { history: [] } }).as(
+      'getHistory'
+    )
+
+    cy.mount(RangeComponent, { props: { id: '123' } })
+    cy.wait('@getHistory').its('request.url').should('include', 'range=30d')
+    cy.get('#change').click()
+    cy.wait('@getHistory').its('request.url').should('include', 'range=60d')
   })
 })

--- a/frontend/src/composables/useAccountHistory.js
+++ b/frontend/src/composables/useAccountHistory.js
@@ -5,19 +5,35 @@ import { ref, isRef, watch } from 'vue'
 import { fetchAccountHistory } from '@/api/accounts'
 
 /**
+ * Cache of previously fetched histories keyed by `${accountId}-${range}`.
+ * @type {Map<string, Array>}
+ */
+const historyCache = new Map()
+
+/**
  * Reactive helper to load recent balance history for an account.
  * @param {import('vue').Ref<string> | string} accountId
+ * @param {import('vue').Ref<string> | string} rangeRef - reactive range string
  */
-export function useAccountHistory(accountId) {
+export function useAccountHistory(accountId, rangeRef) {
   const accountIdRef = isRef(accountId) ? accountId : ref(accountId)
+  const range = isRef(rangeRef) ? rangeRef : ref(rangeRef)
   const history = ref([])
   const loading = ref(false)
 
-  const fetchHistory = async () => {
+  const fetchHistory = async (start, end, { force = false } = {}) => {
     if (!accountIdRef.value) return
+    const rangeKey = start && end ? `${start}-${end}` : range.value
+    const cacheKey = `${accountIdRef.value}-${rangeKey || ''}`
+    if (!force && historyCache.has(cacheKey)) {
+      history.value = historyCache.get(cacheKey)
+      return
+    }
     loading.value = true
     try {
-      const response = await fetchAccountHistory(accountIdRef.value)
+      const options =
+        start && end ? { start_date: start, end_date: end } : { range: rangeKey }
+      const response = await fetchAccountHistory(accountIdRef.value, options)
       let hist = []
       if (Array.isArray(response?.data?.history)) {
         hist = response.data.history
@@ -27,6 +43,7 @@ export function useAccountHistory(accountId) {
         hist = response.data.data.history
       }
       history.value = hist
+      historyCache.set(cacheKey, hist)
     } catch (err) {
       console.error('Failed to load account history:', err)
     } finally {
@@ -34,11 +51,13 @@ export function useAccountHistory(accountId) {
     }
   }
 
-  watch(accountIdRef, fetchHistory, { immediate: true })
+  watch([accountIdRef, range], () => fetchHistory(), { immediate: true })
+
+  const loadHistory = (start, end) => fetchHistory(start, end, { force: true })
 
   return {
     history,
     loading,
-    fetchHistory,
+    loadHistory,
   }
 }

--- a/frontend/src/composables/useAccountHistory.js
+++ b/frontend/src/composables/useAccountHistory.js
@@ -31,8 +31,7 @@ export function useAccountHistory(accountId, rangeRef) {
     }
     loading.value = true
     try {
-      const options =
-        start && end ? { start_date: start, end_date: end } : { range: rangeKey }
+      const options = start && end ? { start_date: start, end_date: end } : { range: rangeKey }
       const response = await fetchAccountHistory(accountIdRef.value, options)
       let hist = []
       if (Array.isArray(response?.data?.history)) {


### PR DESCRIPTION
## Summary
- cache account history by account-range to avoid duplicate fetches
- allow manual history refresh via loadHistory(start,end)
- watch range changes and expose tests for memoization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run test:unit` *(fails: missing Xvfb)*
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c6508a9af8832984440d328efeed1a