### PR TITLE
test(frontend): update FinancialSummary toggle selector

### DIFF
--- a/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
+++ b/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
@@ -25,7 +25,9 @@ describe('FinancialSummary trends', () => {
       },
     })
 
-    await wrapper.find('.stats-toggle-btn').trigger('click')
+    const toggleButton = wrapper.find('.gradient-toggle-btn')
+    expect(toggleButton.exists()).toBe(true)
+    await toggleButton.trigger('click')
     const html = wrapper.html()
     expect(html).toContain('Income Trend')
     expect(html).toContain('+$100.00')


### PR DESCRIPTION
## Summary
- update the FinancialSummary unit test to target the new gradient toggle button class
- assert that the toggle button exists before attempting to click it to avoid empty wrapper errors

## Testing
- `npx vitest run src/components/statistics/__tests__/FinancialSummary.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68d059f860fc8329969b2de47fdc01ef