### PR TITLE
feat(frontend): add typed planning service

### DIFF
--- a/frontend/src/services/planningService.ts
+++ b/frontend/src/services/planningService.ts
@@ -13,6 +13,8 @@ const apiClient = axios.create({
 
 /**
  * Retrieve all bills.
+ *
+ * @returns A list of all bills.
  */
 export async function fetchBills(): Promise<Bill[]> {
   const response = await apiClient.get<Bill[]>('/planning/bills')
@@ -23,6 +25,7 @@ export async function fetchBills(): Promise<Bill[]> {
  * Fetch a single bill by identifier.
  *
  * @param id - Bill identifier
+ * @returns The bill matching the provided identifier.
  */
 export async function fetchBill(id: string): Promise<Bill> {
   const response = await apiClient.get<Bill>(`/planning/bills/${id}`)
@@ -33,6 +36,7 @@ export async function fetchBill(id: string): Promise<Bill> {
  * Create a new bill.
  *
  * @param bill - Bill data to create (without id)
+ * @returns The newly created bill.
  */
 export async function createBill(bill: Omit<Bill, 'id'>): Promise<Bill> {
   const response = await apiClient.post<Bill>('/planning/bills', bill)
@@ -44,6 +48,7 @@ export async function createBill(bill: Omit<Bill, 'id'>): Promise<Bill> {
  *
  * @param id - Bill identifier
  * @param bill - Partial bill data to update
+ * @returns The updated bill.
  */
 export async function updateBill(id: string, bill: Partial<Omit<Bill, 'id'>>): Promise<Bill> {
   const response = await apiClient.put<Bill>(`/planning/bills/${id}`, bill)
@@ -54,6 +59,7 @@ export async function updateBill(id: string, bill: Partial<Omit<Bill, 'id'>>): P
  * Delete a bill.
  *
  * @param id - Bill identifier
+ * @returns A void promise once the bill is deleted.
  */
 export async function deleteBill(id: string): Promise<void> {
   await apiClient.delete(`/planning/bills/${id}`)
@@ -63,6 +69,7 @@ export async function deleteBill(id: string): Promise<void> {
  * Retrieve allocations for a scenario.
  *
  * @param scenarioId - Scenario identifier
+ * @returns A list of allocations for the scenario.
  */
 export async function fetchAllocations(scenarioId: string): Promise<Allocation[]> {
   const response = await apiClient.get<Allocation[]>(
@@ -76,6 +83,7 @@ export async function fetchAllocations(scenarioId: string): Promise<Allocation[]
  *
  * @param scenarioId - Scenario identifier
  * @param allocation - Allocation data (without id)
+ * @returns The newly created allocation.
  */
 export async function createAllocation(
   scenarioId: string,
@@ -94,6 +102,7 @@ export async function createAllocation(
  * @param scenarioId - Scenario identifier
  * @param allocationId - Allocation identifier
  * @param allocation - Partial allocation data to update
+ * @returns The updated allocation.
  */
 export async function updateAllocation(
   scenarioId: string,
@@ -112,6 +121,7 @@ export async function updateAllocation(
  *
  * @param scenarioId - Scenario identifier
  * @param allocationId - Allocation identifier
+ * @returns A void promise once the allocation is deleted.
  */
 export async function deleteAllocation(scenarioId: string, allocationId: string): Promise<void> {
   await apiClient.delete(`/planning/scenarios/${scenarioId}/allocations/${allocationId}`)


### PR DESCRIPTION
## Summary
- add Axios-based planning service with CRUD methods for bills and scenario allocations
- document methods with detailed JSDoc annotations

## Testing
- `pre-commit run --files frontend/src/services/planningService.ts`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem' from 'app.models')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b132c9fc8329a5b3317362d68101