### PR TITLE
feat(webhooks): proxy Plaid webhook via Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Webhook URL should point to `/api/webhooks/plaid`.
 
 Pointing Plaid Webhooks
 
-- New items (during Link): set `BACKEND_PUBLIC_URL` in `backend/.env` to your public backend URL (e.g., `https://your-domain.example` or your tunnel URL). Link tokens will include `webhook = <BACKEND_PUBLIC_URL>/api/webhooks/plaid` automatically.
+- New items (during Link): set `BACKEND_PUBLIC_URL` in `backend/.env` to your public backend URL. When using a Cloudflare Worker to proxy Plaid webhooks, set this to the worker's domain (e.g., `https://your-worker.example`). Link tokens will include `webhook = <BACKEND_PUBLIC_URL>/api/webhooks/plaid` automatically.
+- After updating `BACKEND_PUBLIC_URL`, regenerate link tokens so Plaid registers the new webhook URL.
 - Existing items: call the admin endpoint to update the webhook URL:
   ```bash
   curl -X POST \

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,7 @@ PRODUCTS=transactions
 TELLER_APP_ID=
 TELLER_WEBHOOK_SECRET=
 # Public URL of your backend (used when creating Plaid Link tokens to register webhooks)
-# Example: https://your-domain.example or https://abcd1234.ngrok.app
+# Example: Cloudflare worker domain (https://your-worker.example) or https://abcd1234.ngrok.app
 BACKEND_PUBLIC_URL=
 
 VARIABLE_ENV_TOKEN=

--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,9 @@ services:
     startCommand: gunicorn "backend.run:app" --bind 0.0.0.0:$PORT
     plan: free
     autoDeploy: true
+    envVars:
+      - key: BACKEND_PUBLIC_URL
+        value: https://your-worker.example
     buildFilter:
       paths:
         - backend/**

--- a/workers/plaid_webhook_worker.js
+++ b/workers/plaid_webhook_worker.js
@@ -1,0 +1,30 @@
+/**
+ * Cloudflare Worker that forwards Plaid webhook requests to the backend.
+ *
+ * Set the `BACKEND_URL` environment variable to your backend's public URL
+ * (e.g., your Render deployment). Deploy this worker on the route
+ * `/api/webhooks/plaid` so Plaid's webhook traffic hits Cloudflare first
+ * and is then relayed to your backend.
+ */
+export default {
+  async fetch(request, env) {
+    const backendBase = env.BACKEND_URL;
+    if (!backendBase) {
+      return new Response("BACKEND_URL not configured", { status: 500 });
+    }
+
+    const target = `${backendBase.replace(/\/$/, "")}/api/webhooks/plaid`;
+    const init = {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+    };
+
+    try {
+      const resp = await fetch(target, init);
+      return resp;
+    } catch (err) {
+      return new Response("Error forwarding webhook", { status: 502 });
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add Cloudflare Worker to forward Plaid webhooks to backend
- document Cloudflare domain for `BACKEND_PUBLIC_URL`
- wire `BACKEND_PUBLIC_URL` into Render config

## Testing
- `pre-commit run --files README.md backend/.env.example workers/plaid_webhook_worker.js render.yaml`
- `pytest -q` *(fails: ImportError: cannot import name 'PlaidItem')*


------
https://chatgpt.com/codex/tasks/task_e_68c7cf70cf988329b02fa716fc41a739