### PR TITLE
feat(arbit): capture threshold and fee before start

### DIFF
--- a/frontend/src/components/ArbitControls.vue
+++ b/frontend/src/components/ArbitControls.vue
@@ -1,10 +1,46 @@
 <template>
   <div>
+    <div class="start-config">
+      <div class="field">
+        <label for="start-threshold">Minimum Spread (%)</label>
+        <input
+          id="start-threshold"
+          data-test="start-threshold"
+          v-model.number="startThreshold"
+          type="number"
+          min="0"
+          step="0.01"
+          placeholder="Minimum spread required"
+        />
+        <p class="help-text">Trades trigger once market spread exceeds this percentage.</p>
+        <p v-if="startErrors.threshold" class="error">{{ startErrors.threshold }}</p>
+      </div>
+      <div class="field">
+        <label for="start-fee">Exchange Fee (%)</label>
+        <input
+          id="start-fee"
+          data-test="start-fee"
+          v-model.number="startFee"
+          type="number"
+          min="0"
+          step="0.01"
+          placeholder="Combined taker fees"
+        />
+        <p class="help-text">Include maker/taker and withdrawal fees expected per trade.</p>
+        <p v-if="startErrors.fee" class="error">{{ startErrors.fee }}</p>
+      </div>
+    </div>
     <button class="start-btn" @click="start">Start</button>
     <button class="stop-btn" @click="stop">Stop</button>
     <div>Status: {{ status.running ? 'running' : 'stopped' }}</div>
     <div class="alert-config">
-      <input v-model.number="threshold" type="number" placeholder="Alert threshold" />
+      <input
+        v-model.number="alertThreshold"
+        type="number"
+        min="0"
+        step="0.01"
+        placeholder="Alert threshold"
+      />
       <button class="alert-btn" @click="checkAlert">Check Profit</button>
     </div>
   </div>
@@ -12,20 +48,27 @@
 
 <script setup>
 /**
- * Control panel to start and stop the arbitrage engine.
+ * Control panel to configure spread/fee requirements and control the arbitrage engine.
  */
 import { ref, onMounted } from 'vue'
 import { startArbit, stopArbit, fetchArbitStatus, postArbitAlert } from '@/services/arbit'
 
 const status = ref({ running: false })
-const threshold = ref(0)
+const startThreshold = ref(null)
+const startFee = ref(null)
+const startErrors = ref({})
+const alertThreshold = ref(0)
 
 async function refresh() {
   status.value = await fetchArbitStatus()
 }
 
 async function start() {
-  await startArbit()
+  const { valid, threshold, fee } = validateStartConfig()
+  if (!valid) {
+    return
+  }
+  await startArbit(threshold, fee)
   await refresh()
 }
 
@@ -35,7 +78,36 @@ async function stop() {
 }
 
 async function checkAlert() {
-  await postArbitAlert(threshold.value)
+  await postArbitAlert(alertThreshold.value)
+}
+
+function validateStartConfig() {
+  const errors = {}
+  const thresholdNumber = Number(startThreshold.value)
+  const feeNumber = Number(startFee.value)
+
+  if (
+    startThreshold.value === null ||
+    startThreshold.value === '' ||
+    Number.isNaN(thresholdNumber)
+  ) {
+    errors.threshold = 'Enter the minimum spread percentage required to start trading.'
+  } else if (thresholdNumber <= 0) {
+    errors.threshold = 'Spread threshold must be greater than 0%.'
+  }
+
+  if (startFee.value === null || startFee.value === '' || Number.isNaN(feeNumber)) {
+    errors.fee = 'Provide the expected percentage cost of executing the trade.'
+  } else if (feeNumber < 0) {
+    errors.fee = 'Exchange fees cannot be negative.'
+  }
+
+  startErrors.value = errors
+  return {
+    valid: Object.keys(errors).length === 0,
+    threshold: thresholdNumber,
+    fee: feeNumber,
+  }
 }
 
 onMounted(refresh)

--- a/frontend/src/components/__tests__/ArbitControls.spec.ts
+++ b/frontend/src/components/__tests__/ArbitControls.spec.ts
@@ -1,23 +1,49 @@
 // @vitest-environment jsdom
 import { mount, flushPromises } from '@vue/test-utils'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/services/arbit', () => ({
   startArbit: vi.fn().mockResolvedValue({}),
   stopArbit: vi.fn().mockResolvedValue({}),
   fetchArbitStatus: vi.fn().mockResolvedValue({ running: false }),
+  postArbitAlert: vi.fn().mockResolvedValue({}),
 }))
 
 import { startArbit, stopArbit } from '@/services/arbit'
 import ArbitControls from '../ArbitControls.vue'
 
 describe('ArbitControls.vue', () => {
-  it('calls start and stop services', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('requires spread and fee before starting the engine', async () => {
     const wrapper = mount(ArbitControls)
     await flushPromises()
+
     await wrapper.find('button.start-btn').trigger('click')
+    await flushPromises()
+
+    expect(startArbit).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Enter the minimum spread percentage required to start trading.')
+    expect(wrapper.text()).toContain('Provide the expected percentage cost of executing the trade.')
+  })
+
+  it('calls start and stop services with configured inputs', async () => {
+    const wrapper = mount(ArbitControls)
+    await flushPromises()
+
+    await wrapper.find('[data-test="start-threshold"]').setValue('0.5')
+    await wrapper.find('[data-test="start-fee"]').setValue('0.15')
+
+    await wrapper.find('button.start-btn').trigger('click')
+    await flushPromises()
+
+    expect(startArbit).toHaveBeenCalledWith(0.5, 0.15)
+
     await wrapper.find('button.stop-btn').trigger('click')
-    expect(startArbit).toHaveBeenCalled()
+    await flushPromises()
+
     expect(stopArbit).toHaveBeenCalled()
   })
 })

--- a/frontend/src/services/arbit.ts
+++ b/frontend/src/services/arbit.ts
@@ -41,10 +41,13 @@ export async function fetchArbitTrades() {
 }
 
 /**
- * Start the arbitrage engine.
+ * Start the arbitrage engine with configured spread and fee thresholds.
+ *
+ * @param threshold Minimum spread percentage required to execute trades.
+ * @param fee Estimated combined exchange fee percentage.
  */
-export async function startArbit() {
-  const response = await apiClient.post('/arbit/start')
+export async function startArbit(threshold: number, fee: number) {
+  const response = await apiClient.post('/arbit/start', { threshold, fee })
   return response.data
 }
 


### PR DESCRIPTION
## Summary
- extend the arbitrage service to send threshold and fee values when starting the engine
- add UI controls, validation, and inline guidance for configuring spread and fee requirements
- refresh the ArbitControls unit spec to assert the service contract and client-side validation

## Testing
- npm run lint *(fails: Cannot find module '@vue/eslint-config-prettier/skip-formatting')*
- npm run test -- --run src/components/__tests__/ArbitControls.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68ca52e90f688329bd2c7bcb971ed38f