### PR TITLE
fix(accounts): rename balance chart prop

### DIFF
--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -72,7 +72,7 @@
             />
             <AccountBalanceHistoryChart
               v-else
-              :balances="accountHistory"
+              :history-data="accountHistory"
               :selected-range="selectedRange"
               data-testid="history-chart"
             />


### PR DESCRIPTION
## Summary
- pass historyData prop to AccountBalanceHistoryChart

## Testing
- `pre-commit run --files frontend/src/views/Accounts.vue frontend/src/components/charts/AccountBalanceHistoryChart.vue frontend/src/components/charts/__tests__/AccountBalanceHistoryChart.spec.js`
- `npx vitest run src/components/charts/__tests__/AccountBalanceHistoryChart.spec.js`
- `pytest -q` *(fails: cannot import name 'PlaidItem' from 'app.models')*
- `npm test` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b11cae08832997972af6d4cb2c31