### PR TITLE
fix(frontend): enforce group name truncation

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -294,6 +294,7 @@ function toggleDetails(accountId) {
 
 const showGroupMenu = ref(false)
 const editingGroupId = ref(null)
+// Maximum allowed characters for group names, including ellipsis when truncated.
 const MAX_GROUP_NAME_LENGTH = 30
 const isEditingGroups = ref(props.isEditingGroups)
 watch(
@@ -405,7 +406,7 @@ function startEdit(id) {
 
 /**
  * Disable editing and persist the group name.
- * Truncates names longer than MAX_GROUP_NAME_LENGTH characters and appends an ellipsis.
+ * Truncates names longer than MAX_GROUP_NAME_LENGTH characters (including ellipsis).
  */
 function finishEdit(group) {
   editingGroupId.value = null
@@ -414,7 +415,7 @@ function finishEdit(group) {
     return
   }
   if (group.name.length > MAX_GROUP_NAME_LENGTH) {
-    group.name = `${group.name.slice(0, MAX_GROUP_NAME_LENGTH)}…`
+    group.name = `${group.name.slice(0, MAX_GROUP_NAME_LENGTH - 1)}…`
   }
 }
 

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -107,11 +107,33 @@ describe('TopAccountSnapshot', () => {
     await nextTick()
     const input = wrapper.find('input.bs-tab')
     expect(input.exists()).toBe(true)
+    expect(input.attributes('maxlength')).toBe('30')
     await input.setValue('My Group')
     await input.trigger('blur')
     await nextTick()
     const updated = wrapper.findAll('button.bs-tab').map((b) => b.text())
     expect(updated).toContain('My Group')
+  })
+
+  it('truncates group names longer than 30 characters with ellipsis', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: { stubs: { AccountSparkline: true } },
+    })
+    await nextTick()
+
+    wrapper.vm.addGroup()
+    await nextTick()
+
+    const input = wrapper.find('input.bs-tab')
+    const longName = 'a'.repeat(40)
+    await input.setValue(longName)
+    await input.trigger('blur')
+    await nextTick()
+
+    const names = wrapper.findAll('button.bs-tab').map((b) => b.text())
+    const truncated = 'a'.repeat(29) + '…'
+    expect(names).toContain(truncated)
+    expect(truncated.length).toBe(30)
   })
 
   it('updates group order when accounts are reordered', async () => {


### PR DESCRIPTION
## Summary
- limit group name inputs to 30 characters and ensure edited names are truncated with ellipsis
- test group name truncation behavior

## Testing
- `npm test` *(fails: Maximum recursive updates exceeded in TopAccountSnapshot spec)*
- `pytest -q` *(fails: 20 errors during collection)*
- `pre-commit run --all-files` *(fails: ruff undefined name `_tz`; mypy duplicate module)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abea01c883298ee243cce809b9ac