### PR TITLE
refactor: simplify targeted account selection guard

### DIFF
--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -253,10 +253,9 @@ export default {
       return map
     },
     targetedAccounts() {
-      const ids =
-        this.selectedAccounts && this.selectedAccounts.length
-          ? new Set(this.selectedAccounts)
-          : null
+      const ids = this.selectedAccounts?.length
+        ? new Set(this.selectedAccounts)
+        : null
       return (this.accounts || []).filter((a) => (ids ? ids.has(a.account_id) : true))
     },
     targetedAccountsByInstitution() {


### PR DESCRIPTION
## Summary
- replace the multi-clause logical check in `targetedAccounts` with optional chaining for clarity
- preserve existing filtering logic while avoiding redundant truthiness checks

## Testing
- `npm run test` *(fails: numerous pre-existing vitest component tests and environment warnings)*
- `pre-commit run --all-files` *(fails: repository-wide mypy/pylint/bandit/model-field-validation issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0743a269c8329b583c47ae93e9f46