### PR TITLE
fix(snapshot): enable account selection in empty groups

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -122,7 +122,7 @@
 
     <!-- Render draggable without container Transition to avoid DOM detachment issues -->
     <Draggable
-      v-if="accounts && accounts.length"
+      v-if="activeGroup"
       v-model="accounts"
       item-key="id"
       handle=".bs-drag-handle"
@@ -398,7 +398,8 @@ function selectGroup(id) {
 
 const emit = defineEmits(['update:isEditingGroups'])
 function toggleEditGroups() {
-  emit('update:isEditingGroups', !isEditingGroups.value)
+  isEditingGroups.value = !isEditingGroups.value
+  emit('update:isEditingGroups', isEditingGroups.value)
   showGroupMenu.value = false
 }
 

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -115,6 +115,24 @@ describe('TopAccountSnapshot', () => {
     expect(updated).toContain('My Group')
   })
 
+  it('displays add account placeholder when group has no accounts', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: { stubs: { AccountSparkline: true } },
+    })
+    await nextTick()
+    expect(wrapper.find('.bs-add-placeholder').exists()).toBe(true)
+  })
+
+  it('toggles editing mode locally when toggleEditGroups is called', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      global: { stubs: { AccountSparkline: true } },
+    })
+    expect(wrapper.vm.isEditingGroups.value).toBe(false)
+    wrapper.vm.toggleEditGroups()
+    await nextTick()
+    expect(wrapper.vm.isEditingGroups.value).toBe(true)
+  })
+
   it('truncates group names longer than 30 characters with ellipsis', async () => {
     const wrapper = mount(TopAccountSnapshot, {
       global: { stubs: { AccountSparkline: true } },


### PR DESCRIPTION
## Summary
- allow adding accounts when a group has no accounts
- let group edit mode toggle internally
- test account placeholder and edit toggle behavior

## Testing
- `pre-commit run --files frontend/src/components/widgets/TopAccountSnapshot.vue frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem'...)*
- `npm test` *(fails: Maximum recursive updates exceeded in component <TopAccountSnapshot> and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c8bec86c832986ae002b14fe94a5