### PR TITLE
refactor(frontend): standardize dashboard corner radii with tokens

### DIFF
--- a/docs/frontend/corner-radius-migration-guide.md
+++ b/docs/frontend/corner-radius-migration-guide.md
@@ -1,0 +1,32 @@
+# Corner Radius Migration Guide
+
+## Purpose
+
+This guide defines the allowed corner usage for frontend component categories so the dashboard stays consistent with the angular visual system.
+
+## Radius tokens
+
+Defined in `frontend/src/styles/theme.css`:
+
+- `--radius-0`: no rounding (hard edge)
+- `--radius-1`: compact chip/input radius
+- `--radius-2`: standard interactive control radius
+- `--radius-3`: large surface radius for major cards/panels
+
+## Allowed corner usage by component type
+
+| Component type | Allowed token(s) | Notes |
+| --- | --- | --- |
+| Page/section wrappers, hero cards, dashboard panels | `--radius-3` | Use for prominent, high-visibility surfaces only. |
+| Cards and table containers | `--radius-2` to `--radius-3` | Prefer `--radius-3` for dashboard hero surfaces, `--radius-2` for nested shells. |
+| Buttons, selects, form controls | `--radius-1` to `--radius-2` | Primary buttons typically use `--radius-2`; dense controls can use `--radius-1`. |
+| Chips, filter tags, decorative pills | `--radius-1` | Do not use fully rounded pills for decorative tags. |
+| Hard-edge elements (dividers, bars, strict rectangular surfaces) | `--radius-0` | Explicit no-rounding token for angular edges. |
+| Semantic circles (avatars, status dots, presence indicators) | Circle (`rounded-full`) | Keep circular treatment only when meaning requires a circle. |
+
+## Migration checklist
+
+1. Replace Tailwind `rounded-*` classes on shared/global classes with token-backed radius values.
+2. Prefer `.ui-radius-*` helpers from `frontend/src/assets/css/main.css` in templates.
+3. Keep `rounded-full` only for semantic circles; convert decorative pills to `--radius-1`.
+4. During review, verify new components do not introduce larger radii outside this scale.

--- a/docs/frontend/corner-radius-migration-guide.md
+++ b/docs/frontend/corner-radius-migration-guide.md
@@ -15,14 +15,14 @@ Defined in `frontend/src/styles/theme.css`:
 
 ## Allowed corner usage by component type
 
-| Component type | Allowed token(s) | Notes |
-| --- | --- | --- |
-| Page/section wrappers, hero cards, dashboard panels | `--radius-3` | Use for prominent, high-visibility surfaces only. |
-| Cards and table containers | `--radius-2` to `--radius-3` | Prefer `--radius-3` for dashboard hero surfaces, `--radius-2` for nested shells. |
-| Buttons, selects, form controls | `--radius-1` to `--radius-2` | Primary buttons typically use `--radius-2`; dense controls can use `--radius-1`. |
-| Chips, filter tags, decorative pills | `--radius-1` | Do not use fully rounded pills for decorative tags. |
-| Hard-edge elements (dividers, bars, strict rectangular surfaces) | `--radius-0` | Explicit no-rounding token for angular edges. |
-| Semantic circles (avatars, status dots, presence indicators) | Circle (`rounded-full`) | Keep circular treatment only when meaning requires a circle. |
+| Component type                                                   | Allowed token(s)             | Notes                                                                            |
+| ---------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
+| Page/section wrappers, hero cards, dashboard panels              | `--radius-3`                 | Use for prominent, high-visibility surfaces only.                                |
+| Cards and table containers                                       | `--radius-2` to `--radius-3` | Prefer `--radius-3` for dashboard hero surfaces, `--radius-2` for nested shells. |
+| Buttons, selects, form controls                                  | `--radius-1` to `--radius-2` | Primary buttons typically use `--radius-2`; dense controls can use `--radius-1`. |
+| Chips, filter tags, decorative pills                             | `--radius-1`                 | Do not use fully rounded pills for decorative tags.                              |
+| Hard-edge elements (dividers, bars, strict rectangular surfaces) | `--radius-0`                 | Explicit no-rounding token for angular edges.                                    |
+| Semantic circles (avatars, status dots, presence indicators)     | Circle (`rounded-full`)      | Keep circular treatment only when meaning requires a circle.                     |
 
 ## Migration checklist
 

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -25,6 +25,7 @@ All documentation lives in Markdown under `docs/` and mirrors the backend struct
 - [Financial Summary Detailed](../frontend/FINANCIAL_SUMMARY_DETAILED.md) – DailyNetChart + FinancialSummary wiring details
 - [Component Migration Guide](../frontend/component-migration.md) – frontend component organization strategy
 - [Tailwind + Vite Style Reference](../frontend/tailwind-vite-style-reference.md) – CSS utilities and build notes
+- [Corner Radius Migration Guide](../frontend/corner-radius-migration-guide.md) – token scale and allowed corner usage by component type.
 - [Forecast Frontend Components](../frontend/src/components/forecast/ForecastComponent.md) – forecast layout, summary, chart, and adjustment component docs.
 - [Environment Reference](../ENVIRONMENT_REFERENCE.md) – env vars, setup, troubleshooting
 

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -66,6 +66,22 @@
   .text-muted {
     color: var(--color-text-muted);
   }
+
+  .ui-radius-0 {
+    border-radius: var(--radius-0);
+  }
+
+  .ui-radius-1 {
+    border-radius: var(--radius-1);
+  }
+
+  .ui-radius-2 {
+    border-radius: var(--radius-2);
+  }
+
+  .ui-radius-3 {
+    border-radius: var(--radius-3);
+  }
 }
 
 /* Shared component classes */
@@ -76,14 +92,16 @@
   }
 
   .card {
-    @apply rounded-lg shadow-lg p-6;
+    @apply shadow-lg p-6;
+    border-radius: var(--radius-3);
     background-color: var(--color-bg-secondary);
     border: 1px solid var(--divider);
     color: var(--color-text-light);
   }
 
   .btn {
-    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    @apply inline-flex items-center px-4 py-2 border font-semibold;
+    border-radius: var(--radius-2);
     background-color: var(--accent-primary);
     border-color: var(--accent-primary);
     color: var(--accent-primary-contrast);
@@ -98,7 +116,8 @@
   }
 
   .btn-outline {
-    @apply inline-flex items-center px-4 py-2 border rounded-md bg-transparent font-semibold;
+    @apply inline-flex items-center px-4 py-2 border bg-transparent font-semibold;
+    border-radius: var(--radius-2);
     color: var(--accent-primary);
     border-color: var(--accent-primary);
   }
@@ -114,7 +133,7 @@
     border: 1px solid var(--accent-primary);
     color: var(--accent-primary);
     padding: 0.35rem 0.9rem;
-    border-radius: 0.65rem;
+    border-radius: var(--radius-2);
     font-size: 0.85rem;
     font-weight: 600;
     cursor: pointer;
@@ -199,7 +218,8 @@
   }
 
   .btn-primary {
-    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    @apply inline-flex items-center px-4 py-2 border font-semibold;
+    border-radius: var(--radius-2);
     background-color: var(--primary);
     border-color: var(--primary);
     color: var(--accent-primary-contrast);
@@ -211,7 +231,8 @@
   }
 
   .btn-success {
-    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    @apply inline-flex items-center px-4 py-2 border font-semibold;
+    border-radius: var(--radius-2);
     background-color: var(--color-success);
     border-color: var(--color-success);
     color: var(--accent-primary-contrast);
@@ -222,7 +243,8 @@
   }
 
   .btn-alert {
-    @apply inline-flex items-center px-4 py-2 border rounded-md font-semibold;
+    @apply inline-flex items-center px-4 py-2 border font-semibold;
+    border-radius: var(--radius-2);
     background-color: var(--color-error);
     border-color: var(--color-error);
     color: var(--color-bg-dark);
@@ -233,7 +255,8 @@
   }
 
   .input {
-    @apply w-full px-2 py-1 rounded border text-sm;
+    @apply w-full px-2 py-1 border text-sm;
+    border-radius: var(--radius-1);
     background-color: var(--color-bg-dark);
     border-color: var(--divider);
     color: var(--color-text-light);

--- a/frontend/src/components/dashboard/NetOverviewSection.vue
+++ b/frontend/src/components/dashboard/NetOverviewSection.vue
@@ -5,10 +5,10 @@
 <template>
   <section class="flex flex-col gap-6">
     <div
-      class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
+      class="h-3 w-full ui-radius-1 bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
     ></div>
     <div
-      class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-2xl p-8 flex flex-col items-center gap-2"
+      class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] ui-radius-3 shadow-2xl p-8 flex flex-col items-center gap-2"
     >
       <h1
         class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow"
@@ -20,7 +20,7 @@
       <p class="italic text-muted">{{ netWorthMessage }}</p>
     </div>
     <div
-      class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
+      class="h-3 w-full ui-radius-1 bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
     ></div>
     <div class="flex justify-end mb-4">
       <DateRangeSelector
@@ -34,12 +34,12 @@
     </div>
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
       <div
-        class="col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-green)] p-4 flex flex-col"
+        class="col-span-1 bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-green)] p-4 flex flex-col"
       >
         <TopAccountSnapshot />
       </div>
       <div
-        class="daily-net-chart-panel md:col-span-2 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3 relative"
+        class="daily-net-chart-panel md:col-span-2 bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3 relative"
       >
         <DailyNetChart
           :start-date="activeRange.start"
@@ -108,7 +108,7 @@
     </div>
 
     <div
-      class="net-overview-summary-panel bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6"
+      class="net-overview-summary-panel bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-cyan)] p-6"
     >
       <slot name="summary">
         <FinancialSummary

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -440,7 +440,8 @@ export default {
 @reference "tailwindcss"; /* Keep Tailwind utilities available for scoped @apply (Tailwind v4) */
 
 .table-panel {
-  @apply shadow-xl rounded-2xl p-4 md:p-6;
+  @apply shadow-xl p-4 md:p-6;
+  border-radius: var(--radius-3);
   background-color: var(--table-surface-strong);
   border: 1px solid var(--table-border);
 }
@@ -454,7 +455,8 @@ export default {
 }
 
 .table-shell {
-  @apply overflow-x-auto rounded-xl border;
+  @apply overflow-x-auto border;
+  border-radius: var(--radius-2);
   background-color: var(--table-surface);
   border-color: var(--table-border);
 }
@@ -516,7 +518,7 @@ export default {
 .category-chip {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
+  border-radius: var(--radius-1);
   border: 1px solid var(--table-border);
   background: color-mix(in srgb, var(--table-surface-alt) 92%, transparent);
   padding: 0.35rem 0.75rem;
@@ -527,7 +529,8 @@ export default {
 }
 
 .control-surface {
-  @apply flex flex-col md:flex-row md:items-center gap-4 mb-4 rounded-2xl p-4 shadow-inner;
+  @apply flex flex-col md:flex-row md:items-center gap-4 mb-4 p-4 shadow-inner;
+  border-radius: var(--radius-3);
   background-color: var(--table-control);
   border: 1px solid var(--table-border);
 }
@@ -542,7 +545,8 @@ export default {
 }
 
 .control-select {
-  @apply rounded-xl px-3 py-2 shadow-sm outline-none transition;
+  @apply px-3 py-2 shadow-sm outline-none transition;
+  border-radius: var(--radius-2);
   background-color: var(--table-surface);
   border: 1px solid var(--table-border);
   color: var(--text-primary);
@@ -553,7 +557,8 @@ export default {
 }
 
 .pill {
-  @apply text-xs md:text-sm px-3 py-2 rounded-full border transition shadow-sm;
+  @apply text-xs md:text-sm px-3 py-2 border transition shadow-sm;
+  border-radius: var(--radius-1);
   background-color: var(--table-surface);
   border-color: var(--table-border);
   color: var(--text-primary);
@@ -570,7 +575,8 @@ export default {
 }
 
 .filter-tag {
-  @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs;
+  @apply inline-flex items-center gap-2 px-3 py-1 text-xs;
+  border-radius: var(--radius-1);
   background-color: color-mix(in srgb, var(--color-accent-blue) 12%, transparent);
   border: 1px solid var(--table-border);
   color: var(--text-primary);

--- a/frontend/src/components/widgets/AccountSnapshot.vue
+++ b/frontend/src/components/widgets/AccountSnapshot.vue
@@ -5,7 +5,7 @@
   persist or Cancel to revert to the last saved snapshot.
 -->
 <template>
-  <div class="bg-bg-secondary rounded-3xl p-6 shadow-card w-full max-w-3xl">
+  <div class="bg-bg-secondary ui-radius-3 p-6 shadow-card w-full max-w-3xl">
     <header class="flex flex-wrap items-start justify-between gap-4">
       <div class="space-y-1">
         <h3 class="text-lg font-semibold text-blue-950 dark:text-blue-100">Account Snapshot</h3>
@@ -24,7 +24,7 @@
       <div class="flex flex-wrap items-center gap-2 text-xs">
         <button
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
+          class="inline-flex items-center gap-1 ui-radius-2 border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
           @click="handleRefresh"
           :disabled="isLoading || isSaving"
           aria-label="Refresh account snapshot"
@@ -35,7 +35,7 @@
         <button
           v-if="!isEditing"
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
+          class="inline-flex items-center gap-1 ui-radius-2 border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
           @click="startEditing"
           :disabled="isLoading || isSaving"
           aria-label="Edit snapshot selection"
@@ -46,7 +46,7 @@
         <button
           v-else
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:border-emerald-400 hover:text-emerald-800 focus-visible:ring-2 focus-visible:ring-emerald-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200 dark:focus-visible:ring-offset-gray-900"
+          class="inline-flex items-center gap-1 ui-radius-2 border border-emerald-200 bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:border-emerald-400 hover:text-emerald-800 focus-visible:ring-2 focus-visible:ring-emerald-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200 dark:focus-visible:ring-offset-gray-900"
           @click="saveEditing"
           :disabled="isSaving || !hasStagedChanges"
           :aria-label="isSaving ? 'Saving snapshot' : 'Save snapshot selection'"
@@ -57,7 +57,7 @@
         <button
           v-if="isEditing"
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
+          class="inline-flex items-center gap-1 ui-radius-2 border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 transition hover:border-primary hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-offset-gray-900"
           @click="cancelEditing"
           :disabled="isSaving"
           aria-label="Cancel snapshot edits"
@@ -70,7 +70,7 @@
             v-model="selectionCandidate"
             :disabled="isSaving || !stagedAvailableAccounts.length || !isEditing"
             @change="handleAddAccount"
-            class="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-600 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:border-gray-100 disabled:text-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+            class="ui-radius-2 border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-600 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:border-gray-100 disabled:text-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
           >
             <option value="">Add account…</option>
             <option
@@ -91,7 +91,7 @@
     </header>
 
     <section
-      class="mt-6 rounded-2xl border border-gray-100 bg-white/80 p-4 dark:border-gray-800 dark:bg-gray-900/60"
+      class="mt-6 ui-radius-3 border border-gray-100 bg-white/80 p-4 dark:border-gray-800 dark:bg-gray-900/60"
     >
       <dl class="grid gap-4 sm:grid-cols-2">
         <div>
@@ -131,7 +131,7 @@
         <span
           v-for="account in stagedAccounts"
           :key="account.account_id"
-          class="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/5 px-3 py-1 text-xs text-primary dark:border-primary/60"
+          class="inline-flex items-center gap-2 ui-radius-2 border border-primary/40 bg-primary/5 px-3 py-1 text-xs text-primary dark:border-primary/60"
         >
           <span class="i-carbon-chart-multitype text-sm" aria-hidden="true"></span>
           <span class="max-w-[140px] truncate">{{ account.name }}</span>
@@ -154,12 +154,12 @@
         <div
           v-for="s in 3"
           :key="`snapshot-skeleton-${s}`"
-          class="h-20 animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-800/70"
+          class="h-20 animate-pulse ui-radius-3 bg-gray-100 dark:bg-gray-800/70"
         ></div>
       </div>
       <div
         v-else-if="!stagedAccounts.length"
-        class="rounded-2xl border border-dashed border-gray-300 bg-white/40 p-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400"
+        class="ui-radius-3 border border-dashed border-gray-300 bg-white/40 p-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400"
       >
         No accounts selected yet. Use the control above to build your snapshot.
       </div>
@@ -167,11 +167,11 @@
         <article
           v-for="account in stagedAccounts"
           :key="account.account_id"
-          class="overflow-hidden rounded-2xl border border-gray-100 bg-white p-4 shadow-sm transition hover:border-primary/40 dark:border-gray-800 dark:bg-gray-900"
+          class="overflow-hidden ui-radius-3 border border-gray-100 bg-white p-4 shadow-sm transition hover:border-primary/40 dark:border-gray-800 dark:bg-gray-900"
         >
           <button
             type="button"
-            class="flex w-full items-center justify-between gap-4 rounded-xl text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] dark:focus-visible:ring-offset-gray-900"
+            class="flex w-full items-center justify-between gap-4 ui-radius-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:scale-[0.99] dark:focus-visible:ring-offset-gray-900"
             @click="toggleDetails(account.account_id)"
             @keydown.enter.prevent="toggleDetails(account.account_id)"
             @keydown.space.prevent="toggleDetails(account.account_id)"
@@ -202,7 +202,7 @@
                 {{ formatAccounting(resolveAccountBalance(account)) }}
               </span>
               <span
-                class="inline-flex items-center gap-1 rounded-full text-xs font-medium"
+                class="inline-flex items-center gap-1 ui-radius-2 text-xs font-medium"
                 :class="upcomingPillClass(netUpcoming(account))"
               >
                 <span class="i-carbon-calendar text-sm" aria-hidden="true"></span>
@@ -225,7 +225,7 @@
                 <li
                   v-for="(reminder, idx) in upcomingForAccount(account)"
                   :key="reminder.id || reminder.description + reminder.next_due_date + idx"
-                  class="flex items-start justify-between gap-3 rounded-xl bg-gray-50 px-3 py-2 dark:bg-gray-800/60"
+                  class="flex items-start justify-between gap-3 ui-radius-2 bg-gray-50 px-3 py-2 dark:bg-gray-800/60"
                 >
                   <div>
                     <p class="font-semibold text-gray-700 dark:text-gray-200">
@@ -261,7 +261,7 @@
                 <li
                   v-for="tx in recentTxs[account.account_id]"
                   :key="tx.id || tx.transaction_id"
-                  class="flex items-center justify-between gap-3 rounded-xl bg-gray-50 px-3 py-2 transition hover:bg-gray-100 focus-visible:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 active:scale-[0.99] dark:bg-gray-800/60 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900"
+                  class="flex items-center justify-between gap-3 ui-radius-2 bg-gray-50 px-3 py-2 transition hover:bg-gray-100 focus-visible:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 active:scale-[0.99] dark:bg-gray-800/60 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900"
                   role="button"
                   tabindex="0"
                   data-testid="account-snapshot-transaction"

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -20,6 +20,11 @@
   --table-hover: color-mix(in srgb, var(--hover-bg) 68%, #e5e7eb 32%);
   --table-control: color-mix(in srgb, var(--color-bg-secondary) 80%, #e6edf5 20%);
 
+  --radius-0: 0;
+  --radius-1: 0.25rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+
   --theme-fg: #cdcecf;
   --text-primary: #cdcecf;
   --color-text-dark: #000000;


### PR DESCRIPTION
### Motivation

- Create a single small-radius token scale and helper classes so corner radii are consistent and easy to audit across the frontend. 
- Replace scattered Tailwind `rounded-*` usage on high-visibility dashboard surfaces with token-backed values to enforce the angular visual system and avoid drifting styles.

### Description

- Added radius tokens `--radius-0`..`--radius-3` to `frontend/src/styles/theme.css` and introduced helper utilities `.ui-radius-0`..`.ui-radius-3` in `frontend/src/assets/css/main.css` to centralize corner values. 
- Refactored shared component classes in `frontend/src/assets/css/main.css` (`.card`, `.btn`, `.btn-outline`, `.input`, `.accent-toggle-btn`, `.gradient-toggle-btn` and button variants) to consume the new radius tokens instead of Tailwind `rounded-*` utilities. 
- Replaced large rounding on high-visibility dashboard surfaces in `frontend/src/components/dashboard/NetOverviewSection.vue`, `frontend/src/components/tables/TransactionsTable.vue`, and `frontend/src/components/widgets/AccountSnapshot.vue` with token-backed classes / values and converted decorative pills/chips to low-radius styling while preserving circular treatments only where semantically required. 
- Added a migration guide `docs/frontend/corner-radius-migration-guide.md` documenting allowed corner usage by component type and linked it from `docs/index/INDEX.md`.

### Testing

- Ran `npx eslint` against the modified frontend files (`src/styles/theme.css`, `src/assets/css/main.css`, the three modified Vue files`) which reported warnings but no blocking errors for the touched files. 
- Ran `pytest -q` which failed to collect due to missing backend dependencies in the current environment (errors importing `flask`, `flask_sqlalchemy`, `pdfplumber`, etc.).
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in this environment so that check was not executed.
- Ran `cd frontend && npm run lint` which surfaced pre-existing repository-wide lint errors unrelated to this change and therefore did not produce a clean pass for the whole frontend lint job.
- Ran `cd frontend && npm run test:unit` which failed in this environment because Cypress requires `Xvfb` (headless display dependency) that is unavailable here.

Notes: automated checks that depend on full repository environment (backend Python deps, pre-commit hooks, and Cypress system deps) did not pass due to environment constraints rather than changes introduced by this PR; the touched frontend files were validated by ESLint with warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62deeebd883299174ef29ef227029)