### PR TITLE
Preserve category visuals in chart-driven transaction modal

### DIFF
--- a/frontend/src/components/modals/TransactionModal.vue
+++ b/frontend/src/components/modals/TransactionModal.vue
@@ -105,7 +105,7 @@
             :transactions="transactions"
             :title-date="''"
             :show-date-column="kind === 'category' && showDateColumn"
-            :show-category-visuals="!(kind === 'category' && hideCategoryVisuals)"
+            :show-category-visuals="showCategoryVisuals"
             @row-click="onRowClick"
           />
         </div>
@@ -148,6 +148,14 @@ const titleLabel = computed(() =>
   props.kind === 'category' ? 'Category Transactions' : 'Transactions',
 )
 const subtitlePrefix = computed(() => (props.kind === 'category' ? 'Category' : 'Date'))
+
+/**
+ * Ensure category visuals remain visible unless explicitly hidden by the
+ * consumer. Non-category modals always render visuals.
+ */
+const showCategoryVisuals = computed(
+  () => props.kind !== 'category' || !props.hideCategoryVisuals,
+)
 
 // --- SUMMARY COMPUTATION ---
 const summary = computed(() => {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -387,13 +387,13 @@ async function loadCategoryGroups() {
 // Handle clicks on the DailyNetChart bars and open a modal for that date.
 async function onNetBarClick(label) {
   const result = await fetchTransactions({ start_date: label, end_date: label })
-  modalTransactions.value = result.transactions || []
-  // Configure modal for date mode
-  modalKind.value = 'date'
-  modalShowDate.value = false
-  modalHideCategoryVisuals.value = false
-  modalSubtitle.value = label
-  showModal.value = true
+  configureTransactionModal({
+    transactions: result.transactions || [],
+    kind: 'date',
+    showDateColumn: false,
+    hideCategoryVisuals: false,
+    subtitle: label,
+  })
 }
 
 /**
@@ -424,16 +424,38 @@ async function onCategoryBarClick(payload) {
     start_date: start,
     end_date: end,
   })
-  modalTransactions.value = result.transactions || []
+  configureTransactionModal({
+    transactions: result.transactions || [],
+    kind: 'category',
+    showDateColumn: true,
+    hideCategoryVisuals: false,
+    subtitle: label, // Focus on category label only in header; dates move to table.
+  })
+}
 
-  // Configure modal for category mode
-  modalKind.value = 'category'
-  modalShowDate.value = true
-  // Keep category visuals enabled so parent/child labels remain visible
-  modalHideCategoryVisuals.value = false
-
-  // Focus on category label only in header; dates move to table
-  modalSubtitle.value = label
+/**
+ * Centralize modal state mutations so chart handlers cannot accidentally hide
+ * category visuals when opening transaction details.
+ *
+ * @param {Object} options - Modal configuration overrides.
+ * @param {Array} options.transactions - Transactions to display.
+ * @param {string} options.kind - Modal layout mode, e.g. 'date' or 'category'.
+ * @param {boolean} options.showDateColumn - Whether to show the date column.
+ * @param {boolean} options.hideCategoryVisuals - Hide category visuals inside the modal.
+ * @param {string} options.subtitle - Subtitle label rendered in the modal header.
+ */
+function configureTransactionModal({
+  transactions = [],
+  kind = 'date',
+  showDateColumn = false,
+  hideCategoryVisuals = false,
+  subtitle = '',
+}) {
+  modalTransactions.value = Array.isArray(transactions) ? transactions : []
+  modalKind.value = kind
+  modalShowDate.value = Boolean(showDateColumn)
+  modalHideCategoryVisuals.value = Boolean(hideCategoryVisuals)
+  modalSubtitle.value = subtitle
   showModal.value = true
 }
 </script>


### PR DESCRIPTION
## Summary
- centralize dashboard modal configuration so category-driven launches always keep category visuals enabled
- ensure TransactionModal forwards the show-category-visuals flag via a dedicated computed value

## Testing
- pre-commit run --files frontend/src/views/Dashboard.vue frontend/src/components/modals/TransactionModal.vue *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- pytest -q *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68d05a8ed1ac8329b2831d07d8ed5faa