### PR TITLE
feat(dashboard): prioritize upcoming recurring transactions in snapshot

### DIFF
--- a/backend/app/routes/recurring.py
+++ b/backend/app/routes/recurring.py
@@ -2,13 +2,12 @@
 import types
 from datetime import date, datetime, timedelta, timezone
 
-from flask import Blueprint, jsonify, request
-from sqlalchemy import func
-
 from app.config import logger
 from app.extensions import db
 from app.models import RecurringTransaction, Transaction
 from app.services.recurring_bridge import RecurringBridge
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func
 
 recurring = Blueprint("recurring", __name__)
 

--- a/backend/app/routes/recurring.py
+++ b/backend/app/routes/recurring.py
@@ -29,6 +29,26 @@ def add_months(original_date, months=1):
         return original_date.replace(year=new_year, month=new_month, day=28)
 
 
+def _build_auto_confidence_score(occurrences, latest_date, recent_cutoff, today):
+    """Score auto-detected recurring confidence from history depth and recency.
+
+    Args:
+        occurrences (int): Number of matching transactions in the recent window.
+        latest_date (date): Most recent observed transaction date for the pattern.
+        recent_cutoff (date): Inclusive lower bound used for detection.
+        today (date): Current day.
+
+    Returns:
+        int: Confidence score on a 0-100 scale.
+    """
+    occurrence_score = min(max(occurrences - 1, 0) * 15, 60)
+    lookback_days = max((today - recent_cutoff).days, 1)
+    recency_days = max((today - latest_date).days, 0)
+    recency_ratio = max(0.0, 1 - (recency_days / lookback_days))
+    recency_score = round(recency_ratio * 40)
+    return max(0, min(100, occurrence_score + recency_score))
+
+
 # --------------------------------------
 # PUT /accounts/<account_id>/recurringTx
 # Save or update a recurring transaction
@@ -214,13 +234,26 @@ def get_structured_recurring(account_id):
             if isinstance(next_due, datetime):
                 next_due = next_due.date()
             if 0 <= (next_due - today).days <= 7:
+                confidence_score = _build_auto_confidence_score(
+                    occurrences=row.occurrences,
+                    latest_date=latest_date,
+                    recent_cutoff=recent_cutoff,
+                    today=today,
+                )
                 dummy_tx = types.SimpleNamespace(amount=row.amount)
                 reminders.append(
                     {
                         "source": "auto",
+                        "account_id": account_id,
                         "description": row.description,
                         "amount": display_transaction_amount(dummy_tx),
                         "next_due_date": next_due.strftime("%Y-%m-%d"),
+                        "days_until_due": (next_due - today).days,
+                        "auto_detection": {
+                            "occurrences": row.occurrences,
+                            "latest_transaction_date": latest_date.strftime("%Y-%m-%d"),
+                            "confidence_score": confidence_score,
+                        },
                     }
                 )
 
@@ -235,11 +268,18 @@ def get_structured_recurring(account_id):
                 reminders.append(
                     {
                         "source": "user",
+                        "account_id": account_id,
                         "description": row.description,
                         "amount": display_transaction_amount(row),
                         "next_due_date": next_due.strftime("%Y-%m-%d"),
+                        "days_until_due": (next_due - today).days,
                         "notes": row.notes,
                         "frequency": row.frequency,
+                        "auto_detection": {
+                            "occurrences": 1,
+                            "latest_transaction_date": next_due.strftime("%Y-%m-%d"),
+                            "confidence_score": 35,
+                        },
                     }
                 )
 

--- a/docs/backend/app/routes/recurring.md
+++ b/docs/backend/app/routes/recurring.md
@@ -7,15 +7,18 @@ Status: Active
 # Recurring Transactions Route (`recurring.py`)
 
 ## Purpose
+
 Detect, configure, and track recurring transactions such as subscriptions, rent, or utilities to provide visibility into fixed obligations.
 
 ## Endpoints
+
 - `GET /recurring` – Return detected recurring transactions.
 - `POST /recurring/confirm` – Confirm a transaction pattern as recurring.
 - `DELETE /recurring/<id>` – Remove or disable tracking of a recurring item.
 - `POST /recurring/scan/<account_id>` – Scan an account and persist newly detected recurring entries.
 
 ## Inputs/Outputs
+
 - **GET /recurring**
   - **Inputs:** None.
   - **Outputs:** Array of recurring entries with description, amount, frequency, and next expected date.
@@ -38,17 +41,21 @@ Detect, configure, and track recurring transactions such as subscriptions, rent,
   - **Outputs:** `{ "status": "success", "actions": [] }` summarizing detected changes.
 
 ## Auth
+
 - Requires authenticated user; recurring items are scoped to the user's accounts.
 
 ## Dependencies
+
 - `services.recurring_detector` for detection logic.
 - `models.RecurringTransaction` and `models.Transaction` for storage.
 
 ## Behaviors/Edge Cases
+
 - Recurrence inferred from merchant and cadence heuristics; user confirmation stabilizes predictions.
 - Confirmed recurring entries feed budgeting and forecast views.
 
 ## Sample Request/Response
+
 ```http
 POST /recurring/confirm HTTP/1.1
 Content-Type: application/json
@@ -57,5 +64,10 @@ Content-Type: application/json
 ```
 
 ```json
-{ "id": "rec_001", "description": "Spotify Subscription", "amount": 9.99, "frequency": "monthly" }
+{
+  "id": "rec_001",
+  "description": "Spotify Subscription",
+  "amount": 9.99,
+  "frequency": "monthly"
+}
 ```

--- a/docs/backend/app/routes/recurring.md
+++ b/docs/backend/app/routes/recurring.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-16
+Last Updated: 2026-04-08
 Status: Active
 ---
 
@@ -19,6 +19,14 @@ Detect, configure, and track recurring transactions such as subscriptions, rent,
 - **GET /recurring**
   - **Inputs:** None.
   - **Outputs:** Array of recurring entries with description, amount, frequency, and next expected date.
+- **GET /<account_id>/recurring**
+  - **Inputs:** Path parameter `account_id`.
+  - **Outputs:** `{ "status": "success", "reminders": [...] }` where each reminder now includes:
+    - `account_id`
+    - `days_until_due`
+    - `auto_detection.occurrences`
+    - `auto_detection.latest_transaction_date`
+    - `auto_detection.confidence_score` (0-100 ranking heuristic used by dashboard prioritization)
 - **POST /recurring/confirm**
   - **Inputs:** `{ "transaction_id": "txn_812", "confirmed_label": "Spotify Subscription" }`.
   - **Outputs:** Updated recurring entry metadata.

--- a/docs/frontend/FINANCIAL_SUMMARY_DETAILED.md
+++ b/docs/frontend/FINANCIAL_SUMMARY_DETAILED.md
@@ -9,4 +9,5 @@ Key behaviors:
 - `DailyNetChart` emits padded `data-change` payloads; `FinancialSummary` uses the `startDate` and `endDate` props to align averages, moving averages, and volatility calculations with the padded range.
 - The `summary-change` event from `DailyNetChart` drives the headline totals while the summary panel handles extended metrics (moving averages, trends, volatility) using the padded series.
 - The extended detail view now includes a "Today's Spending" panel that loads a single-day category breakdown and recent transactions for the selected detail date.
+- The extended detail view now includes an "Upcoming Transactions" subsection that merges recurring reminders from selected snapshot accounts and ranks them by recurrence confidence plus observed occurrence count, so stronger auto-detected patterns appear first.
 - When **Compare to average profile** is enabled, chart hover tooltips now provide profile-aware details for each stacked category segment, including the segment amount, share-of-profile percentage, and total stack value for that profile.

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -356,7 +356,8 @@ function buildReminderKey(reminder) {
 function normalizeReminder(reminder, accountId) {
   const occurrences = Number(reminder?.auto_detection?.occurrences ?? 0)
   const serverConfidence = Number(reminder?.auto_detection?.confidence_score)
-  const fallbackConfidence = (reminder?.source === 'auto' ? 40 : 20) + Math.min(occurrences * 12, 60)
+  const fallbackConfidence =
+    (reminder?.source === 'auto' ? 40 : 20) + Math.min(occurrences * 12, 60)
   return {
     ...reminder,
     account_id: reminder?.account_id || accountId,
@@ -380,7 +381,8 @@ function compareReminders(left, right) {
     (right?.auto_detection?.confidence_score || 0) - (left?.auto_detection?.confidence_score || 0)
   if (confidenceDelta !== 0) return confidenceDelta
 
-  const occurrenceDelta = (right?.auto_detection?.occurrences || 0) - (left?.auto_detection?.occurrences || 0)
+  const occurrenceDelta =
+    (right?.auto_detection?.occurrences || 0) - (left?.auto_detection?.occurrences || 0)
   if (occurrenceDelta !== 0) return occurrenceDelta
 
   return String(left?.next_due_date || '').localeCompare(String(right?.next_due_date || ''))
@@ -418,7 +420,9 @@ async function loadUpcomingRecurringTransactions() {
       selectedAccountIds.map(async (accountId) => {
         const response = await getRecurringTransactions(accountId)
         const rawReminders =
-          response?.status === 'success' && Array.isArray(response?.reminders) ? response.reminders : []
+          response?.status === 'success' && Array.isArray(response?.reminders)
+            ? response.reminders
+            : []
         return rawReminders.map((reminder) => normalizeReminder(reminder, accountId))
       }),
     )

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -66,6 +66,40 @@
 
         <DailySpendingPanel :detail-date="detailDate" :min-detail-date="minDetailDate" />
 
+        <section class="recurring-upcoming-panel" aria-live="polite">
+          <div class="recurring-upcoming-header">
+            <h4 class="group-title mb-0">Upcoming Transactions</h4>
+            <p class="recurring-upcoming-subtitle">
+              Prioritized by recurrence confidence and history depth.
+            </p>
+          </div>
+          <p v-if="recurringError" class="recurring-upcoming-state">
+            Unable to load recurring reminders right now.
+          </p>
+          <p v-else-if="isLoadingRecurring" class="recurring-upcoming-state">
+            Loading upcoming recurring transactions…
+          </p>
+          <p v-else-if="!prioritizedReminders.length" class="recurring-upcoming-state">
+            No recurring reminders due in the next 7 days.
+          </p>
+          <ul v-else class="recurring-upcoming-list">
+            <li
+              v-for="reminder in prioritizedReminders"
+              :key="buildReminderKey(reminder)"
+              class="recurring-upcoming-item"
+            >
+              <div>
+                <div class="recurring-upcoming-description">{{ reminder.description }}</div>
+                <div class="recurring-upcoming-meta">
+                  Due {{ reminder.next_due_date }} ·
+                  {{ reminder.auto_detection.occurrences }} matching transactions
+                </div>
+              </div>
+              <div class="recurring-upcoming-amount">{{ reminder.amount }}</div>
+            </li>
+          </ul>
+        </section>
+
         <div class="stats-grid">
           <!-- Averages (Daily + Moving) -->
           <div class="stat-group">
@@ -177,7 +211,9 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
+import api from '@/services/api'
+import { getRecurringTransactions } from '@/api/recurring'
 import { formatAmount } from '@/utils/format'
 import DailySpendingPanel from './DailySpendingPanel.vue'
 
@@ -237,6 +273,10 @@ const TODAY_ISO = formatAsISODate(TODAY)
 
 const detailDate = ref(TODAY_ISO)
 const userAdjustedDate = ref(false)
+const prioritizedReminders = ref([])
+const isLoadingRecurring = ref(false)
+const recurringError = ref(null)
+const remindersFetched = ref(false)
 
 const chartDateBounds = computed(() => {
   const data = Array.isArray(props.chartData) ? props.chartData : []
@@ -295,6 +335,115 @@ function resetDetailDate() {
   userAdjustedDate.value = false
   detailDate.value = defaultDetailDate.value
 }
+
+/**
+ * Build a stable key for rendering recurring reminders.
+ *
+ * @param {Record<string, unknown>} reminder - Reminder payload from recurring endpoints.
+ * @returns {string} Unique-ish key for list rendering.
+ */
+function buildReminderKey(reminder) {
+  return `${reminder.account_id}-${reminder.description}-${reminder.next_due_date}-${reminder.amount}`
+}
+
+/**
+ * Normalize a reminder payload with deterministic fallback confidence.
+ *
+ * @param {Record<string, unknown>} reminder - Raw reminder response item.
+ * @param {string} accountId - Account identifier that produced the reminder.
+ * @returns {Record<string, unknown>} Reminder augmented with sorting metadata.
+ */
+function normalizeReminder(reminder, accountId) {
+  const occurrences = Number(reminder?.auto_detection?.occurrences ?? 0)
+  const serverConfidence = Number(reminder?.auto_detection?.confidence_score)
+  const fallbackConfidence = (reminder?.source === 'auto' ? 40 : 20) + Math.min(occurrences * 12, 60)
+  return {
+    ...reminder,
+    account_id: reminder?.account_id || accountId,
+    auto_detection: {
+      occurrences,
+      latest_transaction_date: reminder?.auto_detection?.latest_transaction_date || '',
+      confidence_score: Number.isFinite(serverConfidence) ? serverConfidence : fallbackConfidence,
+    },
+  }
+}
+
+/**
+ * Sort reminders so high-confidence recurring patterns surface first.
+ *
+ * @param {Record<string, unknown>} left - Left reminder item.
+ * @param {Record<string, unknown>} right - Right reminder item.
+ * @returns {number} Comparator compatible with Array.sort.
+ */
+function compareReminders(left, right) {
+  const confidenceDelta =
+    (right?.auto_detection?.confidence_score || 0) - (left?.auto_detection?.confidence_score || 0)
+  if (confidenceDelta !== 0) return confidenceDelta
+
+  const occurrenceDelta = (right?.auto_detection?.occurrences || 0) - (left?.auto_detection?.occurrences || 0)
+  if (occurrenceDelta !== 0) return occurrenceDelta
+
+  return String(left?.next_due_date || '').localeCompare(String(right?.next_due_date || ''))
+}
+
+/**
+ * Load recurring reminders for selected dashboard snapshot accounts.
+ *
+ * Retrieves up to six reminders due within seven days and ranks them by confidence
+ * and observed recurrence history.
+ *
+ * @returns {Promise<void>} Resolves once reminders are loaded (or gracefully degraded).
+ */
+async function loadUpcomingRecurringTransactions() {
+  if (remindersFetched.value) {
+    return
+  }
+
+  isLoadingRecurring.value = true
+  recurringError.value = null
+
+  try {
+    const snapshotResponse = await api.getAccountSnapshot()
+    const selectedAccountIds = Array.isArray(snapshotResponse?.data?.selected_account_ids)
+      ? snapshotResponse.data.selected_account_ids
+      : []
+
+    if (!selectedAccountIds.length) {
+      prioritizedReminders.value = []
+      remindersFetched.value = true
+      return
+    }
+
+    const reminderGroups = await Promise.all(
+      selectedAccountIds.map(async (accountId) => {
+        const response = await getRecurringTransactions(accountId)
+        const rawReminders =
+          response?.status === 'success' && Array.isArray(response?.reminders) ? response.reminders : []
+        return rawReminders.map((reminder) => normalizeReminder(reminder, accountId))
+      }),
+    )
+
+    prioritizedReminders.value = reminderGroups.flat().sort(compareReminders).slice(0, 6)
+    remindersFetched.value = true
+  } catch (error) {
+    recurringError.value = error
+    prioritizedReminders.value = []
+  } finally {
+    isLoadingRecurring.value = false
+  }
+}
+
+watch(isExtendedView, (showExtended) => {
+  if (showExtended) {
+    loadUpcomingRecurringTransactions()
+  }
+})
+
+onMounted(() => {
+  if (isExtendedView.value) {
+    loadUpcomingRecurringTransactions()
+  }
+})
 
 /**
  * Build an inclusive list of date labels between two ISO date strings.
@@ -818,6 +967,68 @@ function clampDateString(value, min, max) {
 .detail-date-helper {
   font-size: 0.75rem;
   color: var(--color-text-muted);
+}
+
+.recurring-upcoming-panel {
+  border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 25%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  background: color-mix(in srgb, var(--color-bg-sec) 88%, black 12%);
+  margin-top: 0.75rem;
+}
+
+.recurring-upcoming-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.recurring-upcoming-subtitle {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.recurring-upcoming-state {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--color-text-muted);
+}
+
+.recurring-upcoming-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.recurring-upcoming-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--color-accent-cyan) 9%, transparent);
+}
+
+.recurring-upcoming-description {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.recurring-upcoming-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.recurring-upcoming-amount {
+  align-self: center;
+  font-size: 0.86rem;
+  font-weight: 700;
 }
 
 .stats-grid {

--- a/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
+++ b/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
@@ -1,8 +1,25 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import FinancialSummary from '../FinancialSummary.vue'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getAccountSnapshot: vi.fn(async () => ({
+      data: { selected_account_ids: ['acc-1'] },
+    })),
+  },
+}))
+
+vi.mock('@/api/recurring', () => ({
+  getRecurringTransactions: vi.fn(async () => ({
+    status: 'success',
+    reminders: [],
+  })),
+}))
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe('FinancialSummary trends', () => {
   it('uses shared accent utility classes for the global detail toggle', () => {
@@ -186,5 +203,52 @@ describe('FinancialSummary trends', () => {
     expect(metrics.avgDailyNet).toBeCloseTo(16)
     expect(metrics.netMA7).toBeCloseTo(16)
     expect(metrics.netMA30).toBeCloseTo(16)
+  })
+
+  it('ranks upcoming recurring reminders by confidence and occurrences', async () => {
+    const { getRecurringTransactions } = await import('@/api/recurring')
+    getRecurringTransactions.mockImplementation(async () => ({
+      status: 'success',
+      reminders: [
+        {
+          source: 'auto',
+          description: 'Gym Membership',
+          amount: '($45.00)',
+          next_due_date: '2026-04-11',
+          auto_detection: { occurrences: 4, confidence_score: 78 },
+        },
+        {
+          source: 'auto',
+          description: 'Streaming',
+          amount: '($18.00)',
+          next_due_date: '2026-04-10',
+          auto_detection: { occurrences: 6, confidence_score: 92 },
+        },
+      ],
+    }))
+
+    const wrapper = mount(FinancialSummary, {
+      props: {
+        summary: { totalIncome: 600, totalExpenses: 300, totalNet: 300 },
+        chartData: [],
+      },
+      global: {
+        stubs: {
+          DailySpendingPanel: {
+            template: '<div data-test="daily-spending-panel"></div>',
+          },
+        },
+      },
+    })
+
+    await wrapper.find('.accent-toggle-btn').trigger('click')
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    const reminders = wrapper.findAll('.recurring-upcoming-description').map((node) => node.text())
+    expect(reminders[0]).toContain('Streaming')
+    expect(reminders[1]).toContain('Gym Membership')
   })
 })

--- a/tests/test_routes_recurring.py
+++ b/tests/test_routes_recurring.py
@@ -2,7 +2,7 @@ import importlib.util
 import os
 import sys
 import types
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,7 +64,7 @@ class DummyTransaction:
         self.amount = 1.0
         self.description = "d"
         self.merchant_name = ""
-        self.date = datetime.now(UTC)
+        self.date = datetime.now(timezone.utc)
         self.account_id = "acc1"
 
 
@@ -131,7 +131,7 @@ def test_scan_route_returns_list(client, monkeypatch):
         amount=1.0,
         description="d",
         merchant_name="",
-        date=datetime.now(UTC),
+        date=datetime.now(timezone.utc),
         account_id="acc1",  # ✅ Required field
     )
     mock_query.filter_by.return_value = mock_query
@@ -162,3 +162,47 @@ def test_scan_route_returns_list(client, monkeypatch):
     resp = client.post("/api/recurring/scan/acc1")
     assert resp.status_code == 200
     assert isinstance(resp.get_json()["reminders"], list)
+
+
+def test_get_structured_recurring_includes_confidence_metadata(client, monkeypatch):
+    today = recurring_module.date.today()
+    latest_date = today - recurring_module.timedelta(days=3)
+    auto_row = types.SimpleNamespace(
+        description="Rent",
+        amount=-1200.0,
+        occurrences=4,
+        latest_date=latest_date,
+    )
+
+    mock_auto_query = MagicMock()
+    mock_auto_query.filter.return_value = mock_auto_query
+    mock_auto_query.group_by.return_value = mock_auto_query
+    mock_auto_query.having.return_value = mock_auto_query
+    mock_auto_query.all.return_value = [auto_row]
+
+    mock_db = types.SimpleNamespace(session=types.SimpleNamespace(query=MagicMock(return_value=mock_auto_query)))
+    monkeypatch.setattr(recurring_module, "db", mock_db)
+
+    mock_transaction_model = MagicMock()
+    mock_transaction_model.account_id = "account_id"
+    mock_transaction_model.date = "date"
+    mock_transaction_model.id = "id"
+    mock_transaction_model.description = "description"
+    mock_transaction_model.amount = "amount"
+    monkeypatch.setattr(recurring_module, "Transaction", mock_transaction_model)
+
+    mock_recurring_query = MagicMock()
+    mock_recurring_query.filter_by.return_value = mock_recurring_query
+    mock_recurring_query.all.return_value = []
+    mock_recurring_model = MagicMock()
+    mock_recurring_model.query = mock_recurring_query
+    monkeypatch.setattr(recurring_module, "RecurringTransaction", mock_recurring_model)
+
+    response = client.get("/api/recurring/acc1/recurring")
+    assert response.status_code == 200
+    payload = response.get_json()
+    reminder = payload["reminders"][0]
+    assert reminder["source"] == "auto"
+    assert reminder["auto_detection"]["occurrences"] == 4
+    assert 0 <= reminder["auto_detection"]["confidence_score"] <= 100
+    assert reminder["account_id"] == "acc1"


### PR DESCRIPTION
### Motivation
- Surface high-confidence upcoming recurring transactions in the Detailed Financial Snapshot so users can quickly see imminent obligations identified by the system.
- Prefer reminders backed by stronger historical evidence and recent occurrences to reduce noise from weak or one-off matches.
- Provide deterministic frontend ranking and fallbacks so the dashboard can prioritize reminders without requiring additional server-side work for common UX cases.

### Description
- Added an "Upcoming Transactions" subsection to `FinancialSummary.vue` (extended view) that fetches reminders for selected snapshot accounts, normalizes payloads, and displays a prioritized list. The UI includes loading/empty/error states and a compact list layout. (`frontend/src/components/statistics/FinancialSummary.vue`)
- Implemented client-side normalization, deterministic keying, and a comparator that ranks reminders by `auto_detection.confidence_score`, then `occurrences`, then due date. The frontend uses the persisted snapshot via `api.getAccountSnapshot()` to scope which accounts to query. (`frontend/src/components/statistics/FinancialSummary.vue`)
- Extended the backend `GET /api/recurring/<account_id>/recurring` payload to include `account_id`, `days_until_due`, and an `auto_detection` object with `occurrences`, `latest_transaction_date`, and a computed `confidence_score` (0–100) derived from history depth and recency. A `_build_auto_confidence_score` helper implements the scoring heuristic. (`backend/app/routes/recurring.py`)
- Added/updated tests and docs: frontend unit test for reminder ordering and mocks, backend route test to assert presence of confidence metadata, and documentation updates describing the new response fields and the Financial Summary change. (`frontend/src/components/statistics/__tests__/FinancialSummary.spec.js`, `tests/test_routes_recurring.py`, `docs/frontend/FINANCIAL_SUMMARY_DETAILED.md`, `docs/backend/app/routes/recurring.md`)

### Testing
- Ran the component unit tests with Vitest via `npx vitest run src/components/statistics/__tests__/FinancialSummary.spec.js` and they passed (7 tests).
- Ran ESLint on the modified component with `npx eslint` and observed only warnings for style; no new lint errors were introduced for the changed files.
- Attempted to run the backend test suite with `pytest -q` and targeted `pytest -q tests/test_routes_recurring.py`, but tests could not be executed in this environment due to missing system/Python dependencies (for example `flask`, `flask_sqlalchemy`, and other packages); collection aborted in this container.
- `npm run test:unit` (Cypress component runner) could not be executed here because the environment is missing `Xvfb` required by Cypress.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62de7e23c83298bd6a8104ee1e24d)