### PR TITLE
test(planning): add Cypress tests for planning selectors

### DIFF
--- a/frontend/src/views/__tests__/Planning.cy.js
+++ b/frontend/src/views/__tests__/Planning.cy.js
@@ -38,9 +38,7 @@ describe('planning selectors', () => {
     expect(selectTotalBillsCents(state)).to.eq(50000)
 
     // edit
-    state.bills = state.bills.map((b) =>
-      b.id === bill.id ? { ...b, amountCents: 60000 } : b
-    )
+    state.bills = state.bills.map((b) => (b.id === bill.id ? { ...b, amountCents: 60000 } : b))
     expect(selectTotalBillsCents(state)).to.eq(60000)
 
     // delete
@@ -93,9 +91,7 @@ describe('planning selectors', () => {
         id: 's1',
         name: 'Base',
         planningBalanceCents: 100000,
-        allocations: [
-          { id: 'a1', target: 'savings:emergency', kind: 'fixed', value: 20000 },
-        ],
+        allocations: [{ id: 'a1', target: 'savings:emergency', kind: 'fixed', value: 20000 }],
         accountId: '',
       },
     ]

--- a/frontend/src/views/__tests__/Planning.cy.js
+++ b/frontend/src/views/__tests__/Planning.cy.js
@@ -1,16 +1,14 @@
-// Planning.cy.js
-// Cypress tests for planning state operations: bill add/edit/delete,
-// allocation totals, and summary calculations.
-
+/**
+ * Cypress tests for planning state operations: bill add/edit/delete,
+ * allocation total calculations, and summary summaries.
+ */
 import {
   selectAllocatedCents,
   selectRemainingCents,
   selectTotalBillsCents,
 } from '@/selectors/planning'
 
-/**
- * Generate a baseline planning state object.
- */
+// Generate a baseline planning state
 function makeState() {
   return {
     version: 1,
@@ -23,8 +21,8 @@ function makeState() {
   }
 }
 
-describe('planning helpers', () => {
-  it('adds, edits, and deletes bills', () => {
+describe('planning selectors', () => {
+  it('handles bill add, edit, and delete', () => {
     const state = makeState()
     const bill = {
       id: 'b1',
@@ -40,7 +38,9 @@ describe('planning helpers', () => {
     expect(selectTotalBillsCents(state)).to.eq(50000)
 
     // edit
-    state.bills = state.bills.map((b) => (b.id === bill.id ? { ...b, amountCents: 60000 } : b))
+    state.bills = state.bills.map((b) =>
+      b.id === bill.id ? { ...b, amountCents: 60000 } : b
+    )
     expect(selectTotalBillsCents(state)).to.eq(60000)
 
     // delete
@@ -48,7 +48,7 @@ describe('planning helpers', () => {
     expect(selectTotalBillsCents(state)).to.eq(0)
   })
 
-  it('calculates allocation totals', () => {
+  it('computes allocation totals and remaining cents', () => {
     const scenario = {
       id: 's1',
       name: 'Base',
@@ -67,7 +67,7 @@ describe('planning helpers', () => {
     expect(remaining).to.eq(100000 - allocated)
   })
 
-  it('computes summary values', () => {
+  it('summarizes totals from state and scenario', () => {
     const state = makeState()
     state.bills = [
       {
@@ -94,21 +94,17 @@ describe('planning helpers', () => {
         name: 'Base',
         planningBalanceCents: 100000,
         allocations: [
-          {
-            id: 'a1',
-            target: 'savings:emergency',
-            kind: 'fixed',
-            value: 20000,
-          },
+          { id: 'a1', target: 'savings:emergency', kind: 'fixed', value: 20000 },
         ],
         accountId: '',
       },
     ]
 
     state.activeScenarioId = 's1'
+    const scenario = state.scenarios[0]
 
     expect(selectTotalBillsCents(state)).to.eq(60000)
-    const remaining = selectRemainingCents(state.scenarios[0])
-    expect(remaining).to.eq(80000)
+    expect(selectAllocatedCents(scenario)).to.eq(20000)
+    expect(selectRemainingCents(scenario)).to.eq(80000)
   })
 })


### PR DESCRIPTION
## Summary
- add Cypress tests for bill CRUD, allocation totals, and summary calculations in planning selectors

## Testing
- `npm run test:e2e` *(fails: Timed out waiting for: http://localhost:4173)*
- `npm run build` *(fails: "loadPlanning" is not exported by src/services/planningService.ts)*
- `pre-commit run --files frontend/src/views/__tests__/Planning.cy.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6b993b7408329a4903b4f744e0de5