### PR TITLE
refactor: remove teller frontend integration hooks

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,20 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon-new.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finance Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <link rel="icon" href="/favicon-new.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Finance Dashboard</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;700&display=swap" rel="stylesheet">
-</head>
-
-<body>
-  <div id="app"></div>
-  <!-- This script loads your Vue app (using Vite or Vue CLI build) -->
-  <script type="module" src="/src/main.js"></script>
-</body>
-
+  <body>
+    <div id="app"></div>
+    <!-- This script loads your Vue app (using Vite or Vue CLI build) -->
+    <script type="module" src="/src/main.js"></script>
+  </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,8 +15,6 @@
   <div id="app"></div>
   <!-- This script loads your Vue app (using Vite or Vue CLI build) -->
   <script type="module" src="/src/main.js"></script>
-  <!-- Global scripts (e.g. Teller Connect) -->
-  <script src="https://cdn.teller.io/connect/connect.js"></script>
 </body>
 
 </html>

--- a/frontend/src/api/accounts_link.js
+++ b/frontend/src/api/accounts_link.js
@@ -8,52 +8,37 @@ const apiClient = axios.create({
 })
 
 export default {
-  async generateLinkToken(provider, payload = {}) {
-    let url = ""
-    if (provider === "plaid") {
-      const products = payload.products || []
-      const isInvestments = products.length === 1 && products[0] === "investments"
-      url = isInvestments
-        ? "/plaid/investments/generate_link_token"
-        : "/plaid/transactions/generate_link_token"
-    } else if (provider === "teller") {
-      url = "/teller/transactions/generate_link_token"
-    }
+  async generateLinkToken(payload = {}) {
+    const products = payload.products || []
+    const isInvestments = products.length === 1 && products[0] === "investments"
+    const url = isInvestments
+      ? "/plaid/investments/generate_link_token"
+      : "/plaid/transactions/generate_link_token"
+
     const response = await apiClient.post(url, payload)
     return response.data
   },
 
-  async saveTellerToken(data) {
-    const response = await apiClient.post("/teller/token", data)
-    return response.data
-  },
+  async exchangePublicToken(payload = {}) {
+    const products = payload.products || []
+    const url =
+      products.length === 1 && products[0] === "investments"
+        ? "/plaid/investments/exchange_public_token"
+        : "/plaid/transactions/exchange_public_token"
 
-  async exchangePublicToken(provider, payload) {
-    if (provider === "teller") {
-      console.warn("Teller does not use public token exchange.")
-      return { error: "Not supported for Teller" }
-    }
-    let url = `/${provider}/transactions/exchange_public_token`
-    if (provider === "plaid") {
-      const products = payload.products || []
-      if (products.length === 1 && products[0] === "investments") {
-        url = "/plaid/investments/exchange_public_token"
-      }
-    }
     const response = await apiClient.post(url, payload)
     return response.data
   },
 
-  async deleteAccount(provider, account_id) {
-    const urlMap = {
-      plaid: "/plaid/transactions/delete_account",
-      teller: "/teller/transactions/delete_account",
+  async deleteAccount(account_id) {
+    if (!account_id) {
+      throw new Error("account_id is required to delete an account")
     }
-    const url = urlMap[provider]
-    if (!url) return
 
     try {
-      const response = await apiClient.delete(url, { data: { account_id } })
+      const response = await apiClient.delete("/plaid/transactions/delete_account", {
+        data: { account_id },
+      })
       return response.data
     } catch (error) {
       console.error("Failed to delete account:", error)

--- a/frontend/src/api/accounts_link.js
+++ b/frontend/src/api/accounts_link.js
@@ -1,19 +1,19 @@
-import axios from "axios"
+import axios from 'axios'
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_APP_API_BASE_URL || "/api",
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL || '/api',
   headers: {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   },
 })
 
 export default {
   async generateLinkToken(payload = {}) {
     const products = payload.products || []
-    const isInvestments = products.length === 1 && products[0] === "investments"
+    const isInvestments = products.length === 1 && products[0] === 'investments'
     const url = isInvestments
-      ? "/plaid/investments/generate_link_token"
-      : "/plaid/transactions/generate_link_token"
+      ? '/plaid/investments/generate_link_token'
+      : '/plaid/transactions/generate_link_token'
 
     const response = await apiClient.post(url, payload)
     return response.data
@@ -22,9 +22,9 @@ export default {
   async exchangePublicToken(payload = {}) {
     const products = payload.products || []
     const url =
-      products.length === 1 && products[0] === "investments"
-        ? "/plaid/investments/exchange_public_token"
-        : "/plaid/transactions/exchange_public_token"
+      products.length === 1 && products[0] === 'investments'
+        ? '/plaid/investments/exchange_public_token'
+        : '/plaid/transactions/exchange_public_token'
 
     const response = await apiClient.post(url, payload)
     return response.data
@@ -32,16 +32,16 @@ export default {
 
   async deleteAccount(account_id) {
     if (!account_id) {
-      throw new Error("account_id is required to delete an account")
+      throw new Error('account_id is required to delete an account')
     }
 
     try {
-      const response = await apiClient.delete("/plaid/transactions/delete_account", {
+      const response = await apiClient.delete('/plaid/transactions/delete_account', {
         data: { account_id },
       })
       return response.data
     } catch (error) {
-      console.error("Failed to delete account:", error)
+      console.error('Failed to delete account:', error)
       throw error
     }
   },

--- a/frontend/src/api/teller.js
+++ b/frontend/src/api/teller.js
@@ -1,8 +1,0 @@
-
-// src/api/teller.js
-import axios from 'axios'
-
-export const saveTellerToken = async (data) => {
-  const response = await axios.post('/api/link/teller/save_token', data)
-  return response.data
-}

--- a/frontend/src/components/forms/LinkProviderLauncher.vue
+++ b/frontend/src/components/forms/LinkProviderLauncher.vue
@@ -1,16 +1,15 @@
 <template>
   <div class="section-container mt-4">
-    <h3 class="text-md font-medium mb-2">Link Provider</h3>
+    <h3 class="text-md font-medium mb-2">Link accounts with Plaid</h3>
+
+    <p class="text-sm text-neutral-400 mb-3">
+      Select at least one product to enable the Plaid Link flow.
+    </p>
 
     <div class="flex gap-2">
       <button class="btn btn-pill" :class="{ 'opacity-50 cursor-not-allowed': selectedProducts.length === 0 }"
         :disabled="selectedProducts.length === 0 || loading" @click="linkPlaid">
-        {{ loading && activeProvider === 'plaid' ? 'Linking...' : 'Link with Plaid' }}
-      </button>
-
-      <button class="btn btn-pill" :class="{ 'opacity-50 cursor-not-allowed': selectedProducts.length === 0 }"
-        :disabled="selectedProducts.length === 0 || loading" @click="linkTeller">
-        {{ loading && activeProvider === 'teller' ? 'Linking...' : 'Link with Teller.io' }}
+        {{ loading ? 'Linking…' : 'Link with Plaid' }}
       </button>
     </div>
   </div>
@@ -34,7 +33,6 @@ const props = defineProps({
 const emit = defineEmits(['refresh'])
 
 const loading = ref(false)
-const activeProvider = ref(null)
 
 async function ensurePlaidScript() {
   if (window.Plaid) return
@@ -52,12 +50,11 @@ async function ensurePlaidScript() {
 const linkPlaid = async () => {
   if (props.selectedProducts.length === 0) return
   loading.value = true
-  activeProvider.value = 'plaid'
 
   try {
     await ensurePlaidScript()
 
-    const { link_token } = await accountLinkApi.generateLinkToken('plaid', {
+    const { link_token } = await accountLinkApi.generateLinkToken({
       user_id: props.userId,
       products: props.selectedProducts,
     })
@@ -70,7 +67,7 @@ const linkPlaid = async () => {
     const handler = window.Plaid.create({
       token: link_token,
       onSuccess: async (public_token) => {
-        await accountLinkApi.exchangePublicToken('plaid', {
+        await accountLinkApi.exchangePublicToken({
           public_token,
           user_id: props.userId,
           products: props.selectedProducts,
@@ -87,35 +84,6 @@ const linkPlaid = async () => {
     console.error('Error linking Plaid:', e)
   } finally {
     loading.value = false
-    activeProvider.value = null
-  }
-}
-
-const linkTeller = async () => {
-  if (props.selectedProducts.length === 0) return
-  loading.value = true
-  activeProvider.value = 'teller'
-
-  try {
-    const connect = window.TellerConnect.setup({
-      applicationId: import.meta.env.VITE_TELLER_APP_ID,
-      environment: import.meta.env.VITE_TELLER_ENV || 'sandbox',
-      products: props.selectedProducts,
-      onSuccess: async (enrollment) => {
-        await accountLinkApi.exchangePublicToken('teller', {
-          public_token: enrollment.accessToken,
-          user_id: props.userId,
-        })
-        emit('refresh')
-      },
-    })
-
-    connect.open()
-  } catch (e) {
-    console.error('Error linking Teller:', e)
-  } finally {
-    loading.value = false
-    activeProvider.value = null
   }
 }
 </script>

--- a/frontend/src/components/forms/LinkProviderLauncher.vue
+++ b/frontend/src/components/forms/LinkProviderLauncher.vue
@@ -7,8 +7,12 @@
     </p>
 
     <div class="flex gap-2">
-      <button class="btn btn-pill" :class="{ 'opacity-50 cursor-not-allowed': selectedProducts.length === 0 }"
-        :disabled="selectedProducts.length === 0 || loading" @click="linkPlaid">
+      <button
+        class="btn btn-pill"
+        :class="{ 'opacity-50 cursor-not-allowed': selectedProducts.length === 0 }"
+        :disabled="selectedProducts.length === 0 || loading"
+        @click="linkPlaid"
+      >
         {{ loading ? 'Linking…' : 'Link with Plaid' }}
       </button>
     </div>

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -160,16 +160,13 @@
 
 <script>
 import api from '@/services/api'
-import accountLinkApi from '@/api/accounts_link'
 import AccountSparkline from '@/components/widgets/AccountSparkline.vue'
+import accountLinkApi from '@/api/accounts_link'
 
 export default {
   name: 'AccountsTable',
   components: { AccountSparkline },
   emits: ['refresh'],
-  props: {
-    provider: { type: String, default: 'teller' },
-  },
   data() {
     return {
       accounts: [],
@@ -252,7 +249,7 @@ export default {
     async deleteAccount(accountId) {
       if (!confirm('Are you sure you want to delete this account and all its transactions?')) return
       try {
-        const res = await accountLinkApi.deleteAccount(this.provider, accountId)
+        const res = await accountLinkApi.deleteAccount(accountId)
         if (res.status === 'success') {
           alert('Account deleted successfully.')
           this.fetchAccounts()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -80,50 +80,6 @@ export default {
     return response.data
   },
 
-  async generateLinkToken(provider, payload = {}) {
-    let url = ''
-    if (provider === 'plaid') {
-      url = '/plaid/transactions/generate_link_token'
-    } else if (provider === 'teller') {
-      url = '/teller/transactions/generate_link_token'
-    }
-    const response = await apiClient.post(url, payload)
-    return response.data
-  },
-
-  async saveTellerToken(data) {
-    const response = await apiClient.post('/teller/token', data)
-    return response.data
-  },
-
-  async exchangePublicToken(provider, payload) {
-    if (provider === 'teller') {
-      console.warn('Teller does not use public token exchange.')
-      return { error: 'Not supported for Teller' }
-    }
-    const response = await apiClient.post(
-      `/${provider}/transactions/exchange_public_token`,
-      payload,
-    )
-    return response.data
-  },
-  async deleteAccount(provider, account_id) {
-    const urlMap = {
-      plaid: '/plaid/transactions/delete_account',
-      teller: '/teller/transactions/delete_account',
-    }
-    const url = urlMap[provider]
-    if (!url) return
-
-    try {
-      const response = await apiClient.delete(url, { data: { account_id } })
-      return response.data
-    } catch (error) {
-      console.error('Failed to delete account:', error)
-      throw error
-    }
-  },
-
   async setAccountHidden(account_id, hidden) {
     const response = await apiClient.put(`/accounts/${account_id}/hidden`, { hidden })
     return response.data

--- a/frontend/src/services/loadExternalScripts.js
+++ b/frontend/src/services/loadExternalScripts.js
@@ -28,9 +28,8 @@ export function loadExternalScripts() {
   if (!loadPromise) {
     loadPromise = (async () => {
       await loadScript("https://cdn.plaid.com/link/v2/stable/link-initialize.js");
-      await loadScript("https://cdn.teller.io/connect/connect.js");
       scriptsLoaded = true;
-      console.log("External scripts loaded");
+      console.log("Plaid script loaded");
     })();
   }
   return loadPromise;

--- a/frontend/src/services/loadExternalScripts.js
+++ b/frontend/src/services/loadExternalScripts.js
@@ -1,36 +1,35 @@
-
 // src/utils/externalScripts.js
 
-let scriptsLoaded = false;
-let loadPromise = null;
+let scriptsLoaded = false
+let loadPromise = null
 
 function loadScript(src) {
   return new Promise((resolve, reject) => {
     // Check if the script is already in the document.
     if (document.querySelector(`script[src="${src}"]`)) {
-      resolve();
-      return;
+      resolve()
+      return
     }
-    const script = document.createElement("script");
-    script.src = src;
+    const script = document.createElement('script')
+    script.src = src
     // Do not use async or defer to ensure immediate execution.
-    script.async = false;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
-    document.head.appendChild(script);
-  });
+    script.async = false
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error(`Failed to load script: ${src}`))
+    document.head.appendChild(script)
+  })
 }
 
 export function loadExternalScripts() {
   if (scriptsLoaded) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
   if (!loadPromise) {
     loadPromise = (async () => {
-      await loadScript("https://cdn.plaid.com/link/v2/stable/link-initialize.js");
-      scriptsLoaded = true;
-      console.log("Plaid script loaded");
-    })();
+      await loadScript('https://cdn.plaid.com/link/v2/stable/link-initialize.js')
+      scriptsLoaded = true
+      console.log('Plaid script loaded')
+    })()
   }
-  return loadPromise;
+  return loadPromise
 }

--- a/frontend/src/utils/externalScripts.js
+++ b/frontend/src/utils/externalScripts.js
@@ -27,9 +27,8 @@ export function loadExternalScripts() {
   if (!loadPromise) {
     loadPromise = (async () => {
       await loadScript("https://cdn.plaid.com/link/v2/stable/link-initialize.js");
-      await loadScript("https://cdn.teller.io/connect/connect.js");
       scriptsLoaded = true;
-      console.log("External scripts loaded");
+      console.log("Plaid script loaded");
     })();
   }
   return loadPromise;

--- a/frontend/src/utils/externalScripts.js
+++ b/frontend/src/utils/externalScripts.js
@@ -1,35 +1,35 @@
 // src/utils/externalScripts.js
 
-let scriptsLoaded = false;
-let loadPromise = null;
+let scriptsLoaded = false
+let loadPromise = null
 
 function loadScript(src) {
   return new Promise((resolve, reject) => {
     // Check if the script is already in the document.
     if (document.querySelector(`script[src="${src}"]`)) {
-      resolve();
-      return;
+      resolve()
+      return
     }
-    const script = document.createElement("script");
-    script.src = src;
+    const script = document.createElement('script')
+    script.src = src
     // Do not use async or defer to ensure immediate execution.
-    script.async = false;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
-    document.head.appendChild(script);
-  });
+    script.async = false
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error(`Failed to load script: ${src}`))
+    document.head.appendChild(script)
+  })
 }
 
 export function loadExternalScripts() {
   if (scriptsLoaded) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
   if (!loadPromise) {
     loadPromise = (async () => {
-      await loadScript("https://cdn.plaid.com/link/v2/stable/link-initialize.js");
-      scriptsLoaded = true;
-      console.log("Plaid script loaded");
-    })();
+      await loadScript('https://cdn.plaid.com/link/v2/stable/link-initialize.js')
+      scriptsLoaded = true
+      console.log('Plaid script loaded')
+    })()
   }
-  return loadPromise;
+  return loadPromise
 }


### PR DESCRIPTION
## Summary
- drop the Teller Connect script reference from the app shell and stop loading it dynamically
- streamline link launcher and account utilities to use Plaid-only link token generation, exchange, and deletion paths
- remove the obsolete Teller API helper module

## Testing
- pytest -q *(fails: missing flask/pdfplumber dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c5bd9a083298cd33ef06e5391bc