### PR TITLE
feat(frontend): add exchange rate validation

### DIFF
--- a/frontend/src/utils/currency.ts
+++ b/frontend/src/utils/currency.ts
@@ -8,6 +8,12 @@
  */
 
 /**
+ * Mapping of ISO 4217 currency codes to their exchange rates relative to a
+ * common base currency.
+ */
+export type ExchangeRates = Record<string, number>
+
+/**
  * Format a numeric value as a localized currency string.
  *
  * @param value - The numeric amount to format.
@@ -25,14 +31,21 @@ export function formatCurrency(value: number, currency = 'USD', locale = 'en-US'
  * @param amount - The numeric amount to convert.
  * @param from - ISO 4217 code representing the source currency.
  * @param to - ISO 4217 code representing the target currency.
- * @param rateTable - Mapping of currency codes to their relative rates.
+ * @param rateTable - Exchange-rate table used for the conversion.
  * @returns The converted amount in the target currency.
+ * @throws {Error} If either currency code is missing from {@link rateTable}.
  */
 export function convertCurrency(
   amount: number,
   from: string,
   to: string,
-  rateTable: Record<string, number>,
+  rateTable: ExchangeRates,
 ): number {
-  return (amount / rateTable[from]) * rateTable[to]
+  const fromRate = rateTable[from]
+  const toRate = rateTable[to]
+  if (fromRate == null || toRate == null) {
+    throw new Error(`Missing exchange rate for "${from}" or "${to}"`)
+  }
+
+  return (amount / fromRate) * toRate
 }


### PR DESCRIPTION
## Summary
- enhance currency utilities with typed exchange-rate table and validation

## Testing
- `pre-commit run --files frontend/src/utils/currency.ts`
- `pytest -q` *(fails: cannot import name 'PlaidItem' from 'app.models')*


------
https://chatgpt.com/codex/tasks/task_e_68c6b13151e48329815f19246fa0cb5b