### PR TITLE
Add server-side investment transaction filters

### DIFF
--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -1,6 +1,6 @@
 """Endpoints for retrieving investment account information and data."""
 
-from datetime import datetime, date
+from datetime import date, datetime
 from typing import Dict, Mapping, Optional
 
 from app.extensions import db
@@ -14,7 +14,9 @@ investments = Blueprint("investments", __name__)
 DATE_PARAM_FORMAT = "%Y-%m-%d"
 
 
-def parse_transaction_filter_params(args: Mapping[str, str]) -> Dict[str, Optional[str | date]]:
+def parse_transaction_filter_params(
+    args: Mapping[str, str],
+) -> Dict[str, Optional[str | date]]:
     """Parse and validate optional filter params for investment transactions.
 
     Args:

--- a/docs/roadmaps/investments.md
+++ b/docs/roadmaps/investments.md
@@ -5,6 +5,16 @@
 - Holdings, securities, and investment transactions are modelled via SQLAlchemy and refreshed through `upsert_investments_from_plaid` / `upsert_investment_transactions`.
 - `/api/plaid/investments/refresh` (single item) and `/api/plaid/investments/refresh_all` (broadcast) trigger refreshes; `/api/investments` exposes read endpoints consumed by the Vue client.
 - Plaid webhooks for `INVESTMENTS_TRANSACTIONS` and `HOLDINGS` are routed through `/api/webhooks/plaid`, enabling automatic updates.
+- `/api/investments/transactions` now accepts filters for account, security, type, subtype, and ISO date ranges so analytics views can request scoped datasets without client-side filtering.
+
+## Progress update (2025-09-17)
+
+| Theme | Status | Notes |
+| --- | --- | --- |
+| Backend reliability & coverage | 🚧 In progress | API filtering has been hardened with server-side validation for type/subtype and date ranges. Webhook-driven tests and instrumentation for refresh timings remain to be implemented. |
+| Data enrichment | ⏳ Not started | Persisting cost basis deltas and unrealised gain/loss data still needs modelling and ETL updates. |
+| Frontend analytics | 🚧 In progress | Vue client can request scoped transactions; UI work for allocation visualisations and CSV export is still pending. |
+| Interaction polish | 🚧 In progress | Backend filter plumbing is complete, but UI caching of filters and security detail drawer UX are open tasks. |
 
 ## Backend priorities
 
@@ -22,7 +32,7 @@
    - Add CSV export for investment transactions with filter state encoded in the query.
 2. **Interaction polish**
    - Implement a security detail drawer with quote metadata and recent activity.
-   - Provide filters by security, type/subtype, and date range; cache last-used filters per user.
+   - Provide filters by security, type/subtype, and date range; cache last-used filters per user (API support shipped 2025-09-17, UI persistence still pending).
 
 ## Operational tooling
 
@@ -35,4 +45,4 @@
 - ✅ Dashboards present allocation/performance insights with export functionality.
 - ✅ Metrics and runbooks exist for monitoring investment data freshness.
 
-_Last updated: 2025-09-10_
+_Last updated: 2025-09-17_

--- a/docs/roadmaps/investments.md
+++ b/docs/roadmaps/investments.md
@@ -9,12 +9,12 @@
 
 ## Progress update (2025-09-17)
 
-| Theme | Status | Notes |
-| --- | --- | --- |
+| Theme                          | Status         | Notes                                                                                                                                                                                |
+| ------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Backend reliability & coverage | 🚧 In progress | API filtering has been hardened with server-side validation for type/subtype and date ranges. Webhook-driven tests and instrumentation for refresh timings remain to be implemented. |
-| Data enrichment | ⏳ Not started | Persisting cost basis deltas and unrealised gain/loss data still needs modelling and ETL updates. |
-| Frontend analytics | 🚧 In progress | Vue client can request scoped transactions; UI work for allocation visualisations and CSV export is still pending. |
-| Interaction polish | 🚧 In progress | Backend filter plumbing is complete, but UI caching of filters and security detail drawer UX are open tasks. |
+| Data enrichment                | ⏳ Not started | Persisting cost basis deltas and unrealised gain/loss data still needs modelling and ETL updates.                                                                                    |
+| Frontend analytics             | 🚧 In progress | Vue client can request scoped transactions; UI work for allocation visualisations and CSV export is still pending.                                                                   |
+| Interaction polish             | 🚧 In progress | Backend filter plumbing is complete, but UI caching of filters and security detail drawer UX are open tasks.                                                                         |
 
 ## Backend priorities
 

--- a/tests/test_investment_transaction_filters.py
+++ b/tests/test_investment_transaction_filters.py
@@ -1,0 +1,48 @@
+"""Unit tests for investment transaction filter parsing."""
+
+import pytest
+
+pytest.importorskip("flask", reason="flask is required to import investment routes")
+
+from backend.app.routes.investments import parse_transaction_filter_params
+
+
+def test_parse_transaction_filters_valid_payload():
+    """Ensure the helper returns normalized filter values for valid input."""
+
+    args = {
+        "account_id": "acct-1",
+        "security_id": "sec-1",
+        "type": "buy",
+        "subtype": "mutual fund",
+        "start_date": "2024-01-15",
+        "end_date": "2024-02-01",
+    }
+
+    filters = parse_transaction_filter_params(args)
+
+    assert filters["account_id"] == "acct-1"
+    assert filters["security_id"] == "sec-1"
+    assert filters["type"] == "buy"
+    assert filters["subtype"] == "mutual fund"
+    assert str(filters["start_date"]) == "2024-01-15"
+    assert str(filters["end_date"]) == "2024-02-01"
+
+
+@pytest.mark.parametrize(
+    "payload,expected_message",
+    [
+        ({"start_date": "20240115"}, "Invalid date"),
+        (
+            {"start_date": "2024-03-01", "end_date": "2024-02-01"},
+            "end_date must be greater",
+        ),
+    ],
+)
+def test_parse_transaction_filters_invalid(payload, expected_message):
+    """Invalid payloads should raise a ``ValueError`` with context."""
+
+    with pytest.raises(ValueError) as excinfo:
+        parse_transaction_filter_params(payload)
+
+    assert expected_message in str(excinfo.value)


### PR DESCRIPTION
## Summary
- extend `/api/investments/transactions` with server-side parsing for type/subtype/date filters and echo applied filter metadata
- document the investments roadmap with a progress table that calls out the new API filter coverage
- add targeted unit coverage for `parse_transaction_filter_params` (skips when Flask is unavailable)

## Testing
- pytest tests/test_investment_transaction_filters.py
- pytest *(fails: missing flask/fastapi/pdfplumber dependencies and syntax error in existing test)*
- pre-commit run --all-files *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc9c187d883298ddb20abae0228f6