### PR TITLE
Add Done control to Account Snapshot editing

### DIFF
--- a/frontend/src/components/widgets/TopAccountSnapshot.vue
+++ b/frontend/src/components/widgets/TopAccountSnapshot.vue
@@ -123,6 +123,16 @@
           </ul>
         </Transition>
       </div>
+
+      <button
+        v-if="isEditingGroups"
+        type="button"
+        class="bs-done-btn gradient-toggle-btn"
+        @click="finishEditingSession"
+        aria-label="Finish editing account groups"
+      >
+        Done
+      </button>
     </div>
 
     <!-- Render draggable without container Transition to avoid DOM detachment issues -->
@@ -471,6 +481,15 @@ function toggleEditGroups() {
   showGroupMenu.value = false
 }
 
+function finishEditingSession() {
+  if (!isEditingGroups.value) return
+  persistGroupOrder()
+  persistAccountOrder()
+  isEditingGroups.value = false
+  emit('update:isEditingGroups', false)
+  showGroupMenu.value = false
+}
+
 /** Enable editing for a group tab */
 function startEdit(id) {
   editingGroupId.value = id
@@ -589,6 +608,7 @@ defineExpose({
   groupAccounts,
   groupAccent,
   isEditingGroups,
+  finishEditingSession,
   selectedAccountId,
   showAccountSelector,
   startAddAccount,
@@ -862,6 +882,19 @@ defineExpose({
 }
 
 .bs-group-btn:focus-visible {
+  outline: none;
+}
+
+.bs-done-btn {
+  padding: 0.35rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bs-done-btn:focus-visible {
   outline: none;
 }
 

--- a/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
+++ b/frontend/src/components/widgets/__tests__/TopAccountSnapshot.spec.js
@@ -178,6 +178,25 @@ describe('TopAccountSnapshot', () => {
     expect(wrapper.vm.isEditingGroups.value).toBe(true)
   })
 
+  it('shows a Done button while editing that exits edit mode and emits updates', async () => {
+    const wrapper = mount(TopAccountSnapshot, {
+      props: { isEditingGroups: true },
+      global: { stubs: { AccountSparkline: true } },
+    })
+
+    await nextTick()
+
+    const doneButton = wrapper.find('button.bs-done-btn')
+    expect(doneButton.exists()).toBe(true)
+
+    await doneButton.trigger('click')
+    await nextTick()
+
+    expect(wrapper.vm.$.exposed.isEditingGroups.value).toBe(false)
+    const updates = wrapper.emitted()['update:isEditingGroups'] || []
+    expect(updates.at(-1)).toEqual([false])
+  })
+
   it('truncates group names longer than 30 characters with ellipsis', async () => {
     const wrapper = mount(TopAccountSnapshot, {
       global: { stubs: { AccountSparkline: true } },


### PR DESCRIPTION
## Summary
- add a persistent Done button to the account snapshot widget while groups are being edited
- call the existing persistence helpers before leaving edit mode so ordering and membership stay saved
- cover the new Done interaction with a focused unit test

## Testing
- npx vitest run src/components/widgets/__tests__/TopAccountSnapshot.spec.js -t "Done button"

------
https://chatgpt.com/codex/tasks/task_e_68e3797964748329a1937c9a725ba8b1