### PR TITLE
feat(charts): animate account history chart

### DIFF
--- a/frontend/src/components/charts/AccountBalanceHistoryChart.vue
+++ b/frontend/src/components/charts/AccountBalanceHistoryChart.vue
@@ -1,35 +1,64 @@
 <template>
   <div class="account-balance-history-chart" style="height: 400px">
-    <canvas ref="chartCanvas" style="width: 100%; height: 100%"></canvas>
+    <Transition name="fade-slide" mode="out-in">
+      <canvas
+        v-if="hasData"
+        :key="transitionKey"
+        ref="chartCanvas"
+        style="width: 100%; height: 100%"
+      ></canvas>
+      <p
+        v-else
+        class="text-center text-sm"
+        style="color: var(--color-text-muted)"
+      >
+        No history available for this period
+      </p>
+    </Transition>
   </div>
 </template>
 
 <script setup>
 import { Chart } from 'chart.js/auto'
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
 import { formatAmount } from '@/utils/format'
 
-// Props: balances array with { date, balance }
+// AccountBalanceHistoryChart.vue
+// Displays a line chart of account balances over time. Accepts historyData and
+// selectedRange props and animates when data or range changes.
 const props = defineProps({
-  balances: {
+  historyData: {
     type: Array,
-    required: true,
+    default: () => [],
+  },
+  selectedRange: {
+    type: String,
+    default: '',
   },
 })
 
 const chartInstance = ref(null)
 const chartCanvas = ref(null)
+const transitionKey = ref(0)
 
-function renderChart() {
+const hasData = computed(() => (props.historyData || []).length > 0)
+
+/**
+ * Render the Chart.js instance using current historyData.
+ * Destroys any existing chart before creating a new one.
+ */
+async function renderChart() {
+  await nextTick()
+
   if (chartInstance.value) {
     chartInstance.value.destroy()
     chartInstance.value = null
   }
 
-  if (!props.balances || props.balances.length === 0) return
+  if (!hasData.value) return
 
-  const labels = props.balances.map((b) => b.date)
-  const values = props.balances.map((b) => b.balance)
+  const labels = props.historyData.map((b) => b.date)
+  const values = props.historyData.map((b) => b.balance)
 
   const ctx = chartCanvas.value.getContext('2d')
   chartInstance.value = new Chart(ctx, {
@@ -88,13 +117,32 @@ function renderChart() {
   })
 }
 
+function triggerRender() {
+  transitionKey.value++
+  renderChart()
+}
+
 onMounted(() => renderChart())
 onUnmounted(() => {
   if (chartInstance.value) chartInstance.value.destroy()
 })
-watch(() => props.balances, renderChart, { deep: true })
+watch(() => props.historyData, triggerRender, { deep: true })
+watch(() => props.selectedRange, triggerRender)
 
 function getStyle(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
 }
 </script>
+
+<style scoped>
+@reference "../../assets/css/main.css";
+.fade-slide-enter-active,
+.fade-slide-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.fade-slide-enter-from,
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(6px);
+}
+</style>

--- a/frontend/src/components/charts/__tests__/AccountBalanceHistoryChart.spec.js
+++ b/frontend/src/components/charts/__tests__/AccountBalanceHistoryChart.spec.js
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import AccountBalanceHistoryChart from '../AccountBalanceHistoryChart.vue'
+
+// Stub canvas context
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}))
+
+const destroyMock = vi.fn()
+vi.mock('chart.js/auto', () => {
+  const Chart = vi.fn().mockImplementation(() => ({ destroy: destroyMock }))
+  Chart.getChart = vi.fn().mockReturnValue(null)
+  return { Chart }
+})
+import { Chart as ChartConstructor } from 'chart.js/auto'
+
+describe('AccountBalanceHistoryChart.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows empty state when no history data', async () => {
+    const wrapper = shallowMount(AccountBalanceHistoryChart, {
+      props: { historyData: [], selectedRange: '30d' },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No history available for this period')
+    expect(ChartConstructor).not.toHaveBeenCalled()
+  })
+
+  it('re-renders chart when history data changes', async () => {
+    const wrapper = shallowMount(AccountBalanceHistoryChart, {
+      props: {
+        historyData: [{ date: '2024-01-01', balance: 10 }],
+        selectedRange: '30d',
+      },
+    })
+    await flushPromises()
+    expect(ChartConstructor).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ historyData: [{ date: '2024-02-01', balance: 20 }] })
+    await flushPromises()
+    expect(ChartConstructor).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-renders chart when selectedRange changes', async () => {
+    const wrapper = shallowMount(AccountBalanceHistoryChart, {
+      props: {
+        historyData: [{ date: '2024-01-01', balance: 10 }],
+        selectedRange: '30d',
+      },
+    })
+    await flushPromises()
+    expect(ChartConstructor).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ selectedRange: '60d' })
+    await flushPromises()
+    expect(ChartConstructor).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- accept `historyData` and `selectedRange` props in AccountBalanceHistoryChart
- show empty-state message and animate dataset transitions
- add unit tests for empty state and prop-driven re-renders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: existing suites fail with recursive update errors)*
- `npm test src/components/charts/__tests__/AccountBalanceHistoryChart.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6562be3808329871a48c9f3fc950d