### PR TITLE
refactor: use optional chaining in refresh teller widget

### DIFF
--- a/frontend/src/components/widgets/RefreshTellerControls.vue
+++ b/frontend/src/components/widgets/RefreshTellerControls.vue
@@ -248,10 +248,7 @@ export default {
       return map
     },
     targetedAccounts() {
-      const ids =
-        this.selectedAccounts && this.selectedAccounts.length
-          ? new Set(this.selectedAccounts)
-          : null
+      const ids = this.selectedAccounts?.length ? new Set(this.selectedAccounts) : null
       return (this.accounts || []).filter((a) => (ids ? ids.has(a.account_id) : true))
     },
     targetedAccountsByInstitution() {


### PR DESCRIPTION
## Summary
- replace manual logical checks with optional chaining when building the selected account id set in the RefreshTellerControls widget

## Testing
- pytest -q *(fails: missing Flask/FastAPI/pdfplumber dependencies in test environment)*
- pre-commit run --all-files *(fails: mypy duplicate-module configuration, existing lint warnings, and missing Flask dependencies for hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68d15c4cc29c83298723b7bec86a0479