### PR TITLE
fix: enforce database cascade semantics

### DIFF
--- a/backend/app/models/account_models.py
+++ b/backend/app/models/account_models.py
@@ -22,7 +22,10 @@ class Account(db.Model, TimestampMixin):
     subtype = db.Column(db.String(64), nullable=True)
     institution_name = db.Column(db.String(128), nullable=True)
     institution_db_id = db.Column(
-        db.Integer, db.ForeignKey("institutions.id"), nullable=True, index=True
+        db.Integer,
+        db.ForeignKey("institutions.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
     )
     status = db.Column(db.String(64), default="active")
     is_hidden = db.Column(db.Boolean, default=False)
@@ -47,7 +50,9 @@ class AccountHistory(db.Model, TimestampMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), nullable=False
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        nullable=False,
     )
     user_id = db.Column(db.String(64), nullable=True, index=True)
     date = db.Column(db.DateTime, nullable=False)
@@ -65,7 +70,10 @@ class FinancialGoal(db.Model, TimestampMixin):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.String(64), index=True, nullable=False)
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), index=True, nullable=False
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
     )
     name = db.Column(db.String(128), nullable=False)
     target_amount = db.Column(db.Numeric(18, 2), nullable=False)

--- a/backend/app/models/institution_models.py
+++ b/backend/app/models/institution_models.py
@@ -32,7 +32,7 @@ class PlaidAccount(db.Model, TimestampMixin):
     id = db.Column(db.Integer, primary_key=True)
     account_id = db.Column(
         db.String(64),
-        db.ForeignKey("accounts.account_id"),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
         unique=True,
@@ -45,7 +45,9 @@ class PlaidAccount(db.Model, TimestampMixin):
     webhook = db.Column(db.String(256), nullable=True)
     last_refreshed = db.Column(db.DateTime, nullable=True)
     institution_db_id = db.Column(
-        db.Integer, db.ForeignKey("institutions.id"), nullable=True
+        db.Integer,
+        db.ForeignKey("institutions.id", ondelete="CASCADE"),
+        nullable=True,
     )
     institution = db.relationship("Institution", back_populates="plaid_accounts")
     sync_cursor = db.Column(db.String(256), nullable=True)
@@ -84,7 +86,9 @@ class TellerAccount(db.Model, TimestampMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), nullable=False
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        nullable=False,
     )
     access_token = db.Column(db.String(256), nullable=False)
     enrollment_id = db.Column(db.String(128), nullable=True)
@@ -92,6 +96,8 @@ class TellerAccount(db.Model, TimestampMixin):
     provider = db.Column(db.String(64), default="Teller")
     last_refreshed = db.Column(db.DateTime, nullable=True)
     institution_db_id = db.Column(
-        db.Integer, db.ForeignKey("institutions.id"), nullable=True
+        db.Integer,
+        db.ForeignKey("institutions.id", ondelete="CASCADE"),
+        nullable=True,
     )
     institution = db.relationship("Institution", back_populates="teller_accounts")

--- a/backend/app/models/investment_models.py
+++ b/backend/app/models/investment_models.py
@@ -28,11 +28,14 @@ class InvestmentHolding(db.Model, TimestampMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), index=True, nullable=False
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
     )
     security_id = db.Column(
         db.String(128),
-        db.ForeignKey("securities.security_id"),
+        db.ForeignKey("securities.security_id", ondelete="CASCADE"),
         index=True,
         nullable=False,
     )
@@ -55,11 +58,14 @@ class InvestmentTransaction(db.Model, TimestampMixin):
 
     investment_transaction_id = db.Column(db.String(128), primary_key=True)
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), index=True, nullable=False
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
     )
     security_id = db.Column(
         db.String(128),
-        db.ForeignKey("securities.security_id"),
+        db.ForeignKey("securities.security_id", ondelete="SET NULL"),
         index=True,
         nullable=True,
     )

--- a/backend/app/models/planning_models.py
+++ b/backend/app/models/planning_models.py
@@ -1,32 +1,27 @@
-# backend/app/models/planning.py
-# --- Planning Features
+"""Relational models for planning scenarios, bills, and allocations."""
+
+from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 from app.extensions import db
 from sqlalchemy import CheckConstraint, Index
 from sqlalchemy.dialects.postgresql import UUID
 
+from .mixins import TimestampMixin
+
 AllocationType = db.Enum("fixed", "percent", name="allocation_type")
 
 
-class PlanningScenario(db.Model):
+class PlanningScenario(db.Model, TimestampMixin):
+    """Financial planning scenario grouping bills and target allocations."""
+
     __tablename__ = "planning_scenarios"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(120), nullable=False)
 
-    created_at = db.Column(
-        db.DateTime, default=datetime.now(tz=timezone.utc), nullable=False
-    )
-    updated_at = db.Column(
-        db.DateTime,
-        default=datetime.now(tz=timezone.utc),
-        onupdate=datetime.now(tz=timezone.utc),
-        nullable=False,
-    )
-
+    #: Relationship to all bills associated with the scenario.
     bills = db.relationship(
         "PlannedBill",
         backref="scenario",
@@ -34,6 +29,7 @@ class PlanningScenario(db.Model):
         passive_deletes=True,
         lazy="selectin",
     )
+    #: Relationship to all allocations associated with the scenario.
     allocations = db.relationship(
         "ScenarioAllocation",
         backref="scenario",
@@ -43,7 +39,9 @@ class PlanningScenario(db.Model):
     )
 
 
-class PlannedBill(db.Model):
+class PlannedBill(db.Model, TimestampMixin):
+    """Upcoming bill expected within a planning scenario."""
+
     __tablename__ = "planned_bills"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -60,23 +58,15 @@ class PlannedBill(db.Model):
     category = db.Column(db.String(80), nullable=True)
     predicted = db.Column(db.Boolean, default=False, nullable=False)
 
-    created_at = db.Column(
-        db.DateTime, default=datetime.now(tz=timezone.utc), nullable=False
-    )
-    updated_at = db.Column(
-        db.DateTime,
-        default=datetime.now(tz=timezone.utc),
-        onupdate=datetime.now(tz=timezone.utc),
-        nullable=False,
-    )
-
     __table_args__ = (
         CheckConstraint("amount_cents >= 0", name="ck_planned_bills_amount_nonneg"),
         Index("ix_planned_bills_scenario_due", "scenario_id", "due_date"),
     )
 
 
-class ScenarioAllocation(db.Model):
+class ScenarioAllocation(db.Model, TimestampMixin):
+    """Funding allocation target scoped to a planning scenario."""
+
     __tablename__ = "scenario_allocations"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -91,16 +81,6 @@ class ScenarioAllocation(db.Model):
     kind = db.Column(AllocationType, nullable=False)
     value = db.Column(db.Integer, nullable=False)
 
-    created_at = db.Column(
-        db.DateTime, default=datetime.now(tz=timezone.utc), nullable=False
-    )
-    updated_at = db.Column(
-        db.DateTime,
-        default=datetime.now(tz=timezone.utc),
-        onupdate=datetime.now(tz=timezone.utc),
-        nullable=False,
-    )
-
     __table_args__ = (
         CheckConstraint(
             "(kind = 'fixed' AND value >= 0) OR (kind = 'percent' AND value BETWEEN 0 AND 100)",
@@ -108,6 +88,3 @@ class ScenarioAllocation(db.Model):
         ),
         Index("ix_allocations_scenario_kind", "scenario_id", "kind"),
     )
-
-
-# End of models/planning.py

--- a/backend/app/models/transaction_models.py
+++ b/backend/app/models/transaction_models.py
@@ -19,7 +19,9 @@ class Category(db.Model):
     pfc_detailed = db.Column(db.String(64), nullable=True)
     pfc_icon_url = db.Column(db.String(256), nullable=True)
     display_name = db.Column(db.String(256), default="Unknown")
-    parent_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    parent_id = db.Column(
+        db.Integer, db.ForeignKey("categories.id", ondelete="SET NULL"), nullable=True
+    )
     parent = db.relationship("Category", remote_side=[id])
 
     __table_args__ = (
@@ -41,7 +43,9 @@ class Transaction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.String(64), nullable=True, index=True)
     transaction_id = db.Column(db.String(64), unique=True, nullable=False, index=True)
-    account_id = db.Column(db.String(64), db.ForeignKey("accounts.account_id"))
+    account_id = db.Column(
+        db.String(64), db.ForeignKey("accounts.account_id", ondelete="CASCADE")
+    )
     amount = db.Column(db.Numeric(18, 2), nullable=False, default=Decimal("0.00"))
     date = db.Column(db.DateTime(timezone=True), nullable=False)
     description = db.Column(db.String(256))
@@ -51,7 +55,9 @@ class Transaction(db.Model):
     user_modified = db.Column(db.Boolean, default=False)
     user_modified_fields = db.Column(db.Text)
     updated_by_rule = db.Column(db.Boolean, default=False)
-    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"))
+    category_id = db.Column(
+        db.Integer, db.ForeignKey("categories.id", ondelete="SET NULL")
+    )
     category = db.Column(db.String(128))
     personal_finance_category = db.Column(db.JSON, nullable=True)
     personal_finance_category_icon_url = db.Column(db.String, nullable=True)
@@ -79,11 +85,16 @@ class RecurringTransaction(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     transaction_id = db.Column(
-        db.String(64), db.ForeignKey("transactions.transaction_id"), nullable=False
+        db.String(64),
+        db.ForeignKey("transactions.transaction_id", ondelete="CASCADE"),
+        nullable=False,
     )
     transaction = db.relationship("Transaction", backref="recurrence_rule")
     account_id = db.Column(
-        db.String(64), db.ForeignKey("accounts.account_id"), nullable=False, index=True
+        db.String(64),
+        db.ForeignKey("accounts.account_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     frequency = db.Column(db.String(64), nullable=False)
     next_due_date = db.Column(db.Date, nullable=False)
@@ -112,7 +123,7 @@ class PlaidTransactionMeta(db.Model, TimestampMixin):
     id = db.Column(db.Integer, primary_key=True)
     transaction_id = db.Column(
         db.String(64),
-        db.ForeignKey("transactions.transaction_id"),
+        db.ForeignKey("transactions.transaction_id", ondelete="CASCADE"),
         unique=True,
         nullable=False,
     )
@@ -121,7 +132,9 @@ class PlaidTransactionMeta(db.Model, TimestampMixin):
     )
 
     plaid_account_id = db.Column(
-        db.String(64), db.ForeignKey("plaid_accounts.account_id"), nullable=False
+        db.String(64),
+        db.ForeignKey("plaid_accounts.account_id", ondelete="CASCADE"),
+        nullable=False,
     )
     plaid_account = db.relationship("PlaidAccount", backref="transaction_meta")
 

--- a/backend/migrations/versions/8f2b541c2d5a_ondelete_rules.py
+++ b/backend/migrations/versions/8f2b541c2d5a_ondelete_rules.py
@@ -1,0 +1,367 @@
+"""Align foreign key ON DELETE rules with application expectations."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8f2b541c2d5a"
+down_revision = "4b9af1d3db6d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("accounts") as batch_op:
+        batch_op.drop_constraint("accounts_institution_db_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("account_history") as batch_op:
+        batch_op.drop_constraint("account_history_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "account_history_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("financial_goals") as batch_op:
+        batch_op.drop_constraint("financial_goals_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "financial_goals_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("plaid_accounts") as batch_op:
+        batch_op.drop_constraint("plaid_accounts_account_id_fkey", type_="foreignkey")
+        batch_op.drop_constraint(
+            "plaid_accounts_institution_db_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "plaid_accounts_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "plaid_accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("teller_accounts") as batch_op:
+        batch_op.drop_constraint("teller_accounts_account_id_fkey", type_="foreignkey")
+        batch_op.drop_constraint(
+            "teller_accounts_institution_db_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "teller_accounts_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "teller_accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("categories") as batch_op:
+        batch_op.drop_constraint("categories_parent_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "categories_parent_id_fkey",
+            "categories",
+            ["parent_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.drop_constraint("transactions_account_id_fkey", type_="foreignkey")
+        batch_op.drop_constraint("transactions_category_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "transactions_category_id_fkey",
+            "categories",
+            ["category_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        batch_op.drop_constraint(
+            "recurring_transactions_transaction_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "recurring_transactions_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "recurring_transactions_transaction_id_fkey",
+            "transactions",
+            ["transaction_id"],
+            ["transaction_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "recurring_transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("plaid_transaction_meta") as batch_op:
+        batch_op.drop_constraint(
+            "plaid_transaction_meta_transaction_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "plaid_transaction_meta_plaid_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "plaid_transaction_meta_transaction_id_fkey",
+            "transactions",
+            ["transaction_id"],
+            ["transaction_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "plaid_transaction_meta_plaid_account_id_fkey",
+            "plaid_accounts",
+            ["plaid_account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("investment_holdings") as batch_op:
+        batch_op.drop_constraint(
+            "investment_holdings_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "investment_holdings_security_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "investment_holdings_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "investment_holdings_security_id_fkey",
+            "securities",
+            ["security_id"],
+            ["security_id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("investment_transactions") as batch_op:
+        batch_op.drop_constraint(
+            "investment_transactions_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "investment_transactions_security_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "investment_transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "investment_transactions_security_id_fkey",
+            "securities",
+            ["security_id"],
+            ["security_id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("investment_transactions") as batch_op:
+        batch_op.drop_constraint(
+            "investment_transactions_security_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "investment_transactions_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "investment_transactions_security_id_fkey",
+            "securities",
+            ["security_id"],
+            ["security_id"],
+        )
+        batch_op.create_foreign_key(
+            "investment_transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("investment_holdings") as batch_op:
+        batch_op.drop_constraint(
+            "investment_holdings_security_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "investment_holdings_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "investment_holdings_security_id_fkey",
+            "securities",
+            ["security_id"],
+            ["security_id"],
+        )
+        batch_op.create_foreign_key(
+            "investment_holdings_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("plaid_transaction_meta") as batch_op:
+        batch_op.drop_constraint(
+            "plaid_transaction_meta_plaid_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "plaid_transaction_meta_transaction_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "plaid_transaction_meta_plaid_account_id_fkey",
+            "plaid_accounts",
+            ["plaid_account_id"],
+            ["account_id"],
+        )
+        batch_op.create_foreign_key(
+            "plaid_transaction_meta_transaction_id_fkey",
+            "transactions",
+            ["transaction_id"],
+            ["transaction_id"],
+        )
+
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        batch_op.drop_constraint(
+            "recurring_transactions_account_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "recurring_transactions_transaction_id_fkey", type_="foreignkey"
+        )
+        batch_op.create_foreign_key(
+            "recurring_transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+        batch_op.create_foreign_key(
+            "recurring_transactions_transaction_id_fkey",
+            "transactions",
+            ["transaction_id"],
+            ["transaction_id"],
+        )
+
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.drop_constraint("transactions_category_id_fkey", type_="foreignkey")
+        batch_op.drop_constraint("transactions_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "transactions_category_id_fkey",
+            "categories",
+            ["category_id"],
+            ["id"],
+        )
+        batch_op.create_foreign_key(
+            "transactions_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("categories") as batch_op:
+        batch_op.drop_constraint("categories_parent_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "categories_parent_id_fkey",
+            "categories",
+            ["parent_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("teller_accounts") as batch_op:
+        batch_op.drop_constraint(
+            "teller_accounts_institution_db_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint("teller_accounts_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "teller_accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+        )
+        batch_op.create_foreign_key(
+            "teller_accounts_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("plaid_accounts") as batch_op:
+        batch_op.drop_constraint(
+            "plaid_accounts_institution_db_id_fkey", type_="foreignkey"
+        )
+        batch_op.drop_constraint("plaid_accounts_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "plaid_accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+        )
+        batch_op.create_foreign_key(
+            "plaid_accounts_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("financial_goals") as batch_op:
+        batch_op.drop_constraint("financial_goals_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "financial_goals_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("account_history") as batch_op:
+        batch_op.drop_constraint("account_history_account_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "account_history_account_id_fkey",
+            "accounts",
+            ["account_id"],
+            ["account_id"],
+        )
+
+    with op.batch_alter_table("accounts") as batch_op:
+        batch_op.drop_constraint("accounts_institution_db_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "accounts_institution_db_id_fkey",
+            "institutions",
+            ["institution_db_id"],
+            ["id"],
+        )

--- a/tests/test_api_planning.py
+++ b/tests/test_api_planning.py
@@ -12,7 +12,7 @@ import os
 import sys
 import types
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -89,7 +89,9 @@ class PlanningScenario:
         self.name = name
         self.bills: list[PlannedBill] = []  # type: ignore[name-defined]
         self.allocations: list[ScenarioAllocation] = []  # type: ignore[name-defined]
-        self.created_at = date.today()
+        now = datetime.now(timezone.utc)
+        self.created_at = now
+        self.updated_at = now
 
 
 class PlannedBill:

--- a/tests/test_model_deletion_behaviors.py
+++ b/tests/test_model_deletion_behaviors.py
@@ -28,8 +28,8 @@ from app.models import (  # noqa: E402
     InvestmentTransaction,
     PlaidAccount,
     PlaidTransactionMeta,
-    PlanningScenario,
     PlannedBill,
+    PlanningScenario,
     RecurringTransaction,
     ScenarioAllocation,
     Security,
@@ -205,7 +205,9 @@ def test_category_delete_retains_transactions(app_context):
     db.session.commit()
 
     assert db.session.get(Category, child.id).parent_id is None
-    remaining_txn = db.session.query(Transaction).filter_by(transaction_id="txn-2").one()
+    remaining_txn = (
+        db.session.query(Transaction).filter_by(transaction_id="txn-2").one()
+    )
     assert remaining_txn.category_id is None
 
 

--- a/tests/test_model_deletion_behaviors.py
+++ b/tests/test_model_deletion_behaviors.py
@@ -1,0 +1,273 @@
+"""Integration tests covering database cascade semantics and mixin timestamps."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+from flask import Flask
+from sqlalchemy import text
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+if BASE_BACKEND not in sys.path:
+    sys.path.insert(0, BASE_BACKEND)
+
+from app.extensions import db  # noqa: E402
+from app.models import (  # noqa: E402
+    Account,
+    AccountGroup,
+    AccountGroupMembership,
+    AccountHistory,
+    Category,
+    FinancialGoal,
+    Institution,
+    InvestmentHolding,
+    InvestmentTransaction,
+    PlaidAccount,
+    PlaidTransactionMeta,
+    PlanningScenario,
+    PlannedBill,
+    RecurringTransaction,
+    ScenarioAllocation,
+    Security,
+    TellerAccount,
+    Transaction,
+)
+
+
+@pytest.fixture()
+def app_context():
+    """Provide an application context backed by an in-memory SQLite database."""
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        db.session.execute(text("PRAGMA foreign_keys = ON"))
+        yield
+        db.session.remove()
+        db.drop_all()
+
+
+def test_institution_delete_cascades_account_tree(app_context):
+    """Deleting an institution removes dependent accounts and related records."""
+
+    institution = Institution(name="Cascade Bank", provider="Plaid")
+    db.session.add(institution)
+    db.session.commit()
+
+    account = Account(
+        account_id="acct-1",
+        name="Primary",
+        type="depository",
+        institution_name="Cascade",
+        institution_db_id=institution.id,
+    )
+    db.session.add(account)
+    db.session.flush()
+
+    db.session.add_all(
+        [
+            AccountHistory(
+                account_id=account.account_id,
+                user_id="user-1",
+                date=datetime.now(timezone.utc),
+                balance=Decimal("10.00"),
+            ),
+            FinancialGoal(
+                user_id="user-1",
+                account_id=account.account_id,
+                name="Emergency Fund",
+                target_amount=Decimal("1000.00"),
+                due_date=date(2025, 1, 1),
+            ),
+            PlaidAccount(
+                account_id=account.account_id,
+                access_token="token",
+                item_id="item-1",
+                product="transactions",
+            ),
+            TellerAccount(
+                account_id=account.account_id,
+                access_token="token",
+            ),
+        ]
+    )
+
+    category = Category(primary_category="Bills", detailed_category="Utilities")
+    db.session.add(category)
+    db.session.flush()
+
+    transaction = Transaction(
+        transaction_id="txn-1",
+        account_id=account.account_id,
+        amount=Decimal("25.00"),
+        date=datetime.now(timezone.utc),
+    )
+    transaction.category_id = category.id
+    db.session.add(transaction)
+    db.session.flush()
+
+    db.session.add_all(
+        [
+            PlaidTransactionMeta(
+                transaction_id=transaction.transaction_id,
+                plaid_account_id=account.account_id,
+            ),
+            RecurringTransaction(
+                transaction_id=transaction.transaction_id,
+                account_id=account.account_id,
+                frequency="monthly",
+                next_due_date=date(2025, 1, 1),
+            ),
+        ]
+    )
+
+    security = Security(security_id="sec-1", name="Fund")
+    db.session.add(security)
+    db.session.flush()
+
+    db.session.add_all(
+        [
+            InvestmentHolding(
+                account_id=account.account_id,
+                security_id=security.security_id,
+                quantity=Decimal("1"),
+            ),
+            InvestmentTransaction(
+                investment_transaction_id="inv-1",
+                account_id=account.account_id,
+                security_id=security.security_id,
+                amount=Decimal("5.00"),
+            ),
+        ]
+    )
+
+    group = AccountGroup(user_id="user-1", name="Group")
+    db.session.add(group)
+    db.session.flush()
+
+    db.session.add(
+        AccountGroupMembership(group_id=group.id, account_id=account.account_id)
+    )
+    db.session.commit()
+
+    db.session.delete(institution)
+    db.session.commit()
+
+    assert db.session.query(Account).count() == 0
+    assert db.session.query(AccountHistory).count() == 0
+    assert db.session.query(FinancialGoal).count() == 0
+    assert db.session.query(Transaction).count() == 0
+    assert db.session.query(RecurringTransaction).count() == 0
+    assert db.session.query(PlaidTransactionMeta).count() == 0
+    assert db.session.query(PlaidAccount).count() == 0
+    assert db.session.query(TellerAccount).count() == 0
+    assert db.session.query(InvestmentHolding).count() == 0
+    assert db.session.query(InvestmentTransaction).count() == 0
+    assert db.session.query(AccountGroupMembership).count() == 0
+    assert db.session.query(AccountGroup).count() == 1
+
+
+def test_category_delete_retains_transactions(app_context):
+    """Deleting a category preserves dependent rows but clears their foreign keys."""
+
+    category = Category(primary_category="Parent", detailed_category="Parent")
+    child = Category(
+        primary_category="Child",
+        detailed_category="Child",
+        parent=category,
+    )
+    db.session.add_all([category, child])
+
+    account = Account(account_id="acct-2", name="Secondary", type="other")
+    db.session.add(account)
+    db.session.flush()
+
+    txn = Transaction(
+        transaction_id="txn-2",
+        account_id=account.account_id,
+        amount=Decimal("15.00"),
+        date=datetime.now(timezone.utc),
+    )
+    txn.category_id = category.id
+    db.session.add(txn)
+    db.session.commit()
+
+    db.session.delete(category)
+    db.session.commit()
+
+    assert db.session.get(Category, child.id).parent_id is None
+    remaining_txn = db.session.query(Transaction).filter_by(transaction_id="txn-2").one()
+    assert remaining_txn.category_id is None
+
+
+def test_security_delete_sets_transaction_security_null(app_context):
+    """Security deletion cascades holdings while retaining transactions with NULL FKs."""
+
+    security = Security(security_id="sec-2", name="Stock")
+    account = Account(account_id="acct-3", name="Brokerage", type="brokerage")
+    db.session.add_all([security, account])
+    db.session.flush()
+
+    holding = InvestmentHolding(
+        account_id=account.account_id,
+        security_id=security.security_id,
+        quantity=Decimal("2"),
+    )
+    txn = InvestmentTransaction(
+        investment_transaction_id="inv-2",
+        account_id=account.account_id,
+        security_id=security.security_id,
+        amount=Decimal("20.00"),
+    )
+    db.session.add_all([holding, txn])
+    db.session.commit()
+
+    db.session.delete(security)
+    db.session.commit()
+
+    assert db.session.query(InvestmentHolding).count() == 0
+    remaining_txn = (
+        db.session.query(InvestmentTransaction)
+        .filter_by(investment_transaction_id="inv-2")
+        .one()
+    )
+    assert remaining_txn.security_id is None
+
+
+def test_planning_models_use_timestamp_mixin(app_context):
+    """Planning models should automatically populate created/updated timestamps."""
+
+    scenario = PlanningScenario(name="Baseline")
+    scenario.bills.append(
+        PlannedBill(name="Rent", amount_cents=120000, due_date=None, predicted=False)
+    )
+    scenario.allocations.append(
+        ScenarioAllocation(target="Savings", kind="percent", value=20)
+    )
+
+    db.session.add(scenario)
+    db.session.commit()
+
+    assert scenario.created_at is not None
+    assert scenario.updated_at is not None
+    bill = scenario.bills[0]
+    alloc = scenario.allocations[0]
+    assert bill.created_at is not None
+    assert bill.updated_at is not None
+    assert alloc.created_at is not None
+    assert alloc.updated_at is not None
+
+    original_updated = scenario.updated_at
+    scenario.name = "Updated Baseline"
+    db.session.commit()
+    db.session.refresh(scenario)
+    assert scenario.updated_at >= original_updated


### PR DESCRIPTION
## Summary
- add explicit `ondelete` rules across account, institution, investment, and transaction models while refactoring planning models to use the shared `TimestampMixin`
- generate an Alembic migration that updates foreign key constraints to match the ORM semantics
- extend the test suite with cascade/timestamp coverage and align the planning API stub with the mixin fields

## Testing
- `pre-commit run --all-files` *(fails: command not found in CI container)*
- `pytest` *(fails: missing optional dependencies such as Flask/FastAPI/pdfplumber in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e09b9322e48329890463fdfa4c2fb3