### PR TITLE
docs(transaction-rules): refresh model references

### DIFF
--- a/docs/backend/features/transaction_rules.md
+++ b/docs/backend/features/transaction_rules.md
@@ -6,7 +6,7 @@ Transaction rules let users automatically modify transactions during sync based 
 
 - **Model**: `TransactionRule`
 - **Purpose**: Persist user-defined criteria that trigger updates on incoming transactions.
-- **Location**: `backend/app/models.py` and accompanying SQL helpers.
+- **Location**: [`backend/app/models/transaction_models.py`](../../../backend/app/models/transaction_models.py) with rule execution logic in [`backend/app/sql/transaction_rules_logic.py`](../../../backend/app/sql/transaction_rules_logic.py).
 
 ## Rule Fields
 
@@ -38,4 +38,4 @@ These endpoints complement the existing `/transactions/update` flow.
 
 ## Migration
 
-See [../temp_migrations/versions/transaction_rules_add_table.md](../temp_migrations/versions/transaction_rules_add_table.md) for Alembic instructions to create the table.
+Review the Alembic revision under [`backend/migrations/versions/`](../../../backend/migrations/versions) that introduces the `transaction_rules` table (look for `add_transaction_rules_table`).

--- a/docs/organize/CODEX_RECC-MIGRATION.md
+++ b/docs/organize/CODEX_RECC-MIGRATION.md
@@ -32,6 +32,7 @@ Below is what’s happening and how to resolve it.
        [`backend/migrations/versions/0bc042573c3a_initial_prod_db.py`](../../backend/migrations/versions/0bc042573c3a_initial_prod_db.py)
 
     3. **SQLAlchemy is therefore trying to `SELECT transactions.user_id` against a SQLite table that doesn’t have it.**
+
 For example, in your paginated‑transactions logic you do:
 
            query = (

--- a/docs/organize/CODEX_RECC-MIGRATION.md
+++ b/docs/organize/CODEX_RECC-MIGRATION.md
@@ -6,7 +6,7 @@ Below is what’s happening and how to resolve it.
 ## What’s going on
 
     1. **Your model defines `user_id` on `transactions`, but your DB schema does not.**
-       In **models.py** you have:
+       In **models/transaction_models.py** you have:
 
            class Transaction(db.Model):
                __tablename__ = "transactions"
@@ -15,7 +15,7 @@ Below is what’s happening and how to resolve it.
                transaction_id = db.Column(db.String(64), unique=True, nullable=False)
                …
 
-       [backend/app/models.py](/home/braydenchaffee/Projects/pyNance/backend/app/models.py)
+       [`backend/app/models/transaction_models.py`](../../backend/app/models/transaction_models.py)
     2. **Your initial Alembic migration never created that column.**
        In **backend/migrations/versions/0bc042573c3a_initial_prod_db.py** the `transactions` table is built without a `user_id` column:
 
@@ -29,9 +29,9 @@ Below is what’s happening and how to resolve it.
                sa.UniqueConstraint('transaction_id')
            )
 
-       [backend/migrations/versions/0bc042573c3a_initial_prod_db.py](/home/braydenchaffee/Projects/pyNance/backend/migrations/versions/0bc042573c3a_initial_
+       [`backend/migrations/versions/0bc042573c3a_initial_prod_db.py`](../../backend/migrations/versions/0bc042573c3a_initial_prod_db.py)
 
-prod_db.py) 3. **SQLAlchemy is therefore trying to `SELECT transactions.user_id` against a SQLite table that doesn’t have it.**
+    3. **SQLAlchemy is therefore trying to `SELECT transactions.user_id` against a SQLite table that doesn’t have it.**
 For example, in your paginated‑transactions logic you do:
 
            query = (
@@ -41,7 +41,7 @@ For example, in your paginated‑transactions logic you do:
            )
            total = query.count()
 
-       [backend/app/sql/account_logic.py](/home/braydenchaffee/Projects/pyNance/backend/app/sql/account_logic.py)
+       [`backend/app/sql/account_logic.py`](../../backend/app/sql/account_logic.py)
 
        Calling `.count()` on a multi‑entity query wraps the original select (including every column of `Transaction`, among them `user_id`) in a `SELECT
 

--- a/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Component_Responsibilities-Final_Summary.md
+++ b/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Component_Responsibilities-Final_Summary.md
@@ -61,7 +61,6 @@ These call into `helpers/` modules, where the true sync logic begins.
 ### 📁 `sql/category_logic.py`
 
 - Sync-related support functions:
-
   - `upsert_categories_from_plaid_data`
   - `resolve_or_create_category`
 
@@ -70,7 +69,6 @@ These call into `helpers/` modules, where the true sync logic begins.
 ### 📁 `backend/app/models/`
 
 - Central schema definitions are now split across dedicated modules:
-
   - [`account_models.py`](../../../../backend/app/models/account_models.py) – `Account`, `PlaidAccount`, `TellerAccount`, and related history tables.
   - [`transaction_models.py`](../../../../backend/app/models/transaction_models.py) – `Transaction`, `RecurringTransaction`, `TransactionRule`, `Category`, and Plaid transaction metadata.
 

--- a/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Component_Responsibilities-Final_Summary.md
+++ b/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Component_Responsibilities-Final_Summary.md
@@ -67,18 +67,17 @@ These call into `helpers/` modules, where the true sync logic begins.
 
 - Used by both Plaid and Teller sync to resolve category names and create them if missing.
 
-### 📄 `backend/app/models.py`
+### 📁 `backend/app/models/`
 
-- Central schema definition for:
+- Central schema definitions are now split across dedicated modules:
 
-  - `Account`, `PlaidAccount`, `TellerAccount`
-  - `Transaction`, `RecurringTransaction`, `AccountHistory`, `Category`
+  - [`account_models.py`](../../../../backend/app/models/account_models.py) – `Account`, `PlaidAccount`, `TellerAccount`, and related history tables.
+  - [`transaction_models.py`](../../../../backend/app/models/transaction_models.py) – `Transaction`, `RecurringTransaction`, `TransactionRule`, `Category`, and Plaid transaction metadata.
 
-- Relationships (e.g., account-category, transaction-category) are wired via foreign keys
-- Attributes like `user_modified`, `pending`, `merchant_name`, `provider` overlap with sync outputs from Plaid and Teller
+- Relationships (e.g., account-category, transaction-category) remain wired via foreign keys across these modules.
+- Attributes like `user_modified`, `pending`, `merchant_name`, and `provider` still align with Plaid and Teller sync outputs.
 
-➡️ This file serves as the single source of truth for all sync-related schema definitions
-➡️ It should remain unchanged, but referenced heavily during provider/service implementation
+➡️ The models package continues to act as the single source of truth for sync-oriented schemas and should be referenced heavily during provider/service implementation.
 
 ---
 

--- a/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Final_Summary_Overview.md
+++ b/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Final_Summary_Overview.md
@@ -61,7 +61,6 @@ These call into `helpers/` modules, where the true sync logic begins.
 ### 📁 `sql/category_logic.py`
 
 - Sync-related support functions:
-
   - `upsert_categories_from_plaid_data`
   - `resolve_or_create_category`
 
@@ -70,7 +69,6 @@ These call into `helpers/` modules, where the true sync logic begins.
 ### 📁 `backend/app/models/`
 
 - Central schema definitions are now split across dedicated modules:
-
   - [`account_models.py`](../../../../backend/app/models/account_models.py) – `Account`, `PlaidAccount`, `TellerAccount`, and related history tables.
   - [`transaction_models.py`](../../../../backend/app/models/transaction_models.py) – `Transaction`, `RecurringTransaction`, `TransactionRule`, `Category`, and Plaid transaction metadata.
 

--- a/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Final_Summary_Overview.md
+++ b/docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Final_Summary_Overview.md
@@ -67,18 +67,17 @@ These call into `helpers/` modules, where the true sync logic begins.
 
 - Used by both Plaid and Teller sync to resolve category names and create them if missing.
 
-### 📄 `backend/app/models.py`
+### 📁 `backend/app/models/`
 
-- Central schema definition for:
+- Central schema definitions are now split across dedicated modules:
 
-  - `Account`, `PlaidAccount`, `TellerAccount`
-  - `Transaction`, `RecurringTransaction`, `AccountHistory`, `Category`
+  - [`account_models.py`](../../../../backend/app/models/account_models.py) – `Account`, `PlaidAccount`, `TellerAccount`, and related history tables.
+  - [`transaction_models.py`](../../../../backend/app/models/transaction_models.py) – `Transaction`, `RecurringTransaction`, `TransactionRule`, `Category`, and Plaid transaction metadata.
 
-- Relationships (e.g., account-category, transaction-category) are wired via foreign keys
-- Attributes like `user_modified`, `pending`, `merchant_name`, `provider` overlap with sync outputs from Plaid and Teller
+- Relationships (e.g., account-category, transaction-category) remain wired via foreign keys across these modules.
+- Attributes like `user_modified`, `pending`, `merchant_name`, and `provider` still align with Plaid and Teller sync outputs.
 
-➡️ This file serves as the single source of truth for all sync-related schema definitions
-➡️ It should remain unchanged, but referenced heavily during provider/service implementation
+➡️ The models package continues to act as the single source of truth for sync-oriented schemas and should be referenced heavily during provider/service implementation.
 
 ---
 


### PR DESCRIPTION
## Summary
- point the transaction rules feature guide to the split transaction model module and Alembic migration directory
- replace lingering docs references to the old backend/app/models.py file with links into the models package
- update the CODEX migration note to use relative repository links for the Transaction model and supporting SQL logic

## Testing
- `~/.local/bin/pre-commit run --files docs/backend/features/transaction_rules.md docs/organize/CODEX_RECC-MIGRATION.md docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Component_Responsibilities-Final_Summary.md docs/organize/routing_refactor/TxRoutes/Transaction_Integration-Final_Summary_Overview.md` *(fails: missing flask_sqlalchemy dependency in hook test suite)*
- `pytest -q` *(fails: missing flask/fastapi/pdfplumber dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1642e73288329a706b357d1e75639