### PR TITLE
refactor: remove Teller backend branches

### DIFF
--- a/backend/app/helpers/account_refresh_dispatcher.py
+++ b/backend/app/helpers/account_refresh_dispatcher.py
@@ -31,10 +31,10 @@ def is_due(last_synced, provider):
 
 
 def refresh_all_accounts():
-    """
-    Refreshes all linked accounts by provider type (Plaid)
-    if they are due for sync based on ``SYNC_INTERVALS``.
-    Requires that the caller already created a Flask ``app_context``.
+    """Refresh Plaid-linked accounts that are due for sync.
+
+    The caller must ensure a Flask ``app_context`` is active so database updates
+    persist. Accounts that are not Plaid-linked are skipped with a warning.
     """
     logger.info("🔁 Starting account refresh dispatcher...")
 
@@ -47,15 +47,9 @@ def refresh_all_accounts():
 
         if provider == "plaid":
             rel = acct.plaid_account
-        elif provider == "teller":
-            logger.info(
-                "Skipping Teller account %s because the integration was retired.",
-                acct.id,
-            )
-            skipped += 1
-            continue
         else:
             logger.warning(f"⚠️ Unknown provider for account {acct.id}")
+            skipped += 1
             continue
 
         last_synced = getattr(rel, "last_refreshed", None)

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -9,8 +9,10 @@ from app.config import logger
 from app.extensions import db
 from app.models import Account, PlaidItem, RecurringTransaction, Transaction
 from app.sql.forecast_logic import update_account_history
-from app.utils.finance_utils import (display_transaction_amount,
-                                     normalize_account_balance)
+from app.utils.finance_utils import (
+    display_transaction_amount,
+    normalize_account_balance,
+)
 from flask import Blueprint, jsonify, request
 
 # Blueprint for generic accounts routes
@@ -201,9 +203,9 @@ def refresh_all_accounts():
 
                                 if err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
                                     error_map[key]["requires_reauth"] = True
-                                    error_map[key][
-                                        "update_link_token_endpoint"
-                                    ] = "/api/plaid/transactions/generate_update_link_token"
+                                    error_map[key]["update_link_token_endpoint"] = (
+                                        "/api/plaid/transactions/generate_update_link_token"
+                                    )
                                     error_map[key]["affected_account_ids"] = [
                                         account.account_id
                                     ]

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -5,14 +5,12 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
-from app.config import DIRECTORIES, FILES, logger
+from app.config import logger
 from app.extensions import db
 from app.models import Account, PlaidItem, RecurringTransaction, Transaction
 from app.sql.forecast_logic import update_account_history
-from app.utils.finance_utils import (
-    display_transaction_amount,
-    normalize_account_balance,
-)
+from app.utils.finance_utils import (display_transaction_amount,
+                                     normalize_account_balance)
 from flask import Blueprint, jsonify, request
 
 # Blueprint for generic accounts routes
@@ -203,9 +201,9 @@ def refresh_all_accounts():
 
                                 if err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
                                     error_map[key]["requires_reauth"] = True
-                                    error_map[key]["update_link_token_endpoint"] = (
-                                        "/api/plaid/transactions/generate_update_link_token"
-                                    )
+                                    error_map[key][
+                                        "update_link_token_endpoint"
+                                    ] = "/api/plaid/transactions/generate_update_link_token"
                                     error_map[key]["affected_account_ids"] = [
                                         account.account_id
                                     ]
@@ -321,7 +319,7 @@ def refresh_all_accounts():
 
 @accounts.route("/<account_id>/refresh", methods=["POST"])
 def refresh_single_account(account_id):
-    """Refresh a single account for its enabled product set."""
+    """Refresh a single Plaid-linked account for its enabled product set."""
     from app.sql import account_logic
 
     data = request.get_json() or {}
@@ -334,120 +332,107 @@ def refresh_single_account(account_id):
 
     updated = False
 
-    if account.link_type == "Plaid":
-        token = getattr(account.plaid_account, "access_token", None)
-        if not token:
-            return (
-                jsonify({"status": "error", "message": "Missing Plaid token"}),
-                400,
-            )
-        products = _plaid_products_for_account(account)
-        plaid_updated = False
-
-        for product_name in products:
-            if product_name == "transactions":
-                updated_flag, err = account_logic.refresh_data_for_plaid_account(
-                    token,
-                    account_id,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
-
-                if err and err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
-                    logger.warning(
-                        f"Plaid re-auth required for account {account.account_id}: {err.get('plaid_error_message')}. "
-                        "User must re-auth via Link update mode. Call POST /api/plaid/transactions/generate_update_link_token with account_id."
-                    )
-                    return (
-                        jsonify(
-                            {
-                                "status": "success",
-                                "updated": False,
-                                "requires_reauth": True,
-                                "update_link_token_endpoint": "/api/plaid/transactions/generate_update_link_token",
-                                "account_id": account.account_id,
-                                "error": {
-                                    "code": err.get("plaid_error_code"),
-                                    "message": err.get("plaid_error_message"),
-                                },
-                            }
-                        ),
-                        200,
-                    )
-                if err:
-                    logger.error(
-                        "Plaid error on single account refresh %s: %s",
-                        account.account_id,
-                        err,
-                    )
-                    return (
-                        jsonify(
-                            {
-                                "status": "error",
-                                "updated": False,
-                                "message": f"Plaid error: {err.get('plaid_error_message', 'Unknown error')}",
-                                "error": err,
-                            }
-                        ),
-                        502,
-                    )
-                plaid_updated = plaid_updated or updated_flag
-                if updated_flag and account.plaid_account:
-                    account.plaid_account.last_refreshed = datetime.now(timezone.utc)
-            elif product_name == "investments":
-                try:
-                    investments_updated = _refresh_plaid_investments(
-                        account,
-                        token,
-                        start_date=start_date,
-                        end_date=end_date,
-                    )
-                    plaid_updated = plaid_updated or investments_updated
-                    if account.plaid_account:
-                        account.plaid_account.last_refreshed = datetime.now(
-                            timezone.utc
-                        )
-                except Exception as exc:
-                    logger.error(
-                        "Plaid investments refresh failed for account %s: %s",
-                        account.account_id,
-                        exc,
-                        exc_info=True,
-                    )
-                    return (
-                        jsonify(
-                            {
-                                "status": "error",
-                                "updated": False,
-                                "message": "Plaid investments refresh failed.",
-                            }
-                        ),
-                        502,
-                    )
-            else:
-                logger.info(
-                    "Skipping unsupported Plaid product %s for account %s",
-                    product_name,
-                    account.account_id,
-                )
-
-        updated = plaid_updated
-
-    elif account.link_type == "Teller":
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": "Teller integration has been removed.",
-                }
-            ),
-            410,
-        )
-    else:
+    if account.link_type != "Plaid":
         return (
             jsonify({"status": "error", "message": "Unsupported link type"}),
             400,
         )
+
+    token = getattr(account.plaid_account, "access_token", None)
+    if not token:
+        return (
+            jsonify({"status": "error", "message": "Missing Plaid token"}),
+            400,
+        )
+    products = _plaid_products_for_account(account)
+    plaid_updated = False
+
+    for product_name in products:
+        if product_name == "transactions":
+            updated_flag, err = account_logic.refresh_data_for_plaid_account(
+                token,
+                account_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            if err and err.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
+                logger.warning(
+                    f"Plaid re-auth required for account {account.account_id}: {err.get('plaid_error_message')}. "
+                    "User must re-auth via Link update mode. Call POST /api/plaid/transactions/generate_update_link_token with account_id."
+                )
+                return (
+                    jsonify(
+                        {
+                            "status": "success",
+                            "updated": False,
+                            "requires_reauth": True,
+                            "update_link_token_endpoint": "/api/plaid/transactions/generate_update_link_token",
+                            "account_id": account.account_id,
+                            "error": {
+                                "code": err.get("plaid_error_code"),
+                                "message": err.get("plaid_error_message"),
+                            },
+                        }
+                    ),
+                    200,
+                )
+            if err:
+                logger.error(
+                    "Plaid error on single account refresh %s: %s",
+                    account.account_id,
+                    err,
+                )
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "updated": False,
+                            "message": f"Plaid error: {err.get('plaid_error_message', 'Unknown error')}",
+                            "error": err,
+                        }
+                    ),
+                    502,
+                )
+            plaid_updated = plaid_updated or updated_flag
+            if updated_flag and account.plaid_account:
+                account.plaid_account.last_refreshed = datetime.now(timezone.utc)
+        elif product_name == "investments":
+            try:
+                investments_updated = _refresh_plaid_investments(
+                    account,
+                    token,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+                plaid_updated = plaid_updated or investments_updated
+                if account.plaid_account:
+                    account.plaid_account.last_refreshed = datetime.now(timezone.utc)
+            except Exception as exc:
+                logger.error(
+                    "Plaid investments refresh failed for account %s: %s",
+                    account.account_id,
+                    exc,
+                    exc_info=True,
+                )
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "updated": False,
+                            "message": "Plaid investments refresh failed.",
+                        }
+                    ),
+                    502,
+                )
+        else:
+            logger.info(
+                "Skipping unsupported Plaid product %s for account %s",
+                product_name,
+                account.account_id,
+            )
+
+    updated = plaid_updated
 
     if updated:
         db.session.commit()

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -10,8 +10,7 @@ from app.config import FILES, logger
 from app.extensions import db
 from app.helpers.normalize import normalize_amount
 from app.helpers.plaid_helpers import get_accounts, get_transactions
-from app.models import (Account, AccountHistory, Category, PlaidAccount,
-                        Transaction)
+from app.models import Account, AccountHistory, Category, PlaidAccount, Transaction
 from app.sql import transaction_rules_logic
 from app.sql.dialect_utils import dialect_insert
 from app.sql.refresh_metadata import refresh_or_insert_plaid_metadata

--- a/backend/app/sql/account_logic.py
+++ b/backend/app/sql/account_logic.py
@@ -1,19 +1,17 @@
 """Database persistence and refresh helpers for account data."""
 
 import json
-import time
 from datetime import date as pydate
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from tempfile import NamedTemporaryFile
 from typing import Optional
 
-import requests
 from app.config import FILES, logger
 from app.extensions import db
 from app.helpers.normalize import normalize_amount
 from app.helpers.plaid_helpers import get_accounts, get_transactions
-from app.models import Account, AccountHistory, Category, PlaidAccount, Transaction
+from app.models import (Account, AccountHistory, Category, PlaidAccount,
+                        Transaction)
 from app.sql import transaction_rules_logic
 from app.sql.dialect_utils import dialect_insert
 from app.sql.refresh_metadata import refresh_or_insert_plaid_metadata
@@ -158,7 +156,7 @@ def upsert_accounts(user_id, account_list, provider, access_token=None):
             name = account.get("name") or "Unnamed Account"
             acc_type = str(account.get("type") or "Unknown")
 
-            # ✅ Corrected Plaid/Teller-safe balance parsing
+            # ✅ Corrected Plaid balance parsing
             balance_raw = (
                 account.get("balances", {}).get("current")
                 or account.get("balance", {}).get("current")


### PR DESCRIPTION
## Summary
- update the account refresh route to reject non-Plaid providers and keep Plaid token handling intact
- streamline the account refresh dispatcher and sync service to only schedule Plaid accounts, with updated module docstrings
- clean up account logic imports and comments to remove lingering Teller references

## Testing
- black backend/app/routes/accounts.py backend/app/helpers/account_refresh_dispatcher.py backend/app/services/sync_service.py backend/app/sql/account_logic.py
- isort backend/app/routes/accounts.py backend/app/helpers/account_refresh_dispatcher.py backend/app/services/sync_service.py backend/app/sql/account_logic.py
- ruff check backend/app/routes/accounts.py backend/app/helpers/account_refresh_dispatcher.py backend/app/services/sync_service.py backend/app/sql/account_logic.py
- mypy backend/app/routes/accounts.py backend/app/helpers/account_refresh_dispatcher.py backend/app/services/sync_service.py backend/app/sql/account_logic.py *(fails: missing Flask/SQLAlchemy/plaid stubs and annotations in unrelated modules)*
- pytest *(fails: environment lacks Flask/FastAPI/sqlalchemy/pdfplumber dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e901f46483298872482ced61ee15