### PR TITLE
Document Stake integration audit

### DIFF
--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -15,6 +15,7 @@
 - [Dataflow](../dataflow/) – data movement and transformations
 - [Forecast](../forecast/) – financial forecasting docs
 - [Integrations](../integrations/) – third-party connections
+- [Stake Cleanup Audit](../integrations/stake_cleanup.md) – confirmation that the legacy Stake integration has no remaining code paths
 - [Internal](../internal/) – internal notes
 - [Codex](../codex/) – exploratory reports
 - [Latest](../latest/) – recent drafts and experiments

--- a/docs/integrations/stake_cleanup.md
+++ b/docs/integrations/stake_cleanup.md
@@ -1,0 +1,27 @@
+# Stake Integration Cleanup Audit
+
+## Overview
+
+An audit was requested to identify any remaining code that supports the legacy
+Stake brokerage integration.
+
+## Backend API review
+
+- Searched `backend/app/routes` and `backend/app/services` for any modules,
+  blueprints, or functions referencing "stake".
+- No Flask blueprints, FastAPI routers, or background tasks matching that name
+  were found.
+- Existing API documentation (`docs/API_REFERENCE.md`) also contains no Stake
+  endpoints.
+
+## Frontend review
+
+- Scanned `frontend/src` (components, views, stores, and services) for strings
+  or filenames containing "stake".
+- No client-side API calls, routes, or UI components related to Stake are
+  present.
+
+## Conclusion
+
+There is no Stake-specific code or API route in the current repository. No
+changes are required beyond keeping this audit record for future reference.


### PR DESCRIPTION
## Summary
- add a Stake integration cleanup audit documenting that no Stake-specific code or API routes remain
- link the audit from the documentation index for easier discovery

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3172450c88329b972c7dd7bd2c328