### PR TITLE
feat(planning): add in-memory planning service

### DIFF
--- a/backend/app/services/planning_service.py
+++ b/backend/app/services/planning_service.py
@@ -1,20 +1,101 @@
-# backend/app/services/planning_service.py
-from app.models import PlanningScenario, db
-from sqlalchemy.orm import joinedload
+"""In-memory CRUD service for planning bills and allocations.
+
+This module stores bills and allocation records in simple Python lists.
+It provides basic create, read, update, and delete operations used by
+planning-related API endpoints. Allocation percentages are validated to
+ensure the total does not exceed 100 percent.
+"""
+
+from typing import Any, Dict, List
+
+Bill = Dict[str, Any]
+Allocation = Dict[str, Any]
+
+BILLS: List[Bill] = []
+ALLOCATIONS: List[Allocation] = []
 
 
-def get_scenario(scenario_id):
-    return (
-        db.session.query(PlanningScenario)
-        .options(
-            joinedload(PlanningScenario.bills), joinedload(PlanningScenario.allocations)
-        )
-        .filter(PlanningScenario.id == scenario_id)
-        .first()
-    )
+def get_bills() -> List[Bill]:
+    """Return all stored bills."""
+    return list(BILLS)
 
 
-def validate_percent_cap(scenario: PlanningScenario) -> None:
-    pct = sum(a.value for a in scenario.allocations if a.kind == "percent")
-    if pct > 100:
-        raise ValueError("Percent allocations exceed 100%")
+def create_bill(bill: Bill) -> Bill:
+    """Add a new bill to the in-memory store.
+
+    Args:
+        bill: Mapping describing the bill fields.
+
+    Returns:
+        The bill that was added.
+    """
+
+    BILLS.append(bill)
+    return bill
+
+
+def update_bill(bill_id: str, bill: Bill) -> Bill:
+    """Update an existing bill.
+
+    Args:
+        bill_id: Identifier of the bill to update.
+        bill: Mapping of updated fields for the bill.
+
+    Returns:
+        The updated bill.
+
+    Raises:
+        ValueError: If the bill ID does not exist.
+    """
+
+    for idx, existing in enumerate(BILLS):
+        if existing.get("id") == bill_id:
+            updated = {**existing, **bill, "id": bill_id}
+            BILLS[idx] = updated
+            return updated
+    raise ValueError(f"Bill {bill_id} not found")
+
+
+def delete_bill(bill_id: str) -> None:
+    """Remove a bill from the store.
+
+    Args:
+        bill_id: Identifier of the bill to remove.
+
+    Raises:
+        ValueError: If the bill ID does not exist.
+    """
+
+    for idx, existing in enumerate(BILLS):
+        if existing.get("id") == bill_id:
+            BILLS.pop(idx)
+            return
+    raise ValueError(f"Bill {bill_id} not found")
+
+
+def get_allocations() -> List[Allocation]:
+    """Return all allocation entries."""
+    return list(ALLOCATIONS)
+
+
+def update_allocations(allocations: List[Allocation]) -> List[Allocation]:
+    """Replace allocation entries, enforcing a 100% cap.
+
+    Args:
+        allocations: Sequence of allocation mappings. Each mapping may
+            include a ``percentage`` key indicating its percent share.
+
+    Returns:
+        The updated list of allocations.
+
+    Raises:
+        ValueError: If the total percentage exceeds 100.
+    """
+
+    total_pct = sum(a.get("percentage", 0) for a in allocations)
+    if total_pct > 100:
+        raise ValueError("Allocation percentages exceed 100%")
+
+    ALLOCATIONS.clear()
+    ALLOCATIONS.extend(allocations)
+    return list(ALLOCATIONS)


### PR DESCRIPTION
## Summary
- add in-memory planning service with CRUD utilities
- enforce 100% cap on percentage allocations

## Testing
- `pre-commit run --files backend/app/services/planning_service.py` (fails: mypy errors in unrelated modules)
- `pytest tests/test_api_planning.py -q` (fails: file or directory not found)


------
https://chatgpt.com/codex/tasks/task_e_68c70cb604888329818b13ad6e8c05b3