### PR TITLE
Add debt-attribution and per-component debt series to forecast pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pyNance is a full-stack personal finance dashboard that combines a Flask API, a 
 - **Account aggregation and transactions** via Plaid integrations.
 - **Rule-based categorization** to organize spending.
 - **Balance forecasting** to project future account balances.
-- **Forecast recompute API** (`POST /api/forecast/compute`) with moving-average windows, normalization toggles, graph modes, distributed manual adjustments, and typed aspect series for realized income, manual adjustments, spending, and debt totals.
+- **Forecast recompute API** (`POST /api/forecast/compute`) with moving-average windows, normalization toggles, graph modes, distributed manual adjustments, and typed aspect series for realized income, manual adjustments, spending, projected debt totals, debt-interest accrual, and debt growth from new spending.
 - **Goal tracking** for budgeting.
 - **Investment tracking** alongside banking activity.
 - **Deterministic account investment semantics** with persisted account-level flags (`is_investment`, holdings/transactions scope flags, and `account_type` normalization for API consumers).

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -5,6 +5,8 @@ import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
+from flask import Blueprint, g, jsonify, request
+
 from app.config import logger
 from app.extensions import db
 from app.models import Account, PlaidItem, RecurringTransaction, Transaction
@@ -20,7 +22,6 @@ from app.utils.finance_utils import (
     display_transaction_amount,
     normalize_account_balance,
 )
-from flask import Blueprint, g, jsonify, request
 
 # Blueprint for generic accounts routes
 accounts = Blueprint("accounts", __name__)
@@ -273,9 +274,9 @@ def refresh_all_accounts():
 
                                 if err_payload.get("plaid_error_code") == "ITEM_LOGIN_REQUIRED":
                                     error_map[key]["requires_reauth"] = True
-                                    error_map[key]["update_link_token_endpoint"] = (
-                                        "/api/plaid/transactions/generate_update_link_token"
-                                    )
+                                    error_map[key][
+                                        "update_link_token_endpoint"
+                                    ] = "/api/plaid/transactions/generate_update_link_token"
                                     error_map[key]["affected_account_ids"] = [account.account_id]
                             else:
                                 error_map[key]["account_ids"].append(account.account_id)
@@ -853,8 +854,9 @@ def account_net_changes(account_id):
     """
 
     try:
-        from app.sql import account_logic
         from sqlalchemy import case, func
+
+        from app.sql import account_logic
 
         start_date_str = request.args.get("start_date")
         end_date_str = request.args.get("end_date")

--- a/backend/app/routes/forecast.py
+++ b/backend/app/routes/forecast.py
@@ -1,8 +1,9 @@
+from collections import defaultdict
 from datetime import date, datetime, timedelta
 
 from flask import Blueprint, jsonify, request
 from forecast.engine import compute_forecast
-from sqlalchemy import case, func
+from sqlalchemy import func
 
 from app.config import logger
 from app.extensions import db
@@ -22,6 +23,7 @@ LIABILITY_ACCOUNT_TYPE_TOKENS = {
     "student",
     "debt",
 }
+INTEREST_PFC_CATEGORIES = {"BANK_FEES_INTEREST"}
 
 
 def _is_liability_account_type(raw_account_type: object) -> bool:
@@ -38,6 +40,60 @@ def _is_liability_account_type(raw_account_type: object) -> bool:
 
     normalized = normalized.replace("-", " ").replace("/", " ")
     return any(token in normalized for token in LIABILITY_ACCOUNT_TYPE_TOKENS)
+
+
+def _is_interest_charge_transaction(tx: Transaction) -> bool:
+    """Return ``True`` when a liability transaction appears to be interest accrual."""
+    text_fields = [
+        str(tx.description or "").strip().lower(),
+        str(tx.merchant_name or "").strip().lower(),
+        str(tx.category or "").strip().lower(),
+        str(tx.category_slug or "").strip().upper(),
+        str(tx.category_display or "").strip().lower(),
+    ]
+    if any("interest" in value for value in text_fields if value):
+        return True
+
+    pfc = tx.personal_finance_category if isinstance(tx.personal_finance_category, dict) else {}
+    pfc_detailed = str(
+        pfc.get("detailed") or pfc.get("detailed_category") or pfc.get("detailed_category_name") or ""
+    ).upper()
+    if pfc_detailed in INTEREST_PFC_CATEGORIES:
+        return True
+
+    plaid_meta = getattr(tx, "plaid_meta", None)
+    plaid_meta_category = getattr(plaid_meta, "category", None) if plaid_meta else None
+    if isinstance(plaid_meta_category, list):
+        category_path = [str(value or "").strip().lower() for value in plaid_meta_category]
+        return category_path[:2] == ["bank fees", "interest"]
+    if isinstance(plaid_meta_category, dict):
+        category_path = [str(value or "").strip().lower() for value in plaid_meta_category.values()]
+        return category_path[:2] == ["bank fees", "interest"]
+
+    return False
+
+
+def _apply_transaction_to_historical_aggregate(
+    aggregate: dict[str, float | date],
+    *,
+    amount: float,
+    account_type: object,
+    is_interest_charge: bool,
+) -> None:
+    """Apply one transaction to a daily aggregate with explicit debt attribution."""
+    if _is_liability_account_type(account_type):
+        if amount > 0:
+            aggregate["outflow"] = float(aggregate.get("outflow", 0.0)) + amount
+            debt_key = "debt_interest" if is_interest_charge else "debt_new_spending"
+            aggregate[debt_key] = float(aggregate.get(debt_key, 0.0)) + amount
+        elif amount < 0:
+            aggregate["inflow"] = float(aggregate.get("inflow", 0.0)) + abs(amount)
+        return
+
+    if amount > 0:
+        aggregate["inflow"] = float(aggregate.get("inflow", 0.0)) + amount
+    elif amount < 0:
+        aggregate["outflow"] = float(aggregate.get("outflow", 0.0)) + abs(amount)
 
 
 def _snapshot_balance_breakdown(
@@ -237,17 +293,18 @@ def _load_historical_aggregates(
     included_account_ids: list[str] | None = None,
     excluded_account_ids: list[str] | None = None,
 ) -> list[dict[str, object]]:
-    """Return daily inflow/outflow aggregates for the lookback window."""
+    """Return daily inflow/outflow aggregates for the lookback window.
+
+    Liability transactions are additionally classified into explicit debt-growth
+    buckets so the forecast engine can distinguish new spending from interest
+    accrual when building debt-focused chart series.
+    """
     included_ids = included_account_ids or []
     excluded_ids = excluded_account_ids or []
 
     lookback_start = start_date - timedelta(days=LOOKBACK_DAYS)
-    date_expr = func.date(Transaction.date).label("date")
-    inflow_sum = func.sum(case((Transaction.amount > 0, Transaction.amount), else_=0)).label("inflow")
-    outflow_sum = func.sum(case((Transaction.amount < 0, func.abs(Transaction.amount)), else_=0)).label("outflow")
-
     query = (
-        db.session.query(date_expr, inflow_sum, outflow_sum)
+        db.session.query(Transaction, Account.account_type)
         .join(Account, Transaction.account_id == Account.account_id)
         .filter((Account.is_hidden.is_(False)) | (Account.is_hidden.is_(None)))
         .filter((Transaction.is_internal.is_(False)) | (Transaction.is_internal.is_(None)))
@@ -263,15 +320,26 @@ def _load_historical_aggregates(
     if excluded_ids:
         query = query.filter(~Transaction.account_id.in_(excluded_ids))
 
-    rows = query.group_by(date_expr).order_by(date_expr).all()
-    return [
-        {
-            "date": row.date,
-            "inflow": float(row.inflow or 0),
-            "outflow": float(row.outflow or 0),
+    daily_aggregates: dict[date, dict[str, float | date]] = defaultdict(
+        lambda: {
+            "inflow": 0.0,
+            "outflow": 0.0,
+            "debt_interest": 0.0,
+            "debt_new_spending": 0.0,
         }
-        for row in rows
-    ]
+    )
+    for tx, account_type in query.order_by(Transaction.date.asc()).all():
+        tx_date = tx.date.date() if isinstance(tx.date, datetime) else tx.date
+        aggregate = daily_aggregates[tx_date]
+        aggregate["date"] = tx_date
+        _apply_transaction_to_historical_aggregate(
+            aggregate,
+            amount=float(tx.amount or 0),
+            account_type=account_type,
+            is_interest_charge=_is_interest_charge_transaction(tx),
+        )
+
+    return [daily_aggregates[current_date] for current_date in sorted(daily_aggregates)]
 
 
 def _build_realized_history(
@@ -533,6 +601,8 @@ def compute_forecast_route():
         asset_balance, liability_balance, net_snapshot_balance = _snapshot_balance_breakdown(latest_snapshots)
         total_inflow = sum(float(item.get("inflow", 0) or 0) for item in historical_aggregates)
         total_outflow = sum(float(item.get("outflow", 0) or 0) for item in historical_aggregates)
+        total_debt_interest = sum(float(item.get("debt_interest", 0) or 0) for item in historical_aggregates)
+        total_debt_new_spending = sum(float(item.get("debt_new_spending", 0) or 0) for item in historical_aggregates)
         non_zero_historical_days = sum(
             1
             for item in historical_aggregates
@@ -575,6 +645,8 @@ def compute_forecast_route():
                     "snapshot_balance": net_snapshot_balance,
                     "historical_inflow": total_inflow,
                     "historical_outflow": total_outflow,
+                    "debt_interest": total_debt_interest,
+                    "debt_new_spending": total_debt_new_spending,
                 },
                 "historical_aggregate_days": len(historical_aggregates),
                 "historical_aggregate_non_zero_days": non_zero_historical_days,

--- a/backend/app/routes/plaid_investments.py
+++ b/backend/app/routes/plaid_investments.py
@@ -1,5 +1,7 @@
 """Routes for Plaid investments flows and account syncing."""
 
+from flask import Blueprint, jsonify, request
+
 from app.config import logger
 from app.extensions import db
 from app.helpers.plaid_helpers import (
@@ -14,7 +16,6 @@ from app.sql.account_logic import (
     save_plaid_account,
     upsert_accounts,
 )
-from flask import Blueprint, jsonify, request
 
 plaid_investments = Blueprint("plaid_investments", __name__)
 

--- a/backend/forecast/engine.py
+++ b/backend/forecast/engine.py
@@ -22,6 +22,9 @@ DEFAULT_CATEGORY_CONFIDENCE = Decimal("0.6")
 DEFAULT_RECURRING_CONFIDENCE = Decimal("0.85")
 DEFAULT_UNCATEGORIZED_CONFIDENCE = Decimal("0.3")
 DEFAULT_ADJUSTMENT_CONFIDENCE = Decimal("0.95")
+DEBT_SERIES_TOTAL_KEY = "debt_totals"
+DEBT_SERIES_INTEREST_KEY = "debt_interest"
+DEBT_SERIES_NEW_SPENDING_KEY = "debt_new_spending"
 LIABILITY_ACCOUNT_TYPE_TOKENS = {
     "credit",
     "credit card",
@@ -131,6 +134,37 @@ def _cashflow_direction(amount: Decimal) -> str:
 def _cashflow_type(amount: Decimal) -> str:
     """Return the cashflow type for a signed amount."""
     return "income" if amount >= 0 else "expense"
+
+
+def _normalize_debt_component(value: Any) -> str | None:
+    """Normalize debt component labels into stable forecast series keys."""
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {"interest", DEBT_SERIES_INTEREST_KEY}:
+        return DEBT_SERIES_INTEREST_KEY
+    if normalized in {"new_spending", "principal", "spending", DEBT_SERIES_NEW_SPENDING_KEY}:
+        return DEBT_SERIES_NEW_SPENDING_KEY
+    return None
+
+
+def _debt_component_from_entry(entry: Mapping[str, Any] | ForecastCashflowItem | Any) -> str | None:
+    """Read normalized debt attribution metadata from an entry."""
+    metadata = _read_entry_value(entry, "metadata", {}) or {}
+    if isinstance(metadata, Mapping):
+        for key in ("debt_series_key", "debt_component", "debt_contribution_type"):
+            component = _normalize_debt_component(metadata.get(key))
+            if component:
+                return component
+
+    for key in ("debt_series_key", "debt_component", "debt_contribution_type"):
+        component = _normalize_debt_component(_read_entry_value(entry, key))
+        if component:
+            return component
+
+    label = str(_read_entry_value(entry, "label", "")).strip().lower()
+    adjustment_type = str(_read_entry_value(entry, "adjustment_type", "")).strip().lower()
+    if "debt" in label or "liability" in label or "debt" in adjustment_type:
+        return DEBT_SERIES_NEW_SPENDING_KEY
+    return None
 
 
 def _daily_deltas(
@@ -353,7 +387,7 @@ def build_cashflow_items(
     category_sources = _category_sources(category_averages)
     recurring_by_date = _recurring_sources_by_date(recurring_sources, timeline_dates)
 
-    for current_date, delta in daily_deltas:
+    for point, (current_date, delta) in zip(timeline, daily_deltas):
         day_items: list[tuple[Decimal, ForecastCashflowItem]] = []
         recurring_items = recurring_by_date.get(current_date, [])
         recurring_total = sum((_to_decimal(item.get("amount")) for item in recurring_items), Decimal("0"))
@@ -379,7 +413,12 @@ def build_cashflow_items(
                 )
             )
 
-        remaining = delta - recurring_total
+        debt_component_total = Decimal("0")
+        for debt_amount, debt_item in _build_baseline_debt_cashflows(current_date, point.metadata or {}):
+            debt_component_total += debt_amount
+            day_items.append((debt_amount, debt_item))
+
+        remaining = delta - recurring_total - debt_component_total
         for entry in _scaled_category_items(remaining, category_sources):
             amount = _to_decimal(entry.get("amount"))
             if amount == 0:
@@ -429,6 +468,47 @@ def build_cashflow_items(
     return cashflows
 
 
+def _build_baseline_debt_cashflows(
+    current_date: date,
+    point_metadata: Mapping[str, Any],
+) -> list[tuple[Decimal, ForecastCashflowItem]]:
+    """Build explicit cashflow rows for projected debt growth components."""
+    component_configs = (
+        (DEBT_SERIES_INTEREST_KEY, "Debt interest accrual", point_metadata.get("average_debt_interest")),
+        (DEBT_SERIES_NEW_SPENDING_KEY, "Debt new spending", point_metadata.get("average_debt_new_spending")),
+    )
+    items: list[tuple[Decimal, ForecastCashflowItem]] = []
+    for component_key, label, raw_amount in component_configs:
+        growth_amount = _to_decimal(raw_amount)
+        if growth_amount <= 0:
+            continue
+
+        signed_amount = -growth_amount
+        items.append(
+            (
+                signed_amount,
+                ForecastCashflowItem(
+                    date=current_date,
+                    amount=float(signed_amount),
+                    label=label,
+                    category="Debt",
+                    source="historical_debt_average",
+                    type="expense",
+                    confidence=float(DEFAULT_CATEGORY_CONFIDENCE),
+                    direction="outflow",
+                    metadata={
+                        "debt_component": component_key,
+                        "debt_series_key": component_key,
+                        "semantic_type": "debt_contribution",
+                        "affects_debt_total": True,
+                        "debt_growth_amount": float(growth_amount),
+                    },
+                ),
+            )
+        )
+    return items
+
+
 def _build_adjustment_cashflows(
     adjustments: Sequence[Mapping[str, Any]], timeline_dates: Sequence[date]
 ) -> list[ForecastCashflowItem]:
@@ -448,9 +528,27 @@ def _build_adjustment_cashflows(
             fallback=timeline_dates[0],
         )
         confidence = float(_read_entry_value(adjustment, "confidence", DEFAULT_ADJUSTMENT_CONFIDENCE))
+        debt_component = _debt_component_from_entry(adjustment)
 
         for current_date in timeline_dates:
             if _matches_frequency(current_date, start_date, frequency):
+                metadata = {
+                    "adjustment_type": adjustment_type,
+                    "adjustment_id": adjustment_id,
+                    "reason": reason,
+                    "frequency": frequency or "one-time",
+                }
+                if debt_component:
+                    metadata.update(
+                        {
+                            "debt_component": debt_component,
+                            "debt_series_key": debt_component,
+                            "semantic_type": "debt_contribution",
+                            "affects_debt_total": True,
+                            "debt_growth_amount": float(abs(amount)),
+                        }
+                    )
+
                 cashflows.append(
                     ForecastCashflowItem(
                         date=current_date,
@@ -461,12 +559,7 @@ def _build_adjustment_cashflows(
                         type=_cashflow_type(amount),
                         confidence=confidence,
                         direction=_cashflow_direction(amount),
-                        metadata={
-                            "adjustment_type": adjustment_type,
-                            "adjustment_id": adjustment_id,
-                            "reason": reason,
-                            "frequency": frequency or "one-time",
-                        },
+                        metadata=metadata,
                     )
                 )
                 if frequency is None:
@@ -616,10 +709,15 @@ def _build_adjustment_models(
             adjustment_date = date.today()
         reason = _read_entry_value(adjustment, "reason")
         adjustment_id = _read_entry_value(adjustment, "adjustment_id", _read_entry_value(adjustment, "id"))
-        metadata: dict[str, Any] = {}
+        metadata: dict[str, Any] = dict(_read_entry_value(adjustment, "metadata", {}) or {})
         frequency = _read_entry_value(adjustment, "frequency")
         if frequency:
             metadata["frequency"] = frequency
+        debt_component = _debt_component_from_entry(adjustment)
+        if debt_component:
+            metadata.setdefault("debt_component", debt_component)
+            metadata.setdefault("debt_series_key", debt_component)
+            metadata.setdefault("semantic_type", "debt_contribution")
 
         models.append(
             ForecastAdjustment(
@@ -704,17 +802,89 @@ def _spending_values_by_date(
     return spending_by_date
 
 
-def _debt_values_by_date(
-    latest_snapshots: Sequence[Mapping[str, Any]],
-    timeline_dates: Sequence[date],
-) -> dict[date, Decimal]:
-    """Return constant debt totals across the forecast horizon."""
+def _initial_debt_total(latest_snapshots: Sequence[Mapping[str, Any]]) -> Decimal:
+    """Return the total liability balance present in the latest snapshots."""
     debt_total = Decimal("0")
     for snapshot in latest_snapshots:
         balance = _to_decimal(snapshot.get("balance"))
         if _is_liability_account_type(snapshot.get("account_type")):
             debt_total += abs(balance)
-    return {current_date: debt_total for current_date in timeline_dates}
+    return debt_total
+
+
+def _baseline_debt_component_values_by_date(
+    timeline: Sequence[ForecastTimelinePoint],
+) -> dict[str, dict[date, Decimal]]:
+    """Return projected baseline debt growth values keyed by component."""
+    component_map = {
+        DEBT_SERIES_INTEREST_KEY: {},
+        DEBT_SERIES_NEW_SPENDING_KEY: {},
+    }
+    for point in timeline:
+        current_date = _parse_date(point.date, fallback=date.today())
+        metadata = point.metadata or {}
+        component_map[DEBT_SERIES_INTEREST_KEY][current_date] = _to_decimal(metadata.get("average_debt_interest"))
+        component_map[DEBT_SERIES_NEW_SPENDING_KEY][current_date] = _to_decimal(
+            metadata.get("average_debt_new_spending")
+        )
+    return component_map
+
+
+def _adjustment_debt_component_values_by_date(
+    adjustments: Sequence[Mapping[str, Any]] | None,
+    timeline_dates: Sequence[date],
+) -> dict[str, dict[date, Decimal]]:
+    """Return per-day debt component deltas contributed by adjustments."""
+    component_map = {
+        DEBT_SERIES_INTEREST_KEY: {current_date: Decimal("0") for current_date in timeline_dates},
+        DEBT_SERIES_NEW_SPENDING_KEY: {current_date: Decimal("0") for current_date in timeline_dates},
+    }
+    for adjustment in adjustments or []:
+        component = _debt_component_from_entry(adjustment)
+        if not component:
+            continue
+
+        scheduled_values = _build_adjustment_schedule([adjustment], timeline_dates)
+        for current_date, signed_balance_delta in scheduled_values.items():
+            component_map[component][current_date] += -signed_balance_delta
+
+    return component_map
+
+
+def _debt_series_values(
+    *,
+    latest_snapshots: Sequence[Mapping[str, Any]],
+    baseline_timeline: Sequence[ForecastTimelinePoint],
+    adjustments: Sequence[Mapping[str, Any]] | None,
+    timeline_dates: Sequence[date],
+) -> dict[str, dict[date, Decimal]]:
+    """Build debt balance and component series for the forecast horizon."""
+    baseline_components = _baseline_debt_component_values_by_date(baseline_timeline)
+    adjustment_components = _adjustment_debt_component_values_by_date(adjustments, timeline_dates)
+
+    interest_values = {
+        current_date: baseline_components[DEBT_SERIES_INTEREST_KEY].get(current_date, Decimal("0"))
+        + adjustment_components[DEBT_SERIES_INTEREST_KEY].get(current_date, Decimal("0"))
+        for current_date in timeline_dates
+    }
+    new_spending_values = {
+        current_date: baseline_components[DEBT_SERIES_NEW_SPENDING_KEY].get(current_date, Decimal("0"))
+        + adjustment_components[DEBT_SERIES_NEW_SPENDING_KEY].get(current_date, Decimal("0"))
+        for current_date in timeline_dates
+    }
+
+    running_total = _initial_debt_total(latest_snapshots)
+    total_values: dict[date, Decimal] = {}
+    for current_date in timeline_dates:
+        running_total += interest_values.get(current_date, Decimal("0"))
+        running_total += new_spending_values.get(current_date, Decimal("0"))
+        total_values[current_date] = running_total
+
+    return {
+        DEBT_SERIES_TOTAL_KEY: total_values,
+        DEBT_SERIES_INTEREST_KEY: interest_values,
+        DEBT_SERIES_NEW_SPENDING_KEY: new_spending_values,
+    }
 
 
 def _build_forecast_series(
@@ -722,11 +892,18 @@ def _build_forecast_series(
     historical_aggregates: Sequence[Mapping[str, Any]],
     historical_dates: Sequence[date],
     adjustments: Sequence[Mapping[str, Any]] | None,
+    baseline_timeline: Sequence[ForecastTimelinePoint],
     timeline_dates: Sequence[date],
     cashflows: Sequence[ForecastCashflowItem],
     latest_snapshots: Sequence[Mapping[str, Any]],
 ) -> dict[str, ForecastAspectSeries]:
     """Build typed aspect series for frontend charting and summaries."""
+    debt_values = _debt_series_values(
+        latest_snapshots=latest_snapshots,
+        baseline_timeline=baseline_timeline,
+        adjustments=adjustments,
+        timeline_dates=timeline_dates,
+    )
     return {
         "realized_income": _build_daily_series(
             series_id="realized_income",
@@ -749,12 +926,26 @@ def _build_forecast_series(
             values_by_date=_spending_values_by_date(cashflows, timeline_dates),
             metadata={"timeframe": "forecast", "source": "cashflows"},
         ),
-        "debt_totals": _build_daily_series(
-            series_id="debt_totals",
-            label="Debt totals",
+        DEBT_SERIES_TOTAL_KEY: _build_daily_series(
+            series_id=DEBT_SERIES_TOTAL_KEY,
+            label="Total debt",
             dates=timeline_dates,
-            values_by_date=_debt_values_by_date(latest_snapshots, timeline_dates),
-            metadata={"timeframe": "forecast", "source": "latest_snapshots"},
+            values_by_date=debt_values[DEBT_SERIES_TOTAL_KEY],
+            metadata={"timeframe": "forecast", "source": "debt_projection", "value_mode": "balance"},
+        ),
+        DEBT_SERIES_INTEREST_KEY: _build_daily_series(
+            series_id=DEBT_SERIES_INTEREST_KEY,
+            label="Debt interest accrual",
+            dates=timeline_dates,
+            values_by_date=debt_values[DEBT_SERIES_INTEREST_KEY],
+            metadata={"timeframe": "forecast", "source": "debt_projection", "value_mode": "daily_change"},
+        ),
+        DEBT_SERIES_NEW_SPENDING_KEY: _build_daily_series(
+            series_id=DEBT_SERIES_NEW_SPENDING_KEY,
+            label="Debt new spending",
+            dates=timeline_dates,
+            values_by_date=debt_values[DEBT_SERIES_NEW_SPENDING_KEY],
+            metadata={"timeframe": "forecast", "source": "debt_projection", "value_mode": "daily_change"},
         ),
     }
 
@@ -820,6 +1011,12 @@ def compute_forecast(
                         **item,
                         "inflow": float(_extract_amount(item, ("inflow", "income", "credit")) / normalization_factor),
                         "outflow": float(_extract_amount(item, ("outflow", "expense", "debit")) / normalization_factor),
+                        DEBT_SERIES_INTEREST_KEY: float(
+                            _extract_amount(item, (DEBT_SERIES_INTEREST_KEY,)) / normalization_factor
+                        ),
+                        DEBT_SERIES_NEW_SPENDING_KEY: float(
+                            _extract_amount(item, (DEBT_SERIES_NEW_SPENDING_KEY,)) / normalization_factor
+                        ),
                     }
                 )
 
@@ -860,6 +1057,7 @@ def compute_forecast(
         historical_aggregates=historical_window,
         historical_dates=historical_dates,
         adjustments=adjustments,
+        baseline_timeline=baseline_timeline,
         timeline_dates=timeline_dates,
         cashflows=cashflows,
         latest_snapshots=latest_snapshots,
@@ -1084,6 +1282,8 @@ def project_balances(
 
     total_inflow = Decimal("0")
     total_outflow = Decimal("0")
+    total_debt_interest = Decimal("0")
+    total_debt_new_spending = Decimal("0")
     aggregate_dates: set[date] = set()
 
     for aggregate in historical_aggregates:
@@ -1103,14 +1303,20 @@ def project_balances(
 
         total_inflow += inflow
         total_outflow += outflow
+        total_debt_interest += _extract_amount(aggregate, (DEBT_SERIES_INTEREST_KEY,))
+        total_debt_new_spending += _extract_amount(aggregate, (DEBT_SERIES_NEW_SPENDING_KEY,))
 
     day_count = len(aggregate_dates) if aggregate_dates else len(historical_aggregates)
     if day_count <= 0:
         average_inflow = Decimal("0")
         average_outflow = Decimal("0")
+        average_debt_interest = Decimal("0")
+        average_debt_new_spending = Decimal("0")
     else:
         average_inflow = total_inflow / Decimal(day_count)
         average_outflow = total_outflow / Decimal(day_count)
+        average_debt_interest = total_debt_interest / Decimal(day_count)
+        average_debt_new_spending = total_debt_new_spending / Decimal(day_count)
 
     # Build the projection by applying the average daily net change to the latest balance.
     points: list[ForecastTimelinePoint] = []
@@ -1129,6 +1335,8 @@ def project_balances(
                 metadata={
                     "average_inflow": float(average_inflow),
                     "average_outflow": float(average_outflow),
+                    "average_debt_interest": float(average_debt_interest),
+                    "average_debt_new_spending": float(average_debt_new_spending),
                     "starting_balance": float(starting_balance),
                 },
             )

--- a/docs/backend/app/routes/forecast.md
+++ b/docs/backend/app/routes/forecast.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-17
+Last Updated: 2026-03-23
 Status: Active
 ---
 
@@ -25,13 +25,13 @@ Provides projected balances and metadata for dashboard forecasting views by dele
     - `user_id` (string, required)
     - `start_date` (ISO date string, optional; defaults to today)
     - `horizon_days` (integer, optional; defaults to 30)
-    - `adjustments` (list, optional; supports empty list or multiple adjustments, with optional `distribution`, `range_start`, and `range_end` for spread entries)
+    - `adjustments` (list, optional; supports empty list or multiple adjustments, with optional `distribution`, `range_start`, and `range_end` for spread entries; debt adjustments may include `metadata.debt_component` / `metadata.debt_series_key` to classify debt growth semantics)
     - `moving_average_window` (integer, optional; 7, 30, 60, or 90; defaults to 30)
     - `normalize` (boolean, optional; normalizes historical aggregates before projection)
     - `graph_mode` (`combined`, `forecast`, or `historical`; optional chart rendering hint)
     - `included_account_ids` (list of account IDs, optional; defaults to all visible accounts)
     - `excluded_account_ids` (list of account IDs, optional; applied after includes)
-  - **Outputs:** `ForecastResult` JSON containing `timeline`, `summary`, `cashflows`, `adjustments`, and `metadata`. Metadata now includes account filters (`included_account_ids`, `excluded_account_ids`), balance breakdowns (`asset_balance`, `liability_balance`, `net_balance`), and aggregate contribution totals for the selected accounts.
+  - **Outputs:** `ForecastResult` JSON containing `timeline`, `summary`, `cashflows`, `adjustments`, and `metadata`. Metadata now includes account filters (`included_account_ids`, `excluded_account_ids`), balance breakdowns (`asset_balance`, `liability_balance`, `net_balance`), and aggregate contribution totals for the selected accounts, including explicit debt-growth totals for `debt_interest` and `debt_new_spending`.
 
 ## Auth
 
@@ -46,6 +46,7 @@ Provides projected balances and metadata for dashboard forecasting views by dele
 ## Behaviors/Edge Cases
 
 - Historical transaction patterns combined with recurring and nonrecurring projections drive the response.
+- Liability-account transactions are classified into `debt_interest` and `debt_new_spending` while historical aggregates are built so projected debt totals can expose both the total debt line and its daily growth composition.
 - Override parameters (`manual_income`, `liability_rate`) are applied to adjust the forecast.
 - View selection switches horizon lengths (30 days for month, 365 days for year).
 - Forecast recompute uses the most recent account snapshots and a 90-day lookback of transaction inflow/outflow aggregates.

--- a/docs/backend/forecast/engine.md
+++ b/docs/backend/forecast/engine.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-22
+Last Updated: 2026-03-23
 Status: Active
 ---
 
@@ -71,6 +71,8 @@ adjustments.
 ### Behavior
 
 - Computes daily deltas from the baseline timeline without mutating it.
+- Emits explicit debt cashflow rows first when timeline metadata carries projected debt-interest or
+  debt-new-spending averages.
 - Allocates deltas to recurring sources first, then scales category averages to match the remaining
   delta.
 - Adds an `Uncategorized` fallback item when the delta cannot be fully attributed.
@@ -101,7 +103,7 @@ projected balance is at or below zero).
 - Building a baseline projection with `project_balances`.
 - Applying adjustments with `apply_adjustments`.
 - Generating cashflow breakdowns and summary metrics.
-- Building typed aspect series for realized income, manual adjustments, spending, and debt totals.
+- Building typed aspect series for realized income, manual adjustments, spending, and debt totals plus debt-growth component series for interest accrual and new spending.
 - Returning a fully serialized `ForecastResult` payload for the API layer.
 
 ## Extended compute options
@@ -121,7 +123,20 @@ Current emitted aspect keys:
   support auto-calculation context in the UI.
 - `manual_adjustments`: per-day totals for non-auto adjustments entered by the user.
 - `spending`: per-day projected spending totals derived from negative cashflow items.
-- `debt_totals`: liability totals carried across the forecast horizon from the latest snapshot set.
+- `debt_totals`: projected total debt balance across the forecast horizon.
+- `debt_interest`: per-day debt growth attributed to interest accrual.
+- `debt_new_spending`: per-day debt growth attributed to new liability spending.
 
 These series are additive to the existing `timeline`, `cashflows`, and `summary` fields so current
 consumers remain compatible during the frontend migration.
+
+## Debt attribution flow
+
+- Route-level historical aggregates now classify liability transactions into `debt_interest` and
+  `debt_new_spending`.
+- `project_balances` carries those averages into each timeline point’s metadata as
+  `average_debt_interest` and `average_debt_new_spending`.
+- `build_cashflow_items` emits explicit debt cashflow rows with matching metadata so downstream
+  consumers do not need to reverse-engineer debt semantics from generic outflows.
+- Adjustment entries can also declare debt metadata (`debt_component` / `debt_series_key`), allowing
+  manual forecast controls to flow into both cashflow metadata and the debt-focused chart series.

--- a/docs/backend/forecast/models.md
+++ b/docs/backend/forecast/models.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-22
+Last Updated: 2026-03-23
 Status: Active
 ---
 
@@ -22,8 +22,9 @@ this for chart series and balance deltas.
 ### `ForecastCashflowItem`
 
 Captures a single cashflow line item that drives the projection. Each item includes the date, amount,
-category, source, optional type/confidence annotations, and optional account identifiers for
-breakdown widgets.
+category, source, optional type/confidence annotations, optional account identifiers for
+breakdown widgets, and metadata that can now carry explicit debt-attribution semantics such as
+`debt_component`, `debt_series_key`, and `debt_growth_amount`.
 
 ### `ForecastSeriesPoint`
 
@@ -34,7 +35,8 @@ chart overlays and summary widgets that should not infer meaning from generic ca
 
 Encapsulates a named daily series with a stable `id`, user-facing `label`, and ordered `points`.
 The forecast compute response currently emits aspect series for realized income used by the
-auto-calculation baseline, manual user adjustments, spending totals, and debt totals.
+auto-calculation baseline, manual user adjustments, spending totals, projected debt totals, and
+the debt-growth component series `debt_interest` and `debt_new_spending`.
 
 ### `ForecastAdjustment`
 

--- a/docs/frontend/src/components/forecast/ForecastChart.md
+++ b/docs/frontend/src/components/forecast/ForecastChart.md
@@ -4,8 +4,8 @@
 
 `ForecastChart` renders the forecast vs actual balance lines, overlays typed aspect series from the
 forecast response, manages the Month/Year toggle UI, and exposes a compact explanation of the
-compute settings behind the current projection.
-`ForecastChart` renders the forecast chart area, keeps the Month/Year toggle intact, and now switches between multiple forecast aspects without forcing the user off the current timeframe.
+compute settings behind the current projection while letting users switch aspects without changing
+the current timeframe.
 
 ## Props
 
@@ -14,12 +14,11 @@ compute settings behind the current projection.
 - `viewType`: Display mode (`Month` or `Year`).
 - `graphMode`: Chart mode (`combined`, `forecast`, or `historical`).
 - `series`: Structured aspect series keyed by stable names such as `realized_income`,
-  `manual_adjustments`, `spending`, and `debt_totals`.
+  `manual_adjustments`, `spending`, `debt_totals`, `debt_interest`, and `debt_new_spending`.
 - `computeMeta`: Forecast compute metadata from `ForecastLayout`, including lookback days, moving-average window, normalization state, and whether auto-detected adjustments were included.
-- `graphMode`: Overlay mode (`combined`, `forecast`, or `historical`).
 - `selectedAspect`: Active chart aspect (`balances`, `realized_income`, `manual_adjustments`, `spending`, or `debt`).
-- `cashflows`: Forecast cashflow rows used to build income, manual-adjustment, and spending datasets.
-- `assetBalance`, `liabilityBalance`, `netBalance`: Snapshot balances used by the debt-composition view.
+- `cashflows`: Forecast cashflow rows preserved for compatibility with parent callers.
+- `assetBalance`, `liabilityBalance`, `netBalance`: Snapshot balances used only as a fallback when the backend debt series are unavailable.
 
 ## Events
 
@@ -44,6 +43,7 @@ The compact “How this forecast is calculated” element summarizes:
 - The chart title combines the current timeframe and active aspect so users can quickly confirm what they are viewing.
 - Balance mode still overlays realized history with projected balances.
 - Graph mode continues to control the balance overlay, while the aspect selector remains orthogonal for income, manual-adjustment, spending, and debt views so those series remain visible when users keep the same timeframe but change what is being visualized.
-- Income, manual-adjustment, and spending modes rebuild datasets from forecast cashflows rather than relying on the original hard-coded two-line balance chart.
-- Debt mode presents current asset, liability, and net snapshot lines for quick composition comparison.
+- Income, manual-adjustment, and spending modes read directly from the backend’s typed series payload instead of reconstructing those datasets from generic cashflow rows.
+- Debt mode now prioritizes the backend’s debt series contract so the chart can render projected
+  total debt alongside daily debt-interest and debt-new-spending components.
 - If the active aspect has no renderable data, the component renders a friendly empty-state message instead of the chart canvas.

--- a/docs/frontend/src/components/forecast/ForecastLayout.md
+++ b/docs/frontend/src/components/forecast/ForecastLayout.md
@@ -8,7 +8,8 @@
 
 - Fetch forecast data through `useForecastData`.
 - Load available forecast accounts and Dashboard Account Snapshot groups.
-- Read typed aspect series from the forecast response for sidebar summaries and chart overlays.
+- Read typed aspect series from the forecast response for sidebar summaries and chart overlays,
+  including the debt-total and debt-component series used by the debt chart aspect.
 - Build `forecastComputeMeta` so child components can describe the active lookback window, moving-average selection, normalization state, and auto-detected adjustment usage.
 
 ## Child metadata flow

--- a/docs/frontend/src/components/forecast/ForecastSummaryPanel.md
+++ b/docs/frontend/src/components/forecast/ForecastSummaryPanel.md
@@ -10,7 +10,9 @@
 - `liabilityBalance`: Included liability-account total used as the negative side of the starting balance.
 - `netBalance`: Current starting balance shown as assets minus liabilities for the selected account scope.
 - `manualIncome`: Manual daily income adjustment value.
-- `liabilityRate`: Manual daily liability adjustment value.
+- `liabilityRate`: Manual daily liability adjustment value. The compute payload now classifies this
+  control as debt growth from new spending so backend debt series do not treat it as generic
+  liability drift.
 - `netChange`: Computed net delta returned by the forecast API when available.
 - `viewType`: Current view mode (`Month` or `Year`).
 - `accountGroupOptions`: Dashboard Account Snapshot groups exposed as quick-select account shortcuts.
@@ -29,7 +31,7 @@
 - `Liabilities`: Explains that the value totals included debt balances that offset the starting position.
 - `Current Balance`: Explains that the displayed starting balance is assets minus liabilities before any projected cashflow changes.
 - `Manual Income`: Explains that the input adds a daily manual income amount to each forecasted day and reflects the current control value.
-- `Liability Rate`: Explains that the input subtracts a daily manual liability amount from each forecasted day and reflects the current control value.
+- `Liability Rate`: Explains that the input subtracts a daily manual liability amount from each forecasted day, classifies it as manual debt growth from new spending, and reflects the current control value.
 - `Net Delta`: Explains whether the displayed delta comes from computed forecast output or a fallback of manual income minus liability rate, and references the active moving-average/lookback settings when available.
 
 ## Account Selector

--- a/frontend/src/components/forecast/ForecastChart.vue
+++ b/frontend/src/components/forecast/ForecastChart.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="chart-container">
-    <!-- HEADER -->
     <div class="chart-header">
       <div class="chart-header-copy">
         <h2 class="chart-title">{{ chartTitle }}</h2>
@@ -15,12 +14,12 @@
           </p>
         </details>
       </div>
-      <button class="toggle-button" @click="toggleView">
 
-      <button @click="toggleView" class="toggle-button">
-        Switch to {{ viewType === 'Month' ? 'Year' : 'Month' }}
+      <button type="button" class="toggle-button" @click="toggleView">
+        Switch to {{ props.viewType === 'Month' ? 'Year' : 'Month' }}
       </button>
     </div>
+
     <div v-if="!hasData" class="chart-empty">Forecast chart data is not available yet.</div>
     <canvas v-else ref="chartCanvas"></canvas>
   </div>
@@ -29,17 +28,17 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
-  Chart,
-  LineController,
-  LineElement,
   BarController,
   BarElement,
   CategoryScale,
+  Chart,
+  Filler,
+  Legend,
+  LineController,
+  LineElement,
   LinearScale,
   PointElement,
-  Legend,
   Tooltip,
-  Filler,
   type ChartConfiguration,
   type ChartDataset,
 } from 'chart.js'
@@ -77,13 +76,43 @@ type ForecastComputeMeta = {
   autoDetectedAdjustmentCount?: number
 }
 
+type ForecastAspectKey = 'balances' | 'realized_income' | 'manual_adjustments' | 'spending' | 'debt'
+
+const ASPECT_META: Record<ForecastAspectKey, { label: string; subtitle: string }> = {
+  balances: {
+    label: 'Balances',
+    subtitle: 'Historical balances are overlaid against projected balances.',
+  },
+  realized_income: {
+    label: 'Realized income',
+    subtitle: 'Realized income shows the daily values used for the forecast baseline.',
+  },
+  manual_adjustments: {
+    label: 'Manual adjustments',
+    subtitle: 'Manual adjustments isolate user-entered forecast changes.',
+  },
+  spending: {
+    label: 'Spending',
+    subtitle: 'Spending shows projected outflows from the forecast cashflow model.',
+  },
+  debt: {
+    label: 'Debt composition',
+    subtitle: 'Debt total is rendered alongside new-spending and interest-growth components.',
+  },
+}
+
 const props = withDefaults(
   defineProps<{
     timeline?: ForecastTimelinePoint[]
     realizedHistory?: RealizedHistoryPoint[]
     viewType?: ForecastViewType
     graphMode?: ForecastGraphMode
+    selectedAspect?: ForecastAspectKey
     series?: ForecastSeriesMap
+    cashflows?: Array<Record<string, unknown>>
+    assetBalance?: number
+    liabilityBalance?: number
+    netBalance?: number
     computeMeta?: ForecastComputeMeta
   }>(),
   {
@@ -91,60 +120,13 @@ const props = withDefaults(
     realizedHistory: () => [],
     viewType: 'Month',
     graphMode: 'combined',
+    selectedAspect: 'balances',
     series: () => ({}),
+    cashflows: () => [],
+    assetBalance: 0,
+    liabilityBalance: 0,
+    netBalance: 0,
     computeMeta: () => ({}),
-const ASPECT_META = {
-  balances: {
-    label: 'Balances',
-    subtitle: 'Historical balances are overlaid against projected balances.',
-  },
-  realized_income: {
-    label: 'Realized income',
-    subtitle: 'Income points summarize positive non-adjustment cashflows in the forecast range.',
-  },
-  manual_adjustments: {
-    label: 'Manual adjustments',
-    subtitle: 'Manual entries isolate user-entered or adjustment-sourced forecast changes.',
-  },
-  spending: {
-    label: 'Spending',
-    subtitle: 'Spending points summarize projected outflows as positive magnitudes.',
-  },
-  debt: {
-    label: 'Debt composition',
-    subtitle: 'Debt composition compares current assets, liabilities, and net balance snapshots.',
-  },
-}
-
-const props = defineProps({
-  timeline: { type: Array, default: () => [] },
-  realizedHistory: { type: Array, default: () => [] },
-  viewType: { type: String, default: 'Month' },
-  graphMode: { type: String, default: 'combined' },
-  selectedAspect: { type: String, default: 'balances' },
-  cashflows: { type: Array, default: () => [] },
-  assetBalance: { type: Number, default: 0 },
-  liabilityBalance: { type: Number, default: 0 },
-  netBalance: { type: Number, default: 0 },
-  timeline: {
-    type: Array,
-    default: () => [],
-  },
-  realizedHistory: {
-    type: Array,
-    default: () => [],
-  },
-  viewType: {
-    type: String,
-    default: 'Month',
-  },
-  graphMode: {
-    type: String,
-    default: 'combined',
-  },
-  computeMeta: {
-    type: Object,
-    default: () => ({}),
   },
 )
 
@@ -156,9 +138,6 @@ const chartCanvas = ref<HTMLCanvasElement | null>(null)
 const isMethodologyOpen = ref(false)
 let chartInstance: Chart | null = null
 
-/**
- * Normalize any series point list into a sorted date-keyed axis.
- */
 const axisDates = computed(() => {
   const dateSet = new Set<string>()
 
@@ -178,73 +157,24 @@ const axisDates = computed(() => {
 })
 
 const labels = computed(() => axisDates.value)
-const hasData = computed(() => labels.value.length > 0)
-const historyLabels = computed(() => props.realizedHistory.map((point) => point.label))
-const forecastLabels = computed(() => props.timeline.map((point) => point.label))
-const labels = computed(() => [...historyLabels.value, ...forecastLabels.value])
 const chartMeta = computed(() => ASPECT_META[props.selectedAspect] || ASPECT_META.balances)
 const chartTitle = computed(() => `${props.viewType} · ${chartMeta.value.label}`)
 const chartSubtitle = computed(() => chartMeta.value.subtitle)
-const chartDatasets = computed(() =>
-  buildAspectDatasets({
-    selectedAspect: props.selectedAspect,
-    graphMode: props.graphMode,
-    realizedHistory: props.realizedHistory,
-    timeline: props.timeline,
-    cashflows: props.cashflows,
-    assetBalance: props.assetBalance,
-    liabilityBalance: props.liabilityBalance,
-    netBalance: props.netBalance,
-  }),
-)
-const hasData = computed(
-  () =>
-    labels.value.length > 0 &&
-    chartDatasets.value.some((dataset) => dataset.data.some((value) => value !== null)),
-)
 
-/**
- * Emit the opposite timeframe while leaving the active aspect untouched.
- */
- * Summarize the compute controls shown above the chart for quick reference.
- */
 const methodologyCopy = computed(() => {
   const lookbackDays = Number(props.computeMeta?.lookbackDays ?? 0)
   const movingAverageWindow = Number(props.computeMeta?.movingAverageWindow ?? 0)
   const normalizeState = props.computeMeta?.normalize
-    ? 'Normalization is on'
-    : 'Normalization is off'
+    ? 'Normalization is on.'
+    : 'Normalization is off.'
   const autoDetectedCount = Number(props.computeMeta?.autoDetectedAdjustmentCount ?? 0)
   const autoDetectedCopy = props.computeMeta?.includesAutoDetectedAdjustments
     ? `Auto-detected adjustments are included${autoDetectedCount > 0 ? ` (${autoDetectedCount} detected)` : ''}.`
     : 'Auto-detected adjustments are not included.'
 
-  return `It uses the latest ${lookbackDays || 'available'} days of realized history, applies a ${movingAverageWindow || 'current'}-day moving average, and renders in ${props.graphMode} mode. ${normalizeState}. ${autoDetectedCopy}`
+  return `It uses the latest ${lookbackDays || 'available'} days of realized history, applies a ${movingAverageWindow || 'current'}-day moving average, renders in ${props.graphMode} mode, and keeps debt growth split between new spending and interest when those series are available. ${normalizeState} ${autoDetectedCopy}`
 })
 
-function toggleView() {
-  emit('update:viewType', props.viewType === 'Month' ? 'Year' : 'Month')
-}
-
-/**
- * Tear down any prior Chart.js instance before a re-render.
- */
- * Keep the methodology copy compact until the user requests it.
- */
-function toggleMethodology() {
-  isMethodologyOpen.value = !isMethodologyOpen.value
-}
-
-function destroyChart() {
-  if (chartInstance) {
-    chartInstance.destroy()
-    chartInstance = null
-  }
-}
-
-/**
- * Align a date-keyed point collection to the chart axis, inserting null gaps.
- */
 function alignSeriesValues(
   points: Array<{ date?: string; label: string; value: number | null | undefined }>,
 ): Array<number | null> {
@@ -259,35 +189,22 @@ function alignSeriesValues(
   return axisDates.value.map((axisDate) => valuesByDate.get(axisDate) ?? null)
 }
 
-/**
- * Build balance and aspect datasets from typed backend series.
- */
-const chartDatasets = computed(() => {
+function buildBalanceDatasets(): ChartDataset<'line', Array<number | null>>[] {
+  const datasets: ChartDataset<'line', Array<number | null>>[] = []
   const historicalOnly = props.graphMode === 'historical'
   const forecastOnly = props.graphMode === 'forecast'
-
-  const datasets: ChartDataset<'line' | 'bar', Array<number | null>>[] = []
-
-  const historicalDataset = alignSeriesValues(
-    props.realizedHistory.map((point) => ({
-      date: point.date || point.label,
-      label: point.label,
-      value: point.balance,
-    })),
-  )
-  const forecastDataset = alignSeriesValues(
-    props.timeline.map((point) => ({
-      date: point.date || point.label,
-      label: point.label,
-      value: point.forecast_balance,
-    })),
-  )
 
   if (!forecastOnly) {
     datasets.push({
       type: 'line',
       label: 'Historical balance',
-      data: historicalDataset,
+      data: alignSeriesValues(
+        props.realizedHistory.map((point) => ({
+          date: point.date || point.label,
+          label: point.label,
+          value: point.balance,
+        })),
+      ),
       borderColor: '#10B981',
       backgroundColor: 'rgba(16, 185, 129, 0.15)',
       yAxisID: 'yBalance',
@@ -300,7 +217,13 @@ const chartDatasets = computed(() => {
     datasets.push({
       type: 'line',
       label: 'Forecast balance',
-      data: forecastDataset,
+      data: alignSeriesValues(
+        props.timeline.map((point) => ({
+          date: point.date || point.label,
+          label: point.label,
+          value: point.forecast_balance,
+        })),
+      ),
       borderColor: '#3B82F6',
       backgroundColor: 'rgba(59, 130, 246, 0.15)',
       yAxisID: 'yBalance',
@@ -310,25 +233,25 @@ const chartDatasets = computed(() => {
     })
   }
 
-  const aspectConfigs: Array<{
-    key: keyof ForecastSeriesMap | string
+  return datasets
+}
+
+function buildSingleSeriesDataset(
+  seriesKey: string,
+  config: {
     color: string
     type: 'line' | 'bar'
     yAxisID: 'yBalance' | 'yFlow'
-  }> = [
-    { key: 'realized_income', color: '#16A34A', type: 'bar', yAxisID: 'yFlow' },
-    { key: 'manual_adjustments', color: '#8B5CF6', type: 'bar', yAxisID: 'yFlow' },
-    { key: 'spending', color: '#DC2626', type: 'bar', yAxisID: 'yFlow' },
-    { key: 'debt_totals', color: '#F59E0B', type: 'line', yAxisID: 'yBalance' },
-  ]
+    borderDash?: number[]
+  },
+): ChartDataset<'line' | 'bar', Array<number | null>>[] {
+  const entry = props.series?.[seriesKey]
+  if (!entry || entry.points.length === 0) {
+    return []
+  }
 
-  aspectConfigs.forEach((config) => {
-    const entry = props.series?.[config.key]
-    if (!entry || !entry.points.length) {
-      return
-    }
-
-    datasets.push({
+  return [
+    {
       type: config.type,
       label: entry.label,
       data: alignSeriesValues(entry.points),
@@ -336,14 +259,146 @@ const chartDatasets = computed(() => {
       backgroundColor: `${config.color}${config.type === 'bar' ? '66' : '22'}`,
       yAxisID: config.yAxisID,
       tension: config.type === 'line' ? 0.25 : 0,
-      borderDash: entry.id === 'debt_totals' ? [3, 3] : [],
+      borderDash: config.borderDash ?? [],
       spanGaps: true,
-    })
-  })
+    },
+  ]
+}
 
-  return datasets
+function buildDebtDatasets(): ChartDataset<'line' | 'bar', Array<number | null>>[] {
+  const totalEntry = props.series?.debt_totals
+  const interestEntry = props.series?.debt_interest
+  const newSpendingEntry = props.series?.debt_new_spending
+
+  if (totalEntry || interestEntry || newSpendingEntry) {
+    const datasets: ChartDataset<'line' | 'bar', Array<number | null>>[] = []
+    if (totalEntry) {
+      datasets.push({
+        type: 'line',
+        label: totalEntry.label,
+        data: alignSeriesValues(totalEntry.points),
+        borderColor: '#F59E0B',
+        backgroundColor: '#F59E0B22',
+        yAxisID: 'yBalance',
+        tension: 0.25,
+        borderDash: [3, 3],
+        spanGaps: true,
+      })
+    }
+    if (interestEntry) {
+      datasets.push({
+        type: 'bar',
+        label: interestEntry.label,
+        data: alignSeriesValues(interestEntry.points),
+        borderColor: '#EF4444',
+        backgroundColor: '#EF444466',
+        yAxisID: 'yFlow',
+        tension: 0,
+        spanGaps: true,
+      })
+    }
+    if (newSpendingEntry) {
+      datasets.push({
+        type: 'bar',
+        label: newSpendingEntry.label,
+        data: alignSeriesValues(newSpendingEntry.points),
+        borderColor: '#8B5CF6',
+        backgroundColor: '#8B5CF666',
+        yAxisID: 'yFlow',
+        tension: 0,
+        spanGaps: true,
+      })
+    }
+    return datasets
+  }
+
+  if (!labels.value.length) {
+    return []
+  }
+
+  return [
+    {
+      type: 'line',
+      label: 'Assets',
+      data: labels.value.map(() => props.assetBalance),
+      borderColor: '#10B981',
+      backgroundColor: '#10B98122',
+      yAxisID: 'yBalance',
+      tension: 0.2,
+      spanGaps: true,
+    },
+    {
+      type: 'line',
+      label: 'Liabilities',
+      data: labels.value.map(() => props.liabilityBalance),
+      borderColor: '#F59E0B',
+      backgroundColor: '#F59E0B22',
+      yAxisID: 'yBalance',
+      tension: 0.2,
+      spanGaps: true,
+    },
+    {
+      type: 'line',
+      label: 'Net balance',
+      data: labels.value.map(() => props.netBalance),
+      borderColor: '#3B82F6',
+      backgroundColor: '#3B82F622',
+      yAxisID: 'yBalance',
+      tension: 0.2,
+      spanGaps: true,
+    },
+  ]
+}
+
+const chartDatasets = computed<ChartDataset<'line' | 'bar', Array<number | null>>[]>(() => {
+  switch (props.selectedAspect) {
+    case 'realized_income':
+      return buildSingleSeriesDataset('realized_income', {
+        color: '#16A34A',
+        type: 'bar',
+        yAxisID: 'yFlow',
+      })
+    case 'manual_adjustments':
+      return buildSingleSeriesDataset('manual_adjustments', {
+        color: '#8B5CF6',
+        type: 'bar',
+        yAxisID: 'yFlow',
+      })
+    case 'spending':
+      return buildSingleSeriesDataset('spending', {
+        color: '#DC2626',
+        type: 'bar',
+        yAxisID: 'yFlow',
+      })
+    case 'debt':
+      return buildDebtDatasets()
+    case 'balances':
+    default:
+      return buildBalanceDatasets()
+  }
 })
 
+const hasData = computed(
+  () =>
+    labels.value.length > 0 &&
+    chartDatasets.value.some((dataset) => dataset.data.some((value) => value !== null)),
+)
+
+function toggleView() {
+  emit('update:viewType', props.viewType === 'Month' ? 'Year' : 'Month')
+}
+
+function toggleMethodology() {
+  isMethodologyOpen.value = !isMethodologyOpen.value
+}
+
+function destroyChart() {
+  if (chartInstance) {
+    chartInstance.destroy()
+    chartInstance = null
+  }
+}
+
 function renderChart() {
   if (!chartCanvas.value || !hasData.value) {
     destroyChart()
@@ -356,23 +411,7 @@ function renderChart() {
   }
 
   destroyChart()
-
   const configuration: ChartConfiguration<'line' | 'bar', Array<number | null>, string> = {
- * Render the chart with the currently selected aspect datasets.
- */
-function renderChart() {
-  if (!chartCanvas.value || !hasData.value) {
-    destroyChart()
-    return
-  }
-
-  const ctx = chartCanvas.value.getContext('2d')
-  if (!ctx) {
-    return
-  }
-
-  destroyChart()
-  chartInstance = new Chart(ctx, {
     type: 'line',
     data: {
       labels: labels.value,
@@ -380,331 +419,88 @@ function renderChart() {
     },
     options: {
       responsive: true,
-      interaction: { mode: 'index', intersect: false },
+      maintainAspectRatio: false,
       scales: {
         yBalance: {
           type: 'linear',
           position: 'left',
-          beginAtZero: false,
-          title: {
-            display: true,
-            text: 'Balance',
-          },
         },
         yFlow: {
           type: 'linear',
           position: 'right',
-          grid: { drawOnChartArea: false },
-          title: {
-            display: true,
-            text: 'Daily amount',
+          grid: {
+            drawOnChartArea: false,
           },
-      scales: { y: { beginAtZero: false } },
-      plugins: {
-        legend: {
-          display: chartDatasets.value.length > 1,
         },
       },
     },
   }
-
   chartInstance = new Chart(ctx, configuration)
 }
 
-/**
- * Build Chart.js datasets for the active forecast aspect.
- *
- * @param {{
- *   selectedAspect: string,
- *   graphMode: string,
- *   realizedHistory: Array<{ label: string, balance?: number | null }>,
- *   timeline: Array<{ label: string, forecast_balance?: number | null }>,
- *   cashflows: Array<{ date?: string, label?: string, amount?: number | null, source?: string }>,
- *   assetBalance: number,
- *   liabilityBalance: number,
- *   netBalance: number,
- * }} options
- * @returns {Array<{label: string, data: Array<number | null>, borderColor: string, tension: number, borderDash: number[]}>}
- */
-function buildAspectDatasets({
-  selectedAspect,
-  graphMode,
-  realizedHistory,
-  timeline,
-  cashflows,
-  assetBalance,
-  liabilityBalance,
-  netBalance,
-}) {
-  const historyLength = realizedHistory.length
-  const forecastLength = timeline.length
-  const historyBalanceData = realizedHistory.map((point) => normalizeNumber(point.balance))
-  const forecastBalanceData = timeline.map((point) => normalizeNumber(point.forecast_balance))
-  const forecastTimelineLabels = timeline.map((point) => point.label)
-
-  const aspectBuilders = {
-    balances: () => [
-      makeHistoricalDataset(
-        'Historical balance',
-        historyBalanceData,
-        forecastLength,
-        graphMode,
-        '#10B981',
-      ),
-      makeForecastDataset(
-        'Projected balance',
-        forecastBalanceData,
-        historyLength,
-        graphMode,
-        '#3B82F6',
-      ),
-    ],
-    realized_income: () => [
-      makeForecastDataset(
-        'Projected income',
-        aggregateCashflowsByLabel({
-          labels: forecastTimelineLabels,
-          cashflows,
-          include: (item) => item.amount > 0 && item.source !== 'adjustment',
-          transform: (amount) => amount,
-        }),
-        historyLength,
-        '#16A34A',
-        { ignoreGraphMode: true },
-      ),
-    ],
-    manual_adjustments: () => [
-      makeForecastDataset(
-        'Manual adjustments',
-        aggregateCashflowsByLabel({
-          labels: forecastTimelineLabels,
-          cashflows,
-          include: (item) => item.source === 'adjustment',
-          transform: (amount) => amount,
-        }),
-        historyLength,
-        '#7C3AED',
-        { ignoreGraphMode: true },
-      ),
-    ],
-    spending: () => [
-      makeForecastDataset(
-        'Projected spending',
-        aggregateCashflowsByLabel({
-          labels: forecastTimelineLabels,
-          cashflows,
-          include: (item) => item.amount < 0 && item.source !== 'adjustment',
-          transform: (amount) => Math.abs(amount),
-        }),
-        historyLength,
-        '#DC2626',
-        { ignoreGraphMode: true },
-      ),
-    ],
-    debt: () => {
-      const snapshotLength = historyLength + forecastLength
-      return [
-        makeStaticDataset('Assets', assetBalance, snapshotLength, '#0EA5E9'),
-        makeStaticDataset('Liabilities', liabilityBalance, snapshotLength, '#F97316'),
-        makeStaticDataset('Net balance', netBalance, snapshotLength, '#111827'),
-      ]
-    },
-  }
-
-  const datasets = (aspectBuilders[selectedAspect] || aspectBuilders.balances)()
-  return datasets.filter((dataset) => dataset.data.some((value) => value !== null))
-}
-
-/**
- * Keep chart values numeric and convert absent points into nulls.
- *
- * @param {number | null | undefined} value
- * @returns {number | null}
- */
-function normalizeNumber(value) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
-}
-
-/**
- * Prefix a forecast-only dataset with nulls so it aligns after realized history.
- *
- * @param {string} label
- * @param {Array<number | null>} values
- * @param {number} historyLength
- * @param {string} graphMode
- * @param {string} borderColor
- * @param {{ ignoreGraphMode?: boolean }} [options]
- */
-function makeForecastDataset(label, values, historyLength, graphMode, borderColor, options = {}) {
-  const isHidden = !options.ignoreGraphMode && graphMode === 'historical'
-  return {
-    label,
-    data: isHidden ? [] : [...new Array(historyLength).fill(null), ...values],
-    borderColor,
-    tension: 0.3,
-    borderDash: [5, 5],
-  }
-}
-
-/**
- * Pad a realized-history dataset so it stops before forecast points begin.
- *
- * @param {string} label
- * @param {Array<number | null>} values
- * @param {number} forecastLength
- * @param {string} graphMode
- * @param {string} borderColor
- */
-function makeHistoricalDataset(label, values, forecastLength, graphMode, borderColor) {
-  const isHidden = graphMode === 'forecast'
-  return {
-    label,
-    data: isHidden ? [] : [...values, ...new Array(forecastLength).fill(null)],
-    borderColor,
-    tension: 0.3,
-    borderDash: [],
-  }
-}
-
-/**
- * Create a constant-value dataset for snapshot-style comparisons.
- *
- * @param {string} label
- * @param {number} value
- * @param {number} pointCount
- * @param {string} borderColor
- */
-function makeStaticDataset(label, value, pointCount, borderColor) {
-  return {
-    label,
-    data: new Array(pointCount).fill(normalizeNumber(value)),
-    borderColor,
-    tension: 0.15,
-    borderDash: [],
-  }
-}
-
-/**
- * Aggregate forecast cashflows onto the displayed timeline labels.
- *
- * @param {{
- *   labels: string[],
- *   cashflows: Array<{ date?: string, label?: string, amount?: number | null }>,
- *   include: (item: { amount?: number | null, source?: string }) => boolean,
- *   transform: (amount: number) => number,
- * }} options
- * @returns {Array<number | null>}
- */
-function aggregateCashflowsByLabel({ labels, cashflows, include, transform }) {
-  const totals = new Map()
-
-  // The API can emit multiple cashflow rows per day, so the chart collapses them into a single
-  // point per rendered label before plotting the selected aspect.
-  cashflows.forEach((item) => {
-    if (!include(item)) {
-      return
-    }
-
-    const key = String(item.date || item.label || '')
-    if (!key) {
-      return
-    }
-
-    totals.set(key, (totals.get(key) ?? 0) + transform(Number(item.amount ?? 0)))
-  })
-
-  return labels.map((label) => normalizeNumber(totals.get(label) ?? null))
-}
-
-onMounted(renderChart)
-onBeforeUnmount(destroyChart)
-watch(() => [props.timeline, props.realizedHistory, props.graphMode, props.series], renderChart, {
-  deep: true,
-})
 watch(
   () => [
     props.timeline,
     props.realizedHistory,
     props.graphMode,
+    props.series,
     props.selectedAspect,
-    props.cashflows,
-    props.assetBalance,
-    props.liabilityBalance,
-    props.netBalance,
   ],
   renderChart,
   { deep: true },
 )
+
+onMounted(() => {
+  renderChart()
+})
+
+onBeforeUnmount(() => {
+  destroyChart()
+})
 </script>
 
 <style scoped>
-@reference "../../assets/css/main.css";
 .chart-container {
-  background-color: var(--surface);
-  color: var(--theme-fg);
-  border: 1px solid var(--divider);
-  border-radius: 0.5rem;
-  padding: 1rem;
+  min-height: 24rem;
 }
+
 .chart-header {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 1rem;
   margin-bottom: 1rem;
-  gap: 1rem;
 }
+
 .chart-header-copy {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.35rem;
 }
+
 .chart-title {
   font-size: 1.125rem;
   font-weight: 600;
 }
-.chart-subtitle {
-  margin-top: 0.25rem;
-  font-size: 0.875rem;
-  color: var(--text-muted);
+
+.chart-subtitle,
+.chart-methodology-body,
+.chart-empty {
+  color: #4b5563;
 }
-.chart-methodology {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
+
 .chart-methodology-summary {
   cursor: pointer;
-  list-style: none;
   font-weight: 500;
 }
-.chart-methodology-summary::-webkit-details-marker {
-  display: none;
-}
-.chart-methodology-summary::before {
-  content: 'ⓘ';
-  margin-right: 0.35rem;
-}
-.chart-methodology-body {
-  margin-top: 0.35rem;
-  max-width: 36rem;
-  line-height: 1.45;
-}
+
 .toggle-button {
-  font-size: 0.875rem;
-  padding: 0.25rem 0.75rem;
-  border: 1px solid var(--divider);
-  border-radius: 0.375rem;
-  background-color: var(--input-bg);
-  color: var(--theme-fg);
-  cursor: pointer;
-  transition: background-color 0.2s ease;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
 }
-.toggle-button:hover {
-  background-color: var(--hover-bg);
-}
-.chart-empty {
-  padding: 1.5rem;
-  text-align: center;
-  font-size: 0.9rem;
-  color: var(--text-muted);
+
+canvas {
+  min-height: 20rem;
 }
 </style>

--- a/frontend/src/components/forecast/ForecastLayout.vue
+++ b/frontend/src/components/forecast/ForecastLayout.vue
@@ -9,6 +9,7 @@
     <div v-else-if="!hasForecastData" class="card glass text-sm text-gray-500">
       Forecast data is not available yet. Add adjustments or try again later.
     </div>
+
     <ForecastSummaryPanel
       :asset-balance="assetBalance"
       :liability-balance="liabilityBalance"
@@ -54,7 +55,7 @@
           <option :value="90">90 days</option>
         </select>
       </label>
-      <label> <input v-model="normalize" type="checkbox" class="mr-1" /> Normalize history </label>
+      <label><input v-model="normalize" type="checkbox" class="mr-1" /> Normalize history</label>
     </div>
 
     <div class="card glass adjustments-grid">
@@ -105,12 +106,12 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import ForecastSummaryPanel from './ForecastSummaryPanel.vue'
-import ForecastChart from './ForecastChart.vue'
-import ForecastBreakdown from './ForecastBreakdown.vue'
 import ForecastAdjustmentsForm from './ForecastAdjustmentsForm.vue'
+import ForecastBreakdown from './ForecastBreakdown.vue'
+import ForecastChart from './ForecastChart.vue'
+import ForecastSummaryPanel from './ForecastSummaryPanel.vue'
 import {
   type ForecastAdjustmentInput,
   type ForecastAspectSeries,
@@ -119,7 +120,6 @@ import {
   type ForecastViewType,
   useForecastData,
 } from '@/composables/useForecastData'
-import { useForecastData } from '@/composables/useForecastData'
 import { useAccountGroups } from '@/composables/useAccountGroups'
 import api from '@/services/api'
 
@@ -129,9 +129,8 @@ const FORECAST_ASPECT_OPTIONS = [
   { value: 'manual_adjustments', label: 'Manual adjustments' },
   { value: 'spending', label: 'Spending' },
   { value: 'debt', label: 'Debt composition' },
-]
+] as const
 
-const viewType = ref('Month')
 type ForecastComputeMeta = {
   lookbackDays: number
   movingAverageWindow: 7 | 30 | 60 | 90
@@ -140,24 +139,31 @@ type ForecastComputeMeta = {
   autoDetectedAdjustmentCount: number
 }
 
+type ForecastAccountOption = {
+  account_id: string
+  name: string
+  institution_name: string
+}
+
 const viewType = ref<ForecastViewType>('Month')
 const manualIncome = ref(0)
 const liabilityRate = ref(0)
-const adjustments = ref([])
+const adjustments = ref<ForecastAdjustmentInput[]>([])
 const userId = ref(import.meta.env.VITE_USER_ID_PLAID || '')
-const forecastAccounts = ref([])
-const includedAccountIds = ref([])
-const excludedAccountIds = ref([])
-const movingAverageWindow = ref(30)
+const forecastAccounts = ref<ForecastAccountOption[]>([])
+const includedAccountIds = ref<string[]>([])
+const excludedAccountIds = ref<string[]>([])
+const movingAverageWindow = ref<7 | 30 | 60 | 90>(30)
 const normalize = ref(false)
-const graphMode = ref('combined')
-const selectedAspect = ref('balances')
+const graphMode = ref<ForecastGraphMode>('combined')
+const selectedAspect = ref<(typeof FORECAST_ASPECT_OPTIONS)[number]['value']>('balances')
 const forecastAspectOptions = computed(() => FORECAST_ASPECT_OPTIONS)
 const { groups: accountSnapshotGroups } = useAccountGroups({ userId: userId.value })
 
 const {
   timeline,
   summary,
+  cashflows,
   adjustments: appliedAdjustments,
   series,
   metadata,
@@ -187,14 +193,14 @@ const netBalance = computed(() =>
   Number(metadata.value?.net_balance ?? summary.value?.starting_balance ?? 0),
 )
 
-const seriesEntries = computed(() => Object.values(series.value || {}))
 const forecastItems = computed(() =>
-  seriesEntries.value.map((entry) => ({
+  Object.values(series.value || {}).map((entry) => ({
     label: entry.label,
     amount: entry.points.reduce((total, point) => total + Number(point.value ?? 0), 0),
   })),
 )
-const baselineTrendAdjustment = computed(() => {
+
+const baselineTrendAdjustment = computed<ForecastAdjustmentInput | null>(() => {
   const avgDaily = Number(summary.value?.average_daily_change ?? 0)
   if (!Number.isFinite(avgDaily) || avgDaily === 0) {
     return null
@@ -208,6 +214,7 @@ const baselineTrendAdjustment = computed(() => {
     reason: 'Derived from historical average net change.',
   }
 })
+
 const autoDetectedAdjustments = computed(() => [
   ...(appliedAdjustments.value || []).filter((adjustment) =>
     String(adjustment?.adjustment_type || '')
@@ -216,6 +223,7 @@ const autoDetectedAdjustments = computed(() => [
   ),
   ...(baselineTrendAdjustment.value ? [baselineTrendAdjustment.value] : []),
 ])
+
 const manualAdjustmentSeries = computed<ForecastAspectSeries | null>(
   () => series.value?.manual_adjustments ?? null,
 )
@@ -228,6 +236,7 @@ const manualAdjustmentPoints = computed<ForecastSeriesPoint[]>(() =>
 const realizedIncomePoints = computed<ForecastSeriesPoint[]>(() =>
   (realizedIncomeSeries.value?.points || []).filter((point) => Number(point.value ?? 0) !== 0),
 )
+
 const forecastAccountIdSet = computed(
   () => new Set(forecastAccounts.value.map((account) => account.account_id)),
 )
@@ -250,8 +259,14 @@ const accountGroupOptions = computed(() =>
     })
     .filter((group) => group.id && group.accountIds.length > 0),
 )
+
 const hasForecastData = computed(
-  () => timeline.value.length > 0 || hasRenderableCashflows(cashflows.value),
+  () =>
+    timeline.value.length > 0 ||
+    cashflows.value.some((entry) => Number(entry?.amount ?? 0) !== 0) ||
+    Object.values(series.value || {}).some((entry) =>
+      entry.points.some((point) => Number(point.value ?? 0) !== 0),
+    ),
 )
 const isLoading = computed(() => loading.value)
 const realizedHistory = computed(
@@ -267,8 +282,14 @@ const forecastComputeMeta = computed<ForecastComputeMeta>(() => ({
       realizedHistory.value.length ??
       0,
   ),
-  movingAverageWindow: movingAverageWindow.value,
-  normalize: normalize.value,
+  movingAverageWindow: Number(
+    metadata.value?.moving_average_window ??
+      summary.value?.metadata?.moving_average_window ??
+      movingAverageWindow.value,
+  ) as 7 | 30 | 60 | 90,
+  normalize: Boolean(
+    metadata.value?.normalize ?? summary.value?.metadata?.normalize ?? normalize.value,
+  ),
   includesAutoDetectedAdjustments: autoDetectedAdjustments.value.length > 0,
   autoDetectedAdjustmentCount: autoDetectedAdjustments.value.length,
 }))
@@ -290,32 +311,20 @@ watch(
     normalize,
     graphMode,
   ],
-  fetchData,
+  () => {
+    void fetchData()
+  },
+  { deep: true },
 )
 
-/**
- * Determine whether any cashflow items exist that can feed non-balance chart aspects.
- *
- * @param {Array<{ amount?: number | null }>} entries
- * @returns {boolean}
- */
-function hasRenderableCashflows(entries) {
-  return entries.some((entry) => Number(entry?.amount ?? 0) !== 0)
-}
-
-/**
- * Load forecast account options and default to including all visible accounts.
- *
- * @returns {Promise<void>}
- */
 async function fetchForecastAccounts() {
   try {
     const response = await api.getAccounts()
     const accounts = Array.isArray(response.accounts) ? response.accounts : []
     forecastAccounts.value = accounts.map((account) => ({
-      account_id: account.account_id,
-      name: account.name,
-      institution_name: account.institution_name,
+      account_id: String(account.account_id),
+      name: String(account.name || 'Unknown account'),
+      institution_name: String(account.institution_name || 'Unknown institution'),
     }))
     if (includedAccountIds.value.length === 0) {
       includedAccountIds.value = forecastAccounts.value.map((account) => account.account_id)
@@ -325,18 +334,14 @@ async function fetchForecastAccounts() {
   }
 }
 
-/**
- * Capture adjustment inputs so the compute request can include them.
- *
- * @param {import('@/composables/useForecastData').ForecastAdjustmentInput} adjustment
- */
-function addAdjustment(adjustment) {
+function addAdjustment(adjustment: ForecastAdjustmentInput) {
   adjustments.value = [...adjustments.value, adjustment]
 }
 </script>
 
 <style scoped>
 @reference "../../assets/css/main.css";
+
 .forecast-layout {
   display: flex;
   flex-direction: column;
@@ -359,30 +364,16 @@ function addAdjustment(adjustment) {
 .adjustments-title {
   font-size: 0.95rem;
   font-weight: 600;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
 }
 
 .adjustments-empty {
-  font-size: 0.85rem;
-  color: var(--text-muted);
+  color: #6b7280;
 }
 
 .adjustments-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.adjustments-list li {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 0.5rem;
-  font-size: 0.85rem;
-}
-
-.adjustments-list.auto strong {
-  color: #047857;
 }
 </style>

--- a/frontend/src/components/forecast/ForecastSummaryPanel.vue
+++ b/frontend/src/components/forecast/ForecastSummaryPanel.vue
@@ -290,10 +290,10 @@ const tooltipCopy = computed(() => {
     liabilities: `Liabilities total included debt balances that reduce the starting position. Click the amount to review ${forecastScope}.`,
     currentBalance: `Current Balance is assets minus liabilities across ${forecastScope} before projected cashflow changes are applied.`,
     manualIncome: `Manual Income adds $${incomeValue} per day to the projection in ${props.viewType} view. Use it for steady income not captured automatically.`,
-    liabilityRate: `Liability Rate subtracts $${liabilityValue} per day from the projection in ${props.viewType} view to model recurring debt growth or payments.`,
+    liabilityRate: `Liability Rate subtracts $${liabilityValue} per day from the projection in ${props.viewType} view and classifies that manual control as debt growth from new spending, not interest accrual.`,
     netDelta: Number.isFinite(Number(props.netChange))
       ? `Net Delta is the forecasted change between the starting and ending balance. It uses a ${movingAverageWindow || 'current'}-day moving average${lookbackDays ? ` across the latest ${lookbackDays} days of history` : ''}${includesAutoDetectedAdjustments ? ` and includes ${autoDetectedAdjustmentCount} auto-detected adjustment${autoDetectedAdjustmentCount === 1 ? '' : 's'}` : ''}.`
-      : 'Net Delta falls back to manual income minus liability rate until computed forecast output is available.',
+      : 'Net Delta falls back to manual income minus liability rate until computed forecast output is available, with the liability control treated as debt growth from new spending.',
   }
 })
 

--- a/frontend/src/components/forecast/__tests__/ForecastChart.spec.ts
+++ b/frontend/src/components/forecast/__tests__/ForecastChart.spec.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import ForecastChart from '../ForecastChart.vue'
 import { Chart } from 'chart.js'
 
@@ -15,10 +14,7 @@ const { chartConstructor, chartDestroySpy } = vi.hoisted(() => {
 })
 
 vi.mock('chart.js', () => ({
-  Chart: Object.assign(
-    vi.fn().mockImplementation(() => ({ destroy: vi.fn() })),
-    { register: vi.fn() },
-  ),
+  Chart: Object.assign(chartConstructor, { register: vi.fn() }),
   LineController: {},
   LineElement: {},
   BarController: {},
@@ -29,135 +25,8 @@ vi.mock('chart.js', () => ({
   Legend: {},
   Tooltip: {},
   Filler: {},
-  Chart: Object.assign(chartConstructor, { register: vi.fn() }),
-  registerables: [],
 }))
 
-describe('ForecastChart graph modes', () => {
-  beforeEach(() => {
-    chartConstructor.mockClear()
-    chartDestroySpy.mockClear()
-    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}))
-  })
-
-  it('renders balance history and forecast datasets in combined mode', () => {
-    const wrapper = mount(ForecastChart, {
-      props: {
-        viewType: 'Month',
-        graphMode: 'combined',
-        selectedAspect: 'balances',
-        realizedHistory: [{ label: '2026-03-20', balance: 90 }],
-        timeline: [{ label: '2026-03-22', forecast_balance: 100, actual_balance: null }],
-      },
-    })
-
-    expect(wrapper.text()).toContain('Month · Balances')
-    expect(wrapper.find('canvas').exists()).toBe(true)
-    expect(chartConstructor).toHaveBeenCalledTimes(1)
-    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
-      expect.objectContaining({
-        label: 'Historical balance',
-        data: [90, null],
-      }),
-      expect.objectContaining({
-        label: 'Projected balance',
-        data: [null, 100],
-      }),
-    ])
-  })
-
-  it('respects graph mode for the balance overlay', () => {
-    mount(ForecastChart, {
-      props: {
-        viewType: 'Month',
-        graphMode: 'historical',
-        selectedAspect: 'balances',
-        realizedHistory: [{ label: '2026-03-20', balance: 90 }],
-        timeline: [{ label: '2026-03-22', forecast_balance: 100, actual_balance: null }],
-      },
-    })
-
-    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
-      expect.objectContaining({
-        label: 'Historical balance',
-        data: [90, null],
-      }),
-    ])
-  })
-
-  it('keeps income visible when graph mode changes away from combined', () => {
-    mount(ForecastChart, {
-      props: {
-        viewType: 'Year',
-        graphMode: 'historical',
-        selectedAspect: 'realized_income',
-        realizedHistory: [{ label: '2026-03-20', balance: 90 }],
-        timeline: [
-          { label: '2026-03-22', forecast_balance: 100, actual_balance: null },
-          { label: '2026-03-23', forecast_balance: 110, actual_balance: null },
-        ],
-        cashflows: [
-          {
-            date: '2026-03-22',
-            amount: 125,
-            label: 'Paycheck',
-            category: 'Income',
-            source: 'recurring',
-          },
-          {
-            date: '2026-03-22',
-            amount: 20,
-            label: 'Bonus',
-            category: 'Income',
-            source: 'category_average',
-          },
-          {
-            date: '2026-03-23',
-            amount: -40,
-            label: 'Groceries',
-            category: 'Food',
-            source: 'recurring',
-          },
-          {
-            date: '2026-03-23',
-            amount: 75,
-            label: 'Manual income',
-            category: 'Adjustment',
-            source: 'adjustment',
-          },
-        ],
-      },
-    })
-
-    expect(chartConstructor).toHaveBeenCalledTimes(1)
-    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
-      expect.objectContaining({
-        label: 'Projected income',
-        data: [null, 145, null],
-      }),
-    ])
-  })
-
-  it('shows debt composition datasets with clear labels', () => {
-    const wrapper = mount(ForecastChart, {
-      props: {
-        viewType: 'Month',
-        graphMode: 'combined',
-        selectedAspect: 'debt',
-        realizedHistory: [{ label: '2026-03-20', balance: 90 }],
-        timeline: [{ label: '2026-03-22', forecast_balance: 100, actual_balance: null }],
-        assetBalance: 1200,
-        liabilityBalance: 450,
-        netBalance: 750,
-      },
-    })
-
-    expect(wrapper.text()).toContain('Month · Debt composition')
-    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
-      expect.objectContaining({ label: 'Assets', data: [1200, 1200] }),
-      expect.objectContaining({ label: 'Liabilities', data: [450, 450] }),
-      expect.objectContaining({ label: 'Net balance', data: [750, 750] }),
-    ])
 beforeAll(() => {
   HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
     canvas: document.createElement('canvas'),
@@ -167,28 +36,39 @@ beforeAll(() => {
 const baseProps = {
   viewType: 'Month',
   graphMode: 'combined',
+  selectedAspect: 'balances',
   realizedHistory: [{ date: '2024-01-01', label: 'H1', balance: 90 }],
   timeline: [{ date: '2024-01-02', label: 'F1', forecast_balance: 100, actual_balance: null }],
   series: {
     realized_income: {
       id: 'realized_income',
       label: 'Realized income used for auto-calculation',
-      points: [{ date: '2024-01-01', label: '2024-01-01', value: 20 }],
+      points: [{ date: '2024-01-01', label: '2024-01-01', value: 20, metadata: {} }],
     },
     manual_adjustments: {
       id: 'manual_adjustments',
       label: 'Manual adjustments',
-      points: [{ date: '2024-01-02', label: '2024-01-02', value: 5 }],
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 5, metadata: {} }],
     },
     spending: {
       id: 'spending',
       label: 'Spending',
-      points: [{ date: '2024-01-02', label: '2024-01-02', value: -12 }],
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: -12, metadata: {} }],
     },
     debt_totals: {
       id: 'debt_totals',
-      label: 'Debt totals',
-      points: [{ date: '2024-01-02', label: '2024-01-02', value: 40 }],
+      label: 'Total debt',
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 40, metadata: {} }],
+    },
+    debt_interest: {
+      id: 'debt_interest',
+      label: 'Debt interest accrual',
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 3, metadata: {} }],
+    },
+    debt_new_spending: {
+      id: 'debt_new_spending',
+      label: 'Debt new spending',
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 7, metadata: {} }],
     },
   },
   computeMeta: {
@@ -201,34 +81,40 @@ const baseProps = {
 }
 
 describe('ForecastChart', () => {
-  it('renders the chart canvas and methodology help text', () => {
+  beforeEach(() => {
+    chartConstructor.mockClear()
+    chartDestroySpy.mockClear()
+  })
+
+  it('renders balance history and forecast datasets in combined mode', () => {
     const wrapper = mount(ForecastChart, {
       props: baseProps,
     })
 
+    expect(wrapper.text()).toContain('Month · Balances')
     expect(wrapper.find('canvas').exists()).toBe(true)
-    expect(wrapper.text()).toContain('How this forecast is calculated')
-    expect(wrapper.text()).toContain('latest 90 days of realized history')
-    expect(wrapper.text()).toContain('30-day moving average')
-    expect(wrapper.text()).toContain('Normalization is off')
-    expect(wrapper.text()).toContain('Auto-detected adjustments are included (2 detected)')
-    const chartConfig = (Chart as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1]
-    expect(chartConfig.data.datasets.map((dataset: { label: string }) => dataset.label)).toEqual(
-      expect.arrayContaining([
-        'Historical balance',
-        'Forecast balance',
-        'Realized income used for auto-calculation',
-        'Manual adjustments',
-        'Spending',
-        'Debt totals',
-      ]),
-    )
+    expect(chartConstructor).toHaveBeenCalledTimes(1)
+    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
+      expect.objectContaining({
+        label: 'Historical balance',
+        data: [90, null],
+      }),
+      expect.objectContaining({
+        label: 'Forecast balance',
+        data: [null, 100],
+      }),
+    ])
   })
 
   it('updates methodology help text when compute controls change', async () => {
     const wrapper = mount(ForecastChart, {
       props: baseProps,
     })
+
+    expect(wrapper.text()).toContain('latest 90 days of realized history')
+    expect(wrapper.text()).toContain('30-day moving average')
+    expect(wrapper.text()).toContain('Normalization is off')
+    expect(wrapper.text()).toContain('Auto-detected adjustments are included (2 detected)')
 
     await wrapper.setProps({
       graphMode: 'forecast',
@@ -248,6 +134,39 @@ describe('ForecastChart', () => {
     expect(wrapper.text()).toContain('Auto-detected adjustments are not included')
   })
 
+  it('renders realized income from the typed backend series without balance overlays', async () => {
+    mount(ForecastChart, {
+      props: {
+        ...baseProps,
+        graphMode: 'historical',
+        selectedAspect: 'realized_income',
+      },
+    })
+
+    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
+      expect.objectContaining({
+        label: 'Realized income used for auto-calculation',
+        data: [20, null],
+      }),
+    ])
+  })
+
+  it('renders debt total alongside debt component series', () => {
+    const wrapper = mount(ForecastChart, {
+      props: {
+        ...baseProps,
+        selectedAspect: 'debt',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Month · Debt composition')
+    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
+      expect.objectContaining({ label: 'Total debt', data: [null, 40] }),
+      expect.objectContaining({ label: 'Debt interest accrual', data: [null, 3] }),
+      expect.objectContaining({ label: 'Debt new spending', data: [null, 7] }),
+    ])
+  })
+
   it('emits a view update when toggled', async () => {
     const wrapper = mount(ForecastChart, {
       props: baseProps,
@@ -256,5 +175,16 @@ describe('ForecastChart', () => {
     await wrapper.get('.toggle-button').trigger('click')
 
     expect(wrapper.emitted('update:viewType')).toEqual([['Year']])
+  })
+
+  it('destroys the chart instance when the component unmounts', () => {
+    const wrapper = mount(ForecastChart, {
+      props: baseProps,
+    })
+
+    wrapper.unmount()
+
+    expect(chartDestroySpy).toHaveBeenCalled()
+    expect(Chart).toBeDefined()
   })
 })

--- a/frontend/src/components/forecast/__tests__/ForecastSummaryPanel.spec.ts
+++ b/frontend/src/components/forecast/__tests__/ForecastSummaryPanel.spec.ts
@@ -105,6 +105,9 @@ describe('ForecastSummaryPanel', () => {
 
     expect(wrapper.text()).toContain('Manual Income adds $120.00 per day')
     expect(wrapper.text()).toContain('Liability Rate subtracts $40.00 per day')
+    expect(wrapper.text()).toContain(
+      'classifies that manual control as debt growth from new spending',
+    )
 
     await wrapper.setProps({
       manualIncome: 225,

--- a/frontend/src/composables/__tests__/useForecastData.spec.ts
+++ b/frontend/src/composables/__tests__/useForecastData.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ref, nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 import { useForecastData } from '@/composables/useForecastData'
 
 describe('useForecastData', () => {
@@ -14,7 +14,7 @@ describe('useForecastData', () => {
     vi.restoreAllMocks()
   })
 
-  it('posts account filters and adjustments to the compute endpoint and maps response data', async () => {
+  it('posts account filters and debt-classified adjustments to the compute endpoint and maps response data', async () => {
     const viewType = ref<'Month' | 'Year'>('Month')
     const manualIncome = ref(150)
     const liabilityRate = ref(20)
@@ -54,7 +54,7 @@ describe('useForecastData', () => {
           manual_adjustments: {
             id: 'manual_adjustments',
             label: 'Manual adjustments',
-            points: [{ date: '2024-01-01', label: '2024-01-01', value: 200 }],
+            points: [{ date: '2024-01-01', label: '2024-01-01', value: 200, metadata: {} }],
           },
         },
         metadata: {
@@ -103,14 +103,24 @@ describe('useForecastData', () => {
       expect.arrayContaining([
         expect.objectContaining({ label: 'Manual bonus', amount: 200, frequency: 'monthly' }),
         expect.objectContaining({ label: 'Manual income', amount: 150, frequency: 'daily' }),
-        expect.objectContaining({ label: 'Liability rate', amount: -20, frequency: 'daily' }),
+        expect.objectContaining({
+          label: 'Debt new spending',
+          amount: -20,
+          frequency: 'daily',
+          adjustment_type: 'manual_debt',
+          metadata: expect.objectContaining({
+            debt_component: 'new_spending',
+            debt_series_key: 'debt_new_spending',
+            semantic_type: 'debt_contribution',
+          }),
+        }),
       ]),
     )
 
     expect(timeline.value).toHaveLength(1)
     expect(cashflows.value).toEqual([{ label: 'Manual bonus', amount: 200 }])
     expect(series.value.manual_adjustments?.points).toEqual([
-      { date: '2024-01-01', label: '2024-01-01', value: 200 },
+      { date: '2024-01-01', label: '2024-01-01', value: 200, metadata: {} },
     ])
   })
 
@@ -120,8 +130,8 @@ describe('useForecastData', () => {
     const liabilityRate = ref(0)
     const adjustments = ref([])
     const userId = ref('')
-    const includedAccountIds = ref([])
-    const excludedAccountIds = ref([])
+    const includedAccountIds = ref<string[]>([])
+    const excludedAccountIds = ref<string[]>([])
 
     const { fetchData, error, timeline } = useForecastData({
       viewType,

--- a/frontend/src/composables/useForecastData.ts
+++ b/frontend/src/composables/useForecastData.ts
@@ -1,8 +1,18 @@
-// src/composables/useForecastData.ts
-
-import { ref, computed, type Ref } from 'vue'
+import { computed, ref, type Ref } from 'vue'
 
 export type ForecastViewType = 'Month' | 'Year'
+export type ForecastGraphMode = 'combined' | 'forecast' | 'historical'
+export type DebtComponentType = 'interest' | 'new_spending'
+
+export type ForecastMetadata = {
+  asset_balance?: number
+  liability_balance?: number
+  net_balance?: number
+  debt_component?: DebtComponentType | 'debt_interest' | 'debt_new_spending'
+  debt_series_key?: 'debt_interest' | 'debt_new_spending'
+  semantic_type?: string
+  [key: string]: unknown
+}
 
 export type ForecastAdjustmentInput = {
   label: string
@@ -14,6 +24,7 @@ export type ForecastAdjustmentInput = {
   distribution?: 'single' | 'spread'
   range_start?: string
   range_end?: string
+  metadata?: ForecastMetadata
 }
 
 export type ForecastTimelinePoint = {
@@ -23,13 +34,6 @@ export type ForecastTimelinePoint = {
   actual_balance: number | null
   delta?: number | null
   metadata?: ForecastMetadata
-}
-
-export type ForecastMetadata = {
-  asset_balance?: number
-  liability_balance?: number
-  net_balance?: number
-  [key: string]: unknown
 }
 
 export type ForecastSummary = {
@@ -90,8 +94,6 @@ type ForecastComputeResponse = {
   metadata: ForecastMetadata
 }
 
-export type ForecastGraphMode = 'combined' | 'forecast' | 'historical'
-
 type UseForecastDataOptions = {
   viewType: Ref<ForecastViewType>
   manualIncome: Ref<number>
@@ -103,6 +105,28 @@ type UseForecastDataOptions = {
   movingAverageWindow: Ref<7 | 30 | 60 | 90>
   normalize: Ref<boolean>
   graphMode: Ref<ForecastGraphMode>
+}
+
+/**
+ * Build the explicit debt-growth adjustment emitted for the summary panel's liability control.
+ */
+function buildDebtContributionAdjustment(
+  startDate: string,
+  amount: number,
+): ForecastAdjustmentInput {
+  return {
+    label: 'Debt new spending',
+    amount: -Math.abs(amount),
+    date: startDate,
+    frequency: 'daily',
+    adjustment_type: 'manual_debt',
+    reason: 'Manual daily debt contribution from forecast summary controls.',
+    metadata: {
+      debt_component: 'new_spending',
+      debt_series_key: 'debt_new_spending',
+      semantic_type: 'debt_contribution',
+    },
+  }
 }
 
 /**
@@ -155,13 +179,7 @@ export function useForecastData({
       })
     }
     if (liabilityRate.value) {
-      manualEntries.push({
-        label: 'Liability rate',
-        amount: -Math.abs(liabilityRate.value),
-        date: startDate,
-        frequency: 'daily',
-        adjustment_type: 'manual',
-      })
+      manualEntries.push(buildDebtContributionAdjustment(startDate, liabilityRate.value))
     }
 
     return [...entries, ...manualEntries].filter((entry) => entry.amount !== 0)

--- a/tests/test_forecast_engine.py
+++ b/tests/test_forecast_engine.py
@@ -67,6 +67,8 @@ def test_compute_forecast_serializes_full_payload():
     assert payload["series"]["manual_adjustments"]["points"][0]["value"] == -50.0
     assert payload["series"]["spending"]["points"][0]["value"] == 0.0
     assert payload["series"]["debt_totals"]["points"][0]["value"] == 0.0
+    assert payload["series"]["debt_interest"]["points"][0]["value"] == 0.0
+    assert payload["series"]["debt_new_spending"]["points"][0]["value"] == 0.0
 
 
 def test_compute_forecast_is_deterministic():
@@ -255,8 +257,8 @@ def test_compute_forecast_builds_aspect_series_for_history_and_liabilities():
             {"account_id": "debt-1", "balance": -75.0, "date": "2026-01-03", "account_type": "credit_card"},
         ],
         historical_aggregates=[
-            {"date": "2026-01-01", "inflow": 20.0, "outflow": 5.0},
-            {"date": "2026-01-02", "inflow": 30.0, "outflow": 10.0},
+            {"date": "2026-01-01", "inflow": 20.0, "outflow": 5.0, "debt_interest": 1.0, "debt_new_spending": 4.0},
+            {"date": "2026-01-02", "inflow": 30.0, "outflow": 10.0, "debt_interest": 2.0, "debt_new_spending": 3.0},
         ],
         adjustments=[
             {
@@ -283,8 +285,52 @@ def test_compute_forecast_builds_aspect_series_for_history_and_liabilities():
         {"date": "2026-01-04", "label": "2026-01-04", "value": 10.0, "metadata": {}},
     ]
     assert payload["series"]["debt_totals"]["points"] == [
-        {"date": "2026-01-03", "label": "2026-01-03", "value": 75.0, "metadata": {}},
-        {"date": "2026-01-04", "label": "2026-01-04", "value": 75.0, "metadata": {}},
+        {"date": "2026-01-03", "label": "2026-01-03", "value": 80.0, "metadata": {}},
+        {"date": "2026-01-04", "label": "2026-01-04", "value": 85.0, "metadata": {}},
+    ]
+    assert payload["series"]["debt_interest"]["points"] == [
+        {"date": "2026-01-03", "label": "2026-01-03", "value": 1.5, "metadata": {}},
+        {"date": "2026-01-04", "label": "2026-01-04", "value": 1.5, "metadata": {}},
+    ]
+    assert payload["series"]["debt_new_spending"]["points"] == [
+        {"date": "2026-01-03", "label": "2026-01-03", "value": 3.5, "metadata": {}},
+        {"date": "2026-01-04", "label": "2026-01-04", "value": 3.5, "metadata": {}},
+    ]
+
+
+def test_compute_forecast_carries_debt_adjustment_metadata_into_cashflows_and_series():
+    """Debt-classified adjustments should populate cashflow metadata and debt component series."""
+    payload = compute_forecast(
+        user_id=5,
+        start_date=date(2026, 1, 1),
+        horizon_days=2,
+        latest_snapshots=[{"account_id": "debt-1", "balance": -100.0, "date": "2026-01-01", "account_type": "loan"}],
+        historical_aggregates=[],
+        adjustments=[
+            {
+                "label": "Debt new spending",
+                "amount": -15.0,
+                "date": "2026-01-01",
+                "frequency": "daily",
+                "adjustment_type": "manual_debt",
+                "metadata": {
+                    "debt_component": "new_spending",
+                    "debt_series_key": "debt_new_spending",
+                },
+            }
+        ],
+    )
+
+    adjustment_cashflows = [item for item in payload["cashflows"] if item["source"] == "adjustment"]
+    assert adjustment_cashflows[0]["metadata"]["debt_component"] == "debt_new_spending"
+    assert adjustment_cashflows[0]["metadata"]["debt_growth_amount"] == 15.0
+    assert payload["series"]["debt_new_spending"]["points"] == [
+        {"date": "2026-01-01", "label": "2026-01-01", "value": 15.0, "metadata": {}},
+        {"date": "2026-01-02", "label": "2026-01-02", "value": 15.0, "metadata": {}},
+    ]
+    assert payload["series"]["debt_totals"]["points"] == [
+        {"date": "2026-01-01", "label": "2026-01-01", "value": 115.0, "metadata": {}},
+        {"date": "2026-01-02", "label": "2026-01-02", "value": 130.0, "metadata": {}},
     ]
 
 

--- a/tests/test_forecast_route.py
+++ b/tests/test_forecast_route.py
@@ -459,6 +459,8 @@ def test_forecast_compute_includes_account_filters_and_contribution_metadata(cli
         "snapshot_balance": 100.0,
         "historical_inflow": 40.0,
         "historical_outflow": 15.0,
+        "debt_interest": 0.0,
+        "debt_new_spending": 0.0,
     }
     realized_history = captured["metadata"]["realized_history"]
     assert isinstance(realized_history, list)
@@ -562,3 +564,37 @@ def test_forecast_compute_metadata_balance_breakdown_uses_account_type_mapping(c
     assert captured["metadata"]["liability_balance"] == 350.0
     assert captured["metadata"]["net_balance"] == 650.0
     assert captured["metadata"]["starting_balance"] == 650.0
+
+
+def test_apply_transaction_to_historical_aggregate_tracks_debt_components():
+    aggregate = {
+        "date": datetime(2024, 1, 1).date(),
+        "inflow": 0.0,
+        "outflow": 0.0,
+        "debt_interest": 0.0,
+        "debt_new_spending": 0.0,
+    }
+
+    forecast_module._apply_transaction_to_historical_aggregate(
+        aggregate,
+        amount=12.5,
+        account_type="credit_card",
+        is_interest_charge=True,
+    )
+    forecast_module._apply_transaction_to_historical_aggregate(
+        aggregate,
+        amount=30.0,
+        account_type="credit_card",
+        is_interest_charge=False,
+    )
+    forecast_module._apply_transaction_to_historical_aggregate(
+        aggregate,
+        amount=-18.0,
+        account_type="credit_card",
+        is_interest_charge=False,
+    )
+
+    assert aggregate["outflow"] == 42.5
+    assert aggregate["inflow"] == 18.0
+    assert aggregate["debt_interest"] == 12.5
+    assert aggregate["debt_new_spending"] == 30.0


### PR DESCRIPTION
### Motivation

- Surface explicit debt growth semantics so forecasts can distinguish interest accrual from debt incurred by new spending and manual controls. 
- Provide typed aspect series for frontend charting (total debt, debt interest, debt new spending) instead of inferring debt composition from generic cashflows. 
- Allow adjustments to declare debt attribution so manual controls flow into debt-focused series and cashflow metadata. 

### Description

- Route-level changes in `backend/app/routes/forecast.py` now scan transactions per-day (instead of grouping SQL sums), detect interest-like transactions, and classify liability transaction amounts into `debt_interest` and `debt_new_spending` buckets returned in historical aggregates and metadata. 
- Forecast engine updates in `backend/forecast/engine.py` introduce debt-series keys, parse debt-component metadata from adjustments/cashflows, propagate `average_debt_interest` and `average_debt_new_spending` through `project_balances`, emit explicit baseline debt cashflow rows in `build_cashflow_items`, and construct three typed series (`debt_totals`, `debt_interest`, `debt_new_spending`) in `_build_forecast_series`. 
- Adjustment handling now supports debt attribution: adjustments may include `debt_component`/`debt_series_key` metadata, and the summary-panel liability control is translated into a debt-classified adjustment by the frontend composable `useForecastData`. 
- Frontend updates: components and types were extended to consume the new `series` contract and render debt composition (chart, layout, summary panel, and tests updated), and docs/README were updated to reflect the new contract and behavior. 

### Testing

- Ran backend unit tests with `pytest` covering `tests/test_forecast_engine.py` and `tests/test_forecast_route.py`, which were updated to assert debt series and contribution totals and passed. 
- Ran frontend unit tests with `vitest` for `ForecastChart`, `ForecastSummaryPanel`, and composable `useForecastData`, which were updated to assert typed series behavior and passed. 
- Verified end-to-end changes by exercising the `POST /api/forecast/compute` contract in tests to confirm new metadata and series keys are present and correctly populated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10e69ebf483299585fe868c4d6909)