### PR TITLE
fix: keep category visuals when opening transactions from chart

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -429,7 +429,8 @@ async function onCategoryBarClick(payload) {
   // Configure modal for category mode
   modalKind.value = 'category'
   modalShowDate.value = true
-  modalHideCategoryVisuals.value = true
+  // Keep category visuals enabled so parent/child labels remain visible
+  modalHideCategoryVisuals.value = false
 
   // Focus on category label only in header; dates move to table
   modalSubtitle.value = label


### PR DESCRIPTION
## Summary
- ensure the dashboard’s category modal keeps category visuals enabled
- leave a note in the handler to clarify the intent

## Testing
- pytest --cov *(fails: missing Flask/FastAPI/pdfplumber dependencies in test environment)*
- pre-commit run --files frontend/src/views/Dashboard.vue *(fails: model-field-validation hook requires Flask SQLAlchemy in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d002c20148832995cb3faa4bf6dc17