### PR TITLE
fix(frontend): retain focus on account toggle

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -131,14 +131,15 @@
     >
       <template #item="{ element: account }">
         <li class="bs-account-container" :key="account.id">
+          <!-- Enter and space should toggle details without moving focus -->
           <div
             class="bs-row"
             :style="{ '--accent': accentColor(account) }"
-            @click="toggleDetails(account.id)"
+            @click="toggleDetails(account.id, $event)"
             role="button"
             tabindex="0"
-            @keydown.enter.prevent="toggleDetails(account.id)"
-            @keydown.space.prevent="toggleDetails(account.id)"
+            @keydown.enter.prevent="toggleDetails(account.id, $event)"
+            @keydown.space.prevent="toggleDetails(account.id, $event)"
           >
             <GripVertical class="bs-drag-handle" @mousedown.stop @touchstart.stop />
 
@@ -271,8 +272,10 @@ const openAccountId = ref(null)
 const recentTxs = reactive({})
 
 /** Toggle details dropdown for an account and load recent transactions */
-function toggleDetails(accountId) {
+function toggleDetails(accountId, event) {
   openAccountId.value = openAccountId.value === accountId ? null : accountId
+  // Ensure the originating row retains focus for accessibility
+  event?.currentTarget?.focus()
   if (openAccountId.value === accountId && !recentTxs[accountId]) {
     fetchRecentTransactions(accountId, 3)
       .then((res) => {

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -466,18 +466,19 @@ describe('TopAccountSnapshot', () => {
 
     await nextTick()
 
-    let row = wrapper.find('.bs-account-container .bs-row')
+    const row = wrapper.find('.bs-account-container .bs-row')
+    const focusSpy = vi.spyOn(row.element, 'focus')
     row.element.focus()
+    expect(focusSpy).toHaveBeenCalledTimes(1)
 
     await row.trigger('keydown.enter')
     await nextTick()
-    row = wrapper.find('.bs-account-container .bs-row')
     expect(row.find('.bs-toggle-icon').classes()).toContain('bs-expanded')
+    expect(focusSpy).toHaveBeenCalledTimes(2)
 
     await row.trigger('keydown.space')
     await nextTick()
-    row = wrapper.find('.bs-account-container .bs-row')
     expect(row.find('.bs-toggle-icon').classes()).not.toContain('bs-expanded')
-    // TODO: jsdom does not preserve focus reliably; manual verification ensures focus remains on the row.
+    expect(focusSpy).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Summary
- keep account row focus when toggling details via keyboard
- test that toggleDetails re-focuses the row after Enter or Space keypress

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem')*
- `npm test -- -t "keeps focus on account row when toggling details via keyboard"` *(fails: AggregateError in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b1293dcc832990b5ccdac00b6c63