### PR TITLE
Configure DeepSource analyzers and exclusions; document settings in README

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,27 +1,35 @@
 version = 1
 
-[[analyzers]]
-name = "test-coverage"
-
+exclude_patterns = [
+  "node_modules/**",
+  "frontend/node_modules/**",
+  "dist/**",
+  "build/**",
+  ".venv/**",
+  "env/**",
+  "__pycache__/**",
+  "frontend/cypress/videos/**",
+  "frontend/cypress/screenshots/**",
+  "frontend/coverage/**",
+]
 
 [[analyzers]]
 name = "sql"
+enabled = true
 
 [[analyzers]]
 name = "python"
+enabled = true
 
   [analyzers.meta]
-  runtime_version = "3.x.x"
+  runtime_version = "3.11"
 
 [[analyzers]]
 name = "javascript"
+enabled = true
 
   [analyzers.meta]
   plugins = ["vue"]
-  environment = [
-   "vitest", 
-   "cypress"
-  ]
 
 [[code_formatters]]
 name = "prettier"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ To surface live R/S arbitrage data in the UI, add the dashboard flag and run the
   npm run test:unit
   ```
 
+## DeepSource analysis notes
+
+- DeepSource static analysis is configured in `.deepsource.toml`.
+- The repository currently enables `python`, `javascript` (Vue plugin), and `sql` analyzers.
+- Coverage analyzer support is intentionally disabled until a dedicated coverage artifact upload pipeline is added.
+- Large/generated paths (for example virtual environments, build outputs, and Cypress artifacts) are excluded to keep analysis runtime stable.
+
 ## Documentation
 
 - Browse `docs/index/INDEX.md` for the structured documentation tree.


### PR DESCRIPTION
### Motivation

- Enable and tune DeepSource static analysis for the repository by turning on selected analyzers, pinning the Python runtime, and excluding large/generated paths to keep analysis stable.
- Document the static analysis configuration and rationale so contributors understand which analyzers are active and why coverage analysis is currently disabled.

### Description

- Updated `.deepsource.toml` to add `exclude_patterns` for virtualenvs, build artifacts, node modules, and Cypress artifacts to reduce analysis noise and runtime.
- Enabled the `python`, `javascript`, and `sql` analyzers and removed the `test-coverage` analyzer, while pinning the Python analyzer runtime to `3.11` via `runtime_version` in `[analyzers.meta]`.
- Removed the `environment` array under the JavaScript analyzer and left code formatters (`prettier`, `isort`, `black`, `ruff`) configured in the file.
- Added a `DeepSource analysis notes` section to `README.md` describing the current analyzer set, excluded paths, and that coverage analyzer support is intentionally disabled until a coverage artifact upload pipeline is available.

### Testing

- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9930d093c8329969a4954a362b0e8)