### PR TITLE
refactor: simplify plaid targeted accounts filter

### DIFF
--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -254,7 +254,7 @@ export default {
     },
     targetedAccounts() {
       const ids = this.selectedAccounts?.length ? new Set(this.selectedAccounts) : null
-      return (this.accounts || []).filter((a) => (ids ? ids.has(a.account_id) : true))
+      return (this.accounts ?? []).filter((account) => ids?.has(account.account_id) ?? true)
     },
     targetedAccountsByInstitution() {
       const grouped = {}


### PR DESCRIPTION
## Summary
- refactor the targeted accounts filter in RefreshPlaidControls to use optional chaining
- keep the filter logic resilient when no account ids are selected

## Testing
- pytest -q *(fails: missing flask/fastapi/pdfplumber dependencies in environment)*
- pre-commit run --all-files *(fails: pre-commit command unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d0edbc66248329b066b37387d3f7e6