### PR TITLE
test(frontend): add group navigation test

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -56,7 +56,7 @@
           </template>
         </Draggable>
         <TransitionGroup v-else name="fade-in" tag="div" class="bs-tab-list">
-          <template v-for="g in groups" :key="g.id">
+          <template v-for="g in visibleGroups" :key="g.id">
             <input
               v-if="!g.name || editingGroupId === g.id"
               v-model="g.name"

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -415,7 +415,6 @@ describe('TopAccountSnapshot', () => {
 
     const shiftedTabs = wrapper.findAll('button.bs-tab').map((b) => b.text())
     expect(shiftedTabs).toEqual(['G2', 'G3', 'G4'])
-
     ;[left, right] = wrapper.findAll('button.bs-nav-btn')
     expect(left.element.disabled).toBe(false)
     expect(right.element.disabled).toBe(true)
@@ -425,7 +424,6 @@ describe('TopAccountSnapshot', () => {
 
     const revertedTabs = wrapper.findAll('button.bs-tab').map((b) => b.text())
     expect(revertedTabs).toEqual(['G1', 'G2', 'G3'])
-
     ;[left, right] = wrapper.findAll('button.bs-nav-btn')
     expect(left.element.disabled).toBe(true)
     expect(right.element.disabled).toBe(false)

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -384,6 +384,53 @@ describe('TopAccountSnapshot', () => {
     expect(activeItem.find('svg').exists()).toBe(true)
   })
 
+  it('navigates group tabs with arrow buttons', async () => {
+    localStorage.setItem(
+      'accountGroups',
+      JSON.stringify({
+        groups: [
+          { id: 'g1', name: 'G1', accounts: [] },
+          { id: 'g2', name: 'G2', accounts: [] },
+          { id: 'g3', name: 'G3', accounts: [] },
+          { id: 'g4', name: 'G4', accounts: [] },
+        ],
+        activeGroupId: 'g1',
+      }),
+    )
+
+    const wrapper = mount(TopAccountSnapshot, {
+      global: { stubs: { AccountSparkline: true } },
+    })
+    await nextTick()
+
+    const initialTabs = wrapper.findAll('button.bs-tab').map((b) => b.text())
+    expect(initialTabs).toEqual(['G1', 'G2', 'G3'])
+
+    let [left, right] = wrapper.findAll('button.bs-nav-btn')
+    expect(left.element.disabled).toBe(true)
+    expect(right.element.disabled).toBe(false)
+
+    await right.trigger('click')
+    await nextTick()
+
+    const shiftedTabs = wrapper.findAll('button.bs-tab').map((b) => b.text())
+    expect(shiftedTabs).toEqual(['G2', 'G3', 'G4'])
+
+    ;[left, right] = wrapper.findAll('button.bs-nav-btn')
+    expect(left.element.disabled).toBe(false)
+    expect(right.element.disabled).toBe(true)
+
+    await left.trigger('click')
+    await nextTick()
+
+    const revertedTabs = wrapper.findAll('button.bs-tab').map((b) => b.text())
+    expect(revertedTabs).toEqual(['G1', 'G2', 'G3'])
+
+    ;[left, right] = wrapper.findAll('button.bs-nav-btn')
+    expect(left.element.disabled).toBe(true)
+    expect(right.element.disabled).toBe(false)
+  })
+
   it('keeps focus on account row when toggling details via keyboard', async () => {
     localStorage.setItem(
       'accountGroups',


### PR DESCRIPTION
## Summary
- ensure TopAccountSnapshot only renders three group tabs at a time
- test arrow navigation between account groups

## Testing
- `npx vitest run src/components/widgets/__tests__/TopAccountSnapshot.spec.js -t "navigates group tabs with arrow buttons"`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem' from 'app.models'; ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68c672b4c7148329bb32ece14e88c5c4