### PR TITLE
feat: seed transactions view from modal selection

### DIFF
--- a/frontend/src/components/modals/TransactionModal.vue
+++ b/frontend/src/components/modals/TransactionModal.vue
@@ -167,10 +167,21 @@ const summary = computed(() => {
   }
 })
 
+/**
+ * Navigate to the Transactions route, pre-populating highlight and filters
+ * based on the clicked transaction.
+ */
 function onRowClick(tx) {
   const txid = tx?.transaction_id || tx?.id
-  if (txid) router.push({ name: 'Transactions', query: { promote: txid } })
+  const accountId = tx?.account_id || tx?.accountId
+  const query = {}
+
+  if (txid) query.promote = txid
+  if (accountId) query.account_id = accountId
+
+  if (Object.keys(query).length) router.push({ name: 'Transactions', query })
   else router.push({ name: 'Transactions' })
+
   emitClose()
 }
 </script>


### PR DESCRIPTION
## Summary
- include the clicked transaction's account id when routing from the modal so the Transactions view can scope results
- initialize the Transactions view account filter from the new query parameter and keep the promoted transaction id synced with route updates

## Testing
- npm run lint *(fails: cannot resolve @vue/eslint-config-prettier/skip-formatting)*
- pytest -q *(fails: missing Flask/FastAPI/pdfplumber dependencies in test environment)*
- pre-commit run --all-files *(fails: formatting/type/lint checks across untouched backend code)*

------
https://chatgpt.com/codex/tasks/task_e_68d002d0c2088329a18aab4a8f09f5ad