### PR TITLE
feat: expand Arbit dashboard layout

### DIFF
--- a/frontend/src/views/ArbitDashboard.vue
+++ b/frontend/src/views/ArbitDashboard.vue
@@ -1,13 +1,74 @@
 <template>
-  <div class="container py-4">
-    <h1>Arbit Dashboard</h1>
-    <ArbitAlerts />
-  </div>
+  <BasePageLayout class="arbit-dashboard" gap="gap-10">
+    <PageHeader :icon="Activity">
+      <template #title>Arbitrage Command Center</template>
+      <template #subtitle>Monitor engine status, opportunities, and trades</template>
+    </PageHeader>
+
+    <section data-testid="status-controls" class="grid grid-cols-1 gap-6 xl:grid-cols-3">
+      <Card class="h-full p-6 space-y-4">
+        <h2 class="section-title">Engine Status</h2>
+        <ArbitStatus />
+      </Card>
+      <Card class="h-full p-6 space-y-4 xl:col-span-2">
+        <h2 class="section-title">Control Panel</h2>
+        <ArbitControls />
+      </Card>
+    </section>
+
+    <section data-testid="metrics-alerts" class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <Card class="h-full p-6 space-y-4 lg:col-span-2">
+        <h2 class="section-title">Performance Metrics</h2>
+        <ArbitMetrics />
+      </Card>
+      <Card class="h-full p-6 space-y-4">
+        <h2 class="section-title">Live Alerts</h2>
+        <ArbitAlerts />
+      </Card>
+    </section>
+
+    <section data-testid="opportunities-trades" class="grid grid-cols-1 gap-6 xl:grid-cols-3">
+      <Card class="h-full p-6 space-y-4">
+        <h2 class="section-title">Current Opportunities</h2>
+        <ArbitOpportunities />
+      </Card>
+      <Card class="h-full p-6 space-y-4 xl:col-span-2 overflow-x-auto">
+        <h2 class="section-title">Recent Trades</h2>
+        <ArbitTrades />
+      </Card>
+    </section>
+  </BasePageLayout>
 </template>
 
 <script setup>
 /**
- * Displays metrics for the optional Arbit dashboard.
+ * High-level arbitrage dashboard combining status, controls, metrics, alerts,
+ * opportunities, and trades into a single operational view.
  */
+import { Activity } from 'lucide-vue-next'
 import ArbitAlerts from '@/components/ArbitAlerts.vue'
+import ArbitControls from '@/components/ArbitControls.vue'
+import ArbitMetrics from '@/components/ArbitMetrics.vue'
+import ArbitOpportunities from '@/components/ArbitOpportunities.vue'
+import ArbitStatus from '@/components/ArbitStatus.vue'
+import ArbitTrades from '@/components/ArbitTrades.vue'
+import BasePageLayout from '@/components/layout/BasePageLayout.vue'
+import Card from '@/components/ui/Card.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
 </script>
+
+<style scoped>
+@reference "../assets/css/main.css";
+
+.arbit-dashboard {
+  background-color: var(--page-bg);
+  color: var(--theme-fg);
+  min-height: 100vh;
+}
+
+.section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-accent-cyan);
+}
+</style>

--- a/frontend/src/views/__tests__/ArbitDashboard.spec.js
+++ b/frontend/src/views/__tests__/ArbitDashboard.spec.js
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import ArbitDashboard from '../ArbitDashboard.vue'
+
+const PassThrough = { template: '<div class="pass-through"><slot /></div>' }
+
+const PageHeaderStub = {
+  template: '<div class="page-header-stub"><slot name="title" /><slot name="subtitle" /></div>',
+}
+
+const createStub = (testId) => ({
+  template: `<div data-test="${testId}"></div>`,
+})
+
+describe('ArbitDashboard.vue', () => {
+  const mountView = () =>
+    shallowMount(ArbitDashboard, {
+      global: {
+        stubs: {
+          BasePageLayout: PassThrough,
+          PageHeader: PageHeaderStub,
+          Card: PassThrough,
+          ArbitStatus: createStub('arbit-status-stub'),
+          ArbitControls: createStub('arbit-controls-stub'),
+          ArbitMetrics: createStub('arbit-metrics-stub'),
+          ArbitAlerts: createStub('arbit-alerts-stub'),
+          ArbitOpportunities: createStub('arbit-opportunities-stub'),
+          ArbitTrades: createStub('arbit-trades-stub'),
+        },
+      },
+    })
+
+  it('renders dashboard sections with expected components', () => {
+    const wrapper = mountView()
+
+    const statusSection = wrapper.find('[data-testid="status-controls"]')
+    const metricsSection = wrapper.find('[data-testid="metrics-alerts"]')
+    const tradesSection = wrapper.find('[data-testid="opportunities-trades"]')
+
+    expect(statusSection.exists()).toBe(true)
+    expect(metricsSection.exists()).toBe(true)
+    expect(tradesSection.exists()).toBe(true)
+
+    expect(statusSection.find('[data-test="arbit-status-stub"]').exists()).toBe(true)
+    expect(statusSection.find('[data-test="arbit-controls-stub"]').exists()).toBe(true)
+    expect(metricsSection.find('[data-test="arbit-metrics-stub"]').exists()).toBe(true)
+    expect(metricsSection.find('[data-test="arbit-alerts-stub"]').exists()).toBe(true)
+    expect(tradesSection.find('[data-test="arbit-opportunities-stub"]').exists()).toBe(true)
+    expect(tradesSection.find('[data-test="arbit-trades-stub"]').exists()).toBe(true)
+  })
+
+  it('matches snapshot', () => {
+    const wrapper = mountView()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/frontend/src/views/__tests__/__snapshots__/ArbitDashboard.spec.js.snap
+++ b/frontend/src/views/__tests__/__snapshots__/ArbitDashboard.spec.js.snap
@@ -1,0 +1,46 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ArbitDashboard.vue > matches snapshot 1`] = `
+"<div data-v-db7eac05="" class="pass-through arbit-dashboard" gap="gap-10">
+  <div data-v-db7eac05="" class="page-header-stub" icon="(props, { slots, attrs }) => vue.h(
+  Icon,
+  {
+    ...attrs,
+    ...props,
+    iconNode,
+    name: iconName
+  },
+  slots
+)">Arbitrage Command CenterMonitor engine status, opportunities, and trades</div>
+  <section data-v-db7eac05="" data-testid="status-controls" class="grid grid-cols-1 gap-6 xl:grid-cols-3">
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4">
+      <h2 data-v-db7eac05="" class="section-title">Engine Status</h2>
+      <div data-v-db7eac05="" data-test="arbit-status-stub"></div>
+    </div>
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4 xl:col-span-2">
+      <h2 data-v-db7eac05="" class="section-title">Control Panel</h2>
+      <div data-v-db7eac05="" data-test="arbit-controls-stub"></div>
+    </div>
+  </section>
+  <section data-v-db7eac05="" data-testid="metrics-alerts" class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4 lg:col-span-2">
+      <h2 data-v-db7eac05="" class="section-title">Performance Metrics</h2>
+      <div data-v-db7eac05="" data-test="arbit-metrics-stub"></div>
+    </div>
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4">
+      <h2 data-v-db7eac05="" class="section-title">Live Alerts</h2>
+      <div data-v-db7eac05="" data-test="arbit-alerts-stub"></div>
+    </div>
+  </section>
+  <section data-v-db7eac05="" data-testid="opportunities-trades" class="grid grid-cols-1 gap-6 xl:grid-cols-3">
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4">
+      <h2 data-v-db7eac05="" class="section-title">Current Opportunities</h2>
+      <div data-v-db7eac05="" data-test="arbit-opportunities-stub"></div>
+    </div>
+    <div data-v-db7eac05="" class="pass-through h-full p-6 space-y-4 xl:col-span-2 overflow-x-auto">
+      <h2 data-v-db7eac05="" class="section-title">Recent Trades</h2>
+      <div data-v-db7eac05="" data-test="arbit-trades-stub"></div>
+    </div>
+  </section>
+</div>"
+`;


### PR DESCRIPTION
## Summary
- add a responsive BasePageLayout wrapper and page header for the Arbit dashboard
- arrange status, controls, metrics, alerts, opportunities, and trades in card-based sections
- add a vitest view spec and snapshot to assert the new dashboard structure renders

## Testing
- npm --prefix frontend test -- --run ArbitDashboard

------
https://chatgpt.com/codex/tasks/task_e_68ca7651f6508329a092d8774dcd1004