### PR TITLE
feat(account-history): memoize account history with manual refresh

### DIFF
--- a/frontend/src/composables/__tests__/useAccountHistory.cy.js
+++ b/frontend/src/composables/__tests__/useAccountHistory.cy.js
@@ -78,6 +78,7 @@ describe('useAccountHistory', () => {
         expect(params.get('start_date')).to.eq(start)
         expect(params.get('end_date')).to.eq(end)
       })
+    cy.get('@getHistory.all').should('have.length', 2)
   })
 
   it('supports manual refresh with explicit dates', () => {

--- a/frontend/src/composables/useAccountHistory.js
+++ b/frontend/src/composables/useAccountHistory.js
@@ -3,7 +3,7 @@
  * Results are memoized per account and range and can be refreshed manually.
  */
 import { ref, isRef, watch } from 'vue'
-import { fetchAccountHistory } from '@/api/accounts'
+import { fetchAccountHistory, rangeToDates } from '@/api/accounts'
 
 /**
  * Cache of previously fetched histories keyed by `${accountId}-${range}`.
@@ -30,7 +30,7 @@ export function useAccountHistory(accountId, rangeRef) {
     let e = end
     let rangeKey
     if (!s || !e) {
-      rangeKey = typeof start === 'string' && !end ? start : range.value
+      rangeKey = typeof start === 'string' && !end ? start : rangeRef.value
       ;({ start: s, end: e } = rangeToDates(rangeKey))
     } else {
       rangeKey = `${s}-${e}`


### PR DESCRIPTION
## Summary
- cache account histories by account and range
- expose loadHistory for manual refresh
- test memoization and range updates

## Testing
- `pre-commit run --all-files`
- `npm run test:unit` *(fails: libasound.so.2: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e2a9508c83298a4d6ccc86e42037