### PR TITLE
feat: normalize arbit metrics payload

### DIFF
--- a/docs/arbit_dashboard.md
+++ b/docs/arbit_dashboard.md
@@ -35,7 +35,9 @@ Returns whether the dashboard is enabled and echoes the relevant configuration.
 
 Retrieves chart-ready series derived from the exporter. Each series contains a
 `label` and numeric `value` for the profit and latency groups that
-`frontend/src/components/ArbitMetrics.vue` can render directly.
+`frontend/src/components/ArbitMetrics.vue` can render directly. The backend
+maps the raw Prometheus scalars into these groups using a static
+configuration, so clients always receive the chart-friendly structure below.
 
 ```json
 {

--- a/docs/backend/app/services/arbit_metrics.md
+++ b/docs/backend/app/services/arbit_metrics.md
@@ -6,9 +6,9 @@ Fetch metrics from the Arbit exporter and parse key values for dashboard use.
 
 - Call the configured exporter's `/metrics` endpoint.
 - Extract `profit_total`, `orders_total`, `fills_total`, `errors_total`, `skips_total`, and `cycle_latency` from the Prometheus text.
-- Return chart-ready series grouped into `profit` and `latency` arrays, each
-  containing `{"label": str, "value": float}` mappings for use in the
-  frontend charts.
+- Use `SERIES_CONFIG` to map exporter keys into chart-ready series grouped into
+  `profit` and `latency` arrays, each containing `{"label": str, "value":
+  float}` mappings for use in the frontend charts.
 
 ## Usage
 

--- a/docs/backend/app/services/arbit_metrics.md
+++ b/docs/backend/app/services/arbit_metrics.md
@@ -8,7 +8,7 @@ Fetch metrics from the Arbit exporter and parse key values for dashboard use.
 - Extract `profit_total`, `orders_total`, `fills_total`, `errors_total`, `skips_total`, and `cycle_latency` from the Prometheus text.
 - Use `SERIES_CONFIG` to map exporter keys into chart-ready series grouped into
   `profit` and `latency` arrays, each containing `{"label": str, "value":
-  float}` mappings for use in the frontend charts.
+float}` mappings for use in the frontend charts.
 
 ## Usage
 

--- a/frontend/src/components/ArbitMetrics.vue
+++ b/frontend/src/components/ArbitMetrics.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
-    <PortfolioAllocationChart v-if="profit.length" :allocations="profit" />
-    <PortfolioAllocationChart v-if="latency.length" :allocations="latency" />
+    <PortfolioAllocationChart
+      v-if="metrics.profit.length"
+      :allocations="metrics.profit"
+    />
+    <PortfolioAllocationChart
+      v-if="metrics.latency.length"
+      :allocations="metrics.latency"
+    />
   </div>
 </template>
 
@@ -9,17 +15,16 @@
 /**
  * Renders profit and latency metrics using existing chart components.
  */
-import { ref, onMounted } from 'vue'
-import { fetchArbitMetrics, type MetricPoint } from '@/services/arbit'
+import { reactive, onMounted } from 'vue'
+import { fetchArbitMetrics, type ArbitMetricsResponse } from '@/services/arbit'
 import PortfolioAllocationChart from '@/components/charts/PortfolioAllocationChart.vue'
 
-const profit = ref<MetricPoint[]>([])
-const latency = ref<MetricPoint[]>([])
+const metrics = reactive<ArbitMetricsResponse>({ profit: [], latency: [] })
 
 async function load() {
   const data = await fetchArbitMetrics()
-  profit.value = data.profit || []
-  latency.value = data.latency || []
+  metrics.profit = data.profit ?? []
+  metrics.latency = data.latency ?? []
 }
 
 onMounted(load)

--- a/frontend/src/components/ArbitMetrics.vue
+++ b/frontend/src/components/ArbitMetrics.vue
@@ -1,13 +1,7 @@
 <template>
   <div>
-    <PortfolioAllocationChart
-      v-if="metrics.profit.length"
-      :allocations="metrics.profit"
-    />
-    <PortfolioAllocationChart
-      v-if="metrics.latency.length"
-      :allocations="metrics.latency"
-    />
+    <PortfolioAllocationChart v-if="metrics.profit.length" :allocations="metrics.profit" />
+    <PortfolioAllocationChart v-if="metrics.latency.length" :allocations="metrics.latency" />
   </div>
 </template>
 

--- a/frontend/src/components/__tests__/ArbitMetrics.spec.ts
+++ b/frontend/src/components/__tests__/ArbitMetrics.spec.ts
@@ -5,8 +5,8 @@ import ArbitMetrics from '../ArbitMetrics.vue'
 
 vi.mock('@/services/arbit', () => ({
   fetchArbitMetrics: vi.fn().mockResolvedValue({
-    profit: [{ label: 'p', value: 1 }],
-    latency: [{ label: 'l', value: 2 }],
+    profit: [{ label: 'Total Profit ($)', value: 1 }],
+    latency: [{ label: 'Cycle Latency (s)', value: 2 }],
   }),
 }))
 
@@ -17,7 +17,8 @@ describe('ArbitMetrics.vue', () => {
         stubs: {
           PortfolioAllocationChart: {
             props: ['allocations'],
-            template: '<div class="chart">{{ allocations.length }}</div>',
+            template:
+              '<div class="chart">{{ allocations[0].label }}:{{ allocations[0].value }}</div>',
           },
         },
       },
@@ -25,7 +26,7 @@ describe('ArbitMetrics.vue', () => {
     await flushPromises()
     const charts = wrapper.findAll('.chart')
     expect(charts).toHaveLength(2)
-    expect(charts[0].text()).toBe('1')
-    expect(charts[1].text()).toBe('1')
+    expect(charts[0].text()).toBe('Total Profit ($):1')
+    expect(charts[1].text()).toBe('Cycle Latency (s):2')
   })
 })


### PR DESCRIPTION
## Summary
- derive profit and latency series from a central SERIES_CONFIG in the Arbit metrics service
- reactively store the chart data in ArbitMetrics.vue and extend the unit test expectations
- document the finalized metrics contract in the dashboard docs

## Testing
- `pytest`
- `npm run test:unit`
- `pre-commit run --files backend/app/services/arbit_metrics.py docs/arbit_dashboard.md docs/backend/app/services/arbit_metrics.md frontend/src/components/ArbitMetrics.vue frontend/src/components/__tests__/ArbitMetrics.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cae3435a9c8329afd4fa9ee0f24e30