### PR TITLE
Align dashboard toggle buttons with financial summary gradient

### DIFF
--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -52,6 +52,44 @@
     color: var(--color-bg-dark);
   }
 
+  .gradient-toggle-btn {
+    background: linear-gradient(135deg, var(--color-bg-sec) 0%, var(--color-bg-dark) 100%);
+    border: 1px solid var(--color-accent-cyan);
+    color: var(--color-accent-cyan);
+    padding: 0.35rem 0.9rem;
+    border-radius: 0.65rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .gradient-toggle-btn:hover,
+  .gradient-toggle-btn:focus-visible {
+    background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
+    color: var(--color-bg-dark);
+    border-color: var(--color-accent-cyan);
+    outline: none;
+  }
+
+  .gradient-toggle-btn.extended,
+  .gradient-toggle-btn.is-active {
+    background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
+    color: var(--color-bg-dark);
+    border-color: var(--color-accent-cyan);
+  }
+
+  .gradient-toggle-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   .btn-primary {
     @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
     background-color: var(--primary);

--- a/frontend/src/components/DateRangeSelector.vue
+++ b/frontend/src/components/DateRangeSelector.vue
@@ -12,7 +12,12 @@
       @input="onEnd($event.target.value)"
       class="date-picker px-2 py-1 rounded border border-[var(--divider)] bg-[var(--theme-bg)] text-[var(--color-text-light)] focus:ring-2 focus:ring-[var(--color-accent-cyan)]"
     />
-    <button v-if="!disableZoom" class="btn btn-outline hover-lift ml-2" @click="toggleZoom">
+    <button
+      v-if="!disableZoom"
+      class="gradient-toggle-btn ml-2"
+      :class="{ extended: zoomedOut }"
+      @click="toggleZoom"
+    >
       {{ zoomedOut ? 'Zoom In' : 'Zoom Out' }}
     </button>
   </div>

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -12,7 +12,7 @@
       <h3 class="stats-title">Financial Snapshot</h3>
       <div class="stats-controls">
         <button
-          class="stats-toggle-btn"
+          class="gradient-toggle-btn"
           :class="{ extended: isExtendedView }"
           @click="toggleExtendedView"
           :title="isExtendedView ? 'Switch to Basic View' : 'Switch to Extended View'"
@@ -366,30 +366,6 @@ watch(
   font-weight: 600;
   color: var(--color-accent-cyan);
   margin: 0;
-}
-
-.stats-toggle-btn {
-  background: linear-gradient(135deg, var(--color-bg-sec) 0%, var(--color-bg-dark) 100%);
-  border: 1px solid var(--color-accent-cyan);
-  color: var(--color-accent-cyan);
-  padding: 0.25rem 0.75rem;
-  border-radius: 0.5rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.stats-toggle-btn:hover {
-  background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
-  color: var(--color-bg-dark);
-  border-color: var(--color-accent-cyan);
-}
-
-.stats-toggle-btn.extended {
-  background: linear-gradient(135deg, var(--color-accent-cyan) 0%, var(--color-accent-blue) 100%);
-  color: var(--color-bg-dark);
-  border-color: var(--color-accent-cyan);
 }
 
 .basic-stats {

--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -13,7 +13,7 @@
       <div class="bs-tabs-scroll">
         <button
           v-if="!isEditingGroups && groups.length > 3"
-          class="bs-nav-btn"
+          class="bs-nav-btn gradient-toggle-btn"
           @click="shiftWindow(-1)"
           :disabled="visibleGroupIndex === 0"
           aria-label="Previous group"
@@ -85,7 +85,7 @@
 
         <button
           v-if="groups.length > 3"
-          class="bs-nav-btn"
+          class="bs-nav-btn gradient-toggle-btn"
           @click="shiftWindow(1)"
           :disabled="visibleGroupIndex + 3 >= groups.length"
           aria-label="Next group"
@@ -96,7 +96,11 @@
 
       <!-- Group Dropdown -->
       <div class="bs-group-dropdown" :style="{ '--accent': groupAccent }">
-        <button class="bs-group-btn" @click="toggleGroupMenu" aria-label="Select account group">
+        <button
+          class="bs-group-btn gradient-toggle-btn"
+          @click="toggleGroupMenu"
+          aria-label="Select account group"
+        >
           {{ activeGroup ? activeGroup.name : 'Select group' }} ▾
         </button>
         <Transition name="slide-down">
@@ -847,54 +851,38 @@ defineExpose({
 }
 
 .bs-group-btn {
-  padding: 0.4rem 0.8rem;
-  background: var(--color-bg-sec);
-  color: var(--accent);
-  border: 1px solid var(--accent);
-  border-radius: 0.8rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 0.65rem;
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  transition:
-    background 0.2s,
-    color 0.2s;
+  gap: 0.35rem;
+}
+
+.bs-group-btn:focus-visible {
+  outline: none;
 }
 
 .bs-nav-btn {
-  padding: 0.4rem 0.6rem;
-  background: var(--color-bg-sec);
-  color: var(--accent);
-  border: 1px solid var(--accent);
-  border-radius: 0.8rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.65rem;
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition:
-    background 0.2s,
-    color 0.2s;
 }
 
-.bs-nav-btn:hover,
 .bs-nav-btn:focus-visible {
-  background: var(--accent);
-  color: var(--color-bg-dark);
+  outline: none;
 }
 
 .bs-nav-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
-}
-
-.bs-group-btn:hover,
-.bs-group-btn:focus-visible {
-  background: var(--accent);
-  color: var(--color-bg-dark);
 }
 
 .bs-group-menu {


### PR DESCRIPTION
## Summary
- add a shared `gradient-toggle-btn` utility class so dashboard controls reuse the financial snapshot gradient styling
- update the financial snapshot toggle, date range selector, and top accounts navigation to consume the shared gradient class for a consistent look

## Testing
- `pre-commit run --all-files` *(fails: repository hooks require unavailable dependencies such as Flask, mypy duplicate-module configuration, and pytest/bandit checks)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68d002a5e7ec832998e8f2aae8412d60