### PR TITLE
chore: generalize Caddy dev proxy configuration

### DIFF
--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -7,13 +7,15 @@
 # Usage:
 #   export BACKEND_UPSTREAM=192.168.1.198:5000   # DietPi backend
 #   export FRONTEND_UPSTREAM=192.168.1.237:5173  # Desktop Vite dev server
+#   # optional: override the listening address (defaults to 0.0.0.0:8985)
+#   export PYNANCE_SITE_ADDRESS=pynance.local:8985
 #   caddy run --config scripts/Caddyfile
 #
 # Notes:
 # - This serves HTTP on :8985 inside your LAN. For public TLS, put Caddy behind
 #   Cloudflare Tunnel or configure a domain and enable automatic HTTPS.
 
-:8985 {
+{$PYNANCE_SITE_ADDRESS:0.0.0.0:8985} {
     encode zstd gzip
 
     # Proxy API requests to the backend


### PR DESCRIPTION
## Summary
- allow overriding the Caddy dev proxy listener with the `PYNANCE_SITE_ADDRESS` environment variable
- document the optional override so the repo no longer references a personal DuckDNS hostname

## Testing
- pytest -q *(fails: missing flask/fastapi/pdfplumber dependencies in the environment)*
- pre-commit run --all-files *(fails: repository has outstanding formatting and lint issues outside the scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cad87cc3c48329b060e0a6b8dec0e9