### PR TITLE
feat(frontend): tighten dashboard depth and panel framing

### DIFF
--- a/docs/devnotes/elevation-vs-border-contrast.md
+++ b/docs/devnotes/elevation-vs-border-contrast.md
@@ -1,0 +1,51 @@
+# Elevation vs Border Contrast (Dashboard Surfaces)
+
+## Purpose
+
+This note defines when dashboard surfaces should use **elevation** (`box-shadow`) versus **edge contrast** (1px/2px framed borders) so styling stays consistent as components evolve.
+
+## Baseline tokens
+
+Use the shared depth and frame tokens from `frontend/src/styles/theme.css`:
+
+- Shadows: `--depth-shadow-resting`, `--depth-shadow-raised`, `--depth-shadow-overlay`
+- Interior highlight: `--depth-inner-glow`
+- Edge contrast: `--edge-contrast-1`, `--edge-contrast-2`
+- Accent edge contrast: `--edge-contrast-accent-cyan`, `--edge-contrast-accent-green`
+- Panel geometry rhythm: `--panel-radius-tight`, `--panel-radius-roomy`, `--panel-space-1/2/3`
+
+## Decision rule
+
+### Prefer border contrast first
+
+Use edge contrast as the default framing for:
+
+- dashboard cards and table wrappers,
+- filter/control shells inside cards,
+- long-lived panels that should feel stable rather than floating.
+
+Apply:
+
+- `1px` border with `--edge-contrast-1` for standard shells,
+- `2px` border with accent contrast token for primary/hero surfaces.
+
+### Add elevation only when hierarchy needs separation
+
+Use restrained shadows only when a surface must read as visually higher than neighboring content:
+
+- `--depth-shadow-resting` for standard panel lift,
+- `--depth-shadow-raised` for hero or emphasized summary surfaces,
+- `--depth-shadow-overlay` for true overlays and modal-like layers.
+
+Always pair depth with `--depth-inner-glow` for subtle interior definition.
+
+## Practical guidance
+
+1. Start with border contrast and spacing tokens.
+2. Add the smallest shadow tier that solves legibility/stacking.
+3. Avoid mixing heavy gradients plus large shadows on the same shell.
+4. Keep corners tight (`--panel-radius-tight` or `--panel-radius-roomy`) and spacing on the 1rem/1.25rem/1.5rem rhythm.
+
+## Scope for this policy
+
+These rules specifically anchor dashboard surfaces, including net overview shells and table wrappers. If a new screen needs a different visual hierarchy, add a follow-up devnote before introducing new depth patterns.

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -20,6 +20,7 @@ All documentation lives in Markdown under `docs/` and mirrors the backend struct
 - [Integrations](../integrations/) – third-party connections
 - [Stake Cleanup Audit](../integrations/stake_cleanup.md) – confirmation that the legacy Stake integration has no remaining code paths
 - [Devnotes](../devnotes/) – working notes and scratch references
+- [Elevation vs Border Contrast](../devnotes/elevation-vs-border-contrast.md) – dashboard depth and framing rules for consistent panel hierarchy.
 - [Codex](../codex/) – exploratory reports
 - [Latest](../latest/) – recent drafts and experiments
 - [Financial Summary Detailed](../frontend/FINANCIAL_SUMMARY_DETAILED.md) – DailyNetChart + FinancialSummary wiring details

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -209,10 +209,11 @@
   }
 
   .card {
-    @apply shadow-lg p-6;
-    border-radius: var(--radius-3);
+    @apply p-6;
+    border-radius: var(--panel-radius-roomy);
     background-color: var(--color-bg-secondary);
-    border: 1px solid var(--divider);
+    border: 1px solid var(--edge-contrast-1);
+    box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
     color: var(--color-text-light);
   }
 
@@ -581,11 +582,9 @@
       color-mix(in srgb, var(--color-bg-sec) 92%, rgba(99, 205, 207, 0.08)) 0%,
       color-mix(in srgb, var(--color-bg-dark) 82%, rgba(122, 162, 247, 0.06)) 100%
     );
-    border: 1px solid color-mix(in srgb, var(--divider) 72%, var(--color-accent-cyan));
-    border-radius: 1.25rem;
-    box-shadow:
-      0 18px 42px rgba(5, 10, 18, 0.48),
-      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--edge-contrast-1);
+    box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
+    border-radius: var(--panel-radius-roomy);
   }
 
   .dashboard-panel-header {

--- a/frontend/src/components/base/BasePanel.vue
+++ b/frontend/src/components/base/BasePanel.vue
@@ -69,9 +69,9 @@ const panelClasses = computed(() => {
   }
   const shadow = {
     none: '',
-    sm: 'shadow-sm',
-    md: 'shadow-lg',
-    lg: 'shadow-2xl',
+    sm: 'shadow-[var(--depth-shadow-resting)]',
+    md: 'shadow-[var(--depth-shadow-raised)]',
+    lg: 'shadow-[var(--depth-shadow-overlay)]',
   }
 
   return [

--- a/frontend/src/components/dashboard/NetOverviewSection.vue
+++ b/frontend/src/components/dashboard/NetOverviewSection.vue
@@ -4,11 +4,12 @@
 -->
 <template>
   <section class="flex flex-col gap-6">
+    <div class="angular-divider mb-2" aria-hidden="true">
+      <span class="angular-divider__rule"></span>
+      <span class="angular-divider__step"></span>
+    </div>
     <div
-      class="h-3 w-full ui-radius-1 bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
-    ></div>
-    <div
-      class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] ui-radius-3 shadow-2xl p-8 flex flex-col items-center gap-2"
+      class="net-overview-hero w-full mb-8 bg-[var(--color-bg-sec)] ui-radius-2 p-6 md:p-7 flex flex-col items-center gap-2"
     >
       <h1
         class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow"
@@ -19,9 +20,10 @@
       <p class="text-lg text-muted">Today is {{ currentDate }}</p>
       <p class="italic text-muted">{{ netWorthMessage }}</p>
     </div>
-    <div
-      class="h-3 w-full ui-radius-1 bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"
-    ></div>
+    <div class="angular-divider mb-2" aria-hidden="true">
+      <span class="angular-divider__rule"></span>
+      <span class="angular-divider__step"></span>
+    </div>
     <div class="flex justify-end mb-4">
       <DateRangeSelector
         :start-date="dateRange.start"
@@ -34,12 +36,12 @@
     </div>
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
       <div
-        class="col-span-1 bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-green)] p-4 flex flex-col"
+        class="net-overview-panel net-overview-panel--accent-green col-span-1 bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col"
       >
         <TopAccountSnapshot />
       </div>
       <div
-        class="daily-net-chart-panel md:col-span-2 bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3 relative"
+        class="daily-net-chart-panel net-overview-panel net-overview-panel--accent-cyan md:col-span-2 bg-[var(--color-bg-sec)] ui-radius-2 p-5 md:p-6 flex flex-col gap-3 relative"
       >
         <DailyNetChart
           :start-date="activeRange.start"
@@ -108,7 +110,7 @@
     </div>
 
     <div
-      class="net-overview-summary-panel bg-[var(--color-bg-sec)] ui-radius-3 shadow-xl border-2 border-[var(--color-accent-cyan)] p-6"
+      class="net-overview-summary-panel net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] ui-radius-2 p-5 md:p-6"
     >
       <slot name="summary">
         <FinancialSummary
@@ -216,10 +218,10 @@ const activeRange = computed(() => props.netRange || props.debouncedRange)
 </script>
 
 <style scoped>
-@import '../../assets/css/main.css';
-
 .username {
-  @apply text-[var(--color-accent-cyan)] text-lg;
+  color: var(--color-accent-cyan);
+  font-size: 1.125rem;
+  font-weight: 600;
   text-shadow: 2px 6px 8px var(--bar-gradient-end);
 }
 
@@ -244,9 +246,56 @@ const activeRange = computed(() => props.netRange || props.debouncedRange)
   isolation: isolate;
 }
 
+.net-overview-hero {
+  border: 2px solid var(--edge-contrast-accent-cyan);
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-raised);
+}
+
+.net-overview-panel {
+  border: 1px solid var(--edge-contrast-1);
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
+}
+
+.net-overview-panel--accent-cyan {
+  border-width: 2px;
+  border-color: var(--edge-contrast-accent-cyan);
+}
+
+.net-overview-panel--accent-green {
+  border-width: 2px;
+  border-color: var(--edge-contrast-accent-green);
+}
+
 .net-overview-summary-panel {
   position: relative;
   z-index: 1;
+}
+
+.angular-divider {
+  position: relative;
+  height: 0.65rem;
+}
+
+.angular-divider__rule {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-accent-cyan) 75%, transparent) 0%,
+    color-mix(in srgb, var(--color-accent-purple) 80%, transparent) 45%,
+    color-mix(in srgb, var(--color-accent-magenta) 74%, transparent) 100%
+  );
+}
+
+.angular-divider__step {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 5.5rem;
+  height: 0.45rem;
+  clip-path: polygon(0 100%, 18% 0, 100% 0, 82% 100%);
+  background: color-mix(in srgb, var(--color-accent-cyan) 38%, transparent);
 }
 
 .daily-net-chart-controls {

--- a/frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap
+++ b/frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap
@@ -2,21 +2,21 @@
 
 exports[`Dashboard section components > renders net overview content and forwards slot content 1`] = `
 "<section data-v-26cbed55="" class="flex flex-col gap-6">
-  <div data-v-26cbed55="" class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
-  <div data-v-26cbed55="" class="w-full mb-8 bg-[var(--color-bg-sec)] border-2 border-[var(--color-accent-cyan)] rounded-2xl shadow-2xl p-8 flex flex-col items-center gap-2">
+  <div data-v-26cbed55="" class="angular-divider mb-2" aria-hidden="true"><span data-v-26cbed55="" class="angular-divider__rule"></span><span data-v-26cbed55="" class="angular-divider__step"></span></div>
+  <div data-v-26cbed55="" class="net-overview-hero w-full mb-8 bg-[var(--color-bg-sec)] rounded-lg p-6 md:p-7 flex flex-col items-center gap-2">
     <h1 data-v-26cbed55="" class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow"> Welcome, <span data-v-26cbed55="" class="username">Casey</span>! </h1>
     <p data-v-26cbed55="" class="text-lg text-muted">Today is January 1, 2025</p>
     <p data-v-26cbed55="" class="italic text-muted">In the black</p>
   </div>
-  <div data-v-26cbed55="" class="h-3 w-full rounded bg-gradient-to-r from-[var(--color-accent-cyan)] via-[var(--color-accent-purple)] to-[var(--color-accent-magenta)] mb-6"></div>
+  <div data-v-26cbed55="" class="angular-divider mb-2" aria-hidden="true"><span data-v-26cbed55="" class="angular-divider__rule"></span><span data-v-26cbed55="" class="angular-divider__step"></span></div>
   <div data-v-26cbed55="" class="flex justify-end mb-4">
     <div data-v-26cbed55="" class="date-range-stub"></div>
   </div>
   <div data-v-26cbed55="" class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
-    <div data-v-26cbed55="" class="col-span-1 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-green)] p-4 flex flex-col">
+    <div data-v-26cbed55="" class="net-overview-panel net-overview-panel--accent-green col-span-1 bg-[var(--color-bg-sec)] rounded-lg p-4 flex flex-col">
       <top-account-snapshot-stub data-v-26cbed55="" accountsubtype="" usespectrum="false" iseditinggroups="false"></top-account-snapshot-stub>
     </div>
-    <div data-v-26cbed55="" class="daily-net-chart-panel md:col-span-2 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 flex flex-col gap-3 relative">
+    <div data-v-26cbed55="" class="daily-net-chart-panel net-overview-panel net-overview-panel--accent-cyan md:col-span-2 bg-[var(--color-bg-sec)] rounded-lg p-5 md:p-6 flex flex-col gap-3 relative">
       <div data-v-26cbed55="" class="daily-net-chart" show7-day="false" show30-day="false" show-avg-income="false" show-avg-expenses="false" show-comparison-overlay="false" comparison-mode="prior_month_to_date" timeframe="mtd">
         <div class="daily-net-chart__title-shell">
           <div data-v-26cbed55="" class="daily-net-chart-title-block">
@@ -33,7 +33,7 @@ exports[`Dashboard section components > renders net overview content and forward
       </div>
     </div>
   </div>
-  <div data-v-26cbed55="" class="net-overview-summary-panel bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6">
+  <div data-v-26cbed55="" class="net-overview-summary-panel net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] rounded-lg p-5 md:p-6">
     <div class="summary-slot">Custom Summary</div>
   </div>
 </section>"

--- a/frontend/src/components/tables/AccountsTable.vue
+++ b/frontend/src/components/tables/AccountsTable.vue
@@ -448,9 +448,11 @@ export default {
 @reference "tailwindcss"; /* Keep Tailwind utilities available for scoped @apply (Tailwind v4) */
 
 .table-panel {
-  @apply shadow-xl rounded-2xl p-5 md:p-7;
+  padding: var(--panel-space-3);
+  border-radius: var(--panel-radius-roomy);
   background-color: var(--table-surface-strong);
-  border: 1px solid var(--table-border);
+  border: 1px solid var(--edge-contrast-1);
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
 }
 
 .table-panel-header {
@@ -554,9 +556,14 @@ export default {
 }
 
 .control-surface {
-  @apply flex flex-col gap-3 mb-4 rounded-2xl p-3 shadow-inner;
+  @apply flex flex-col;
+  gap: var(--panel-space-1);
+  margin-bottom: var(--panel-space-2);
+  padding: var(--panel-space-1);
+  border-radius: var(--panel-radius-tight);
   background-color: var(--table-control);
-  border: 1px solid var(--table-border);
+  border: 1px solid var(--edge-contrast-1);
+  box-shadow: var(--depth-inner-glow);
 }
 
 .input-shell {

--- a/frontend/src/components/tables/TransactionsTable.vue
+++ b/frontend/src/components/tables/TransactionsTable.vue
@@ -468,10 +468,11 @@ export default {
 @reference "tailwindcss"; /* Keep Tailwind utilities available for scoped @apply (Tailwind v4) */
 
 .table-panel {
-  @apply shadow-xl p-4 md:p-6;
-  border-radius: var(--radius-3);
+  padding: var(--panel-space-2);
+  border-radius: var(--panel-radius-roomy);
   background-color: var(--table-surface-strong);
-  border: 1px solid var(--table-border);
+  border: 1px solid var(--edge-contrast-1);
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
 }
 
 .table-title {
@@ -557,10 +558,14 @@ export default {
 }
 
 .control-surface {
-  @apply flex flex-col md:flex-row md:items-center gap-4 mb-4 p-4 shadow-inner;
-  border-radius: var(--radius-3);
+  @apply flex flex-col md:flex-row md:items-center;
+  gap: var(--panel-space-1);
+  margin-bottom: var(--panel-space-2);
+  padding: var(--panel-space-1);
+  border-radius: var(--panel-radius-tight);
   background-color: var(--table-control);
-  border: 1px solid var(--table-border);
+  border: 1px solid var(--edge-contrast-1);
+  box-shadow: var(--depth-inner-glow);
 }
 
 .control-group {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -24,11 +24,32 @@
   --table-border: color-mix(in srgb, var(--divider) 68%, #cbd5e1 32%);
   --table-hover: color-mix(in srgb, var(--hover-bg) 68%, #e5e7eb 32%);
   --table-control: color-mix(in srgb, var(--color-bg-secondary) 80%, #e6edf5 20%);
+  --depth-shadow-resting: 0 8px 20px rgba(5, 10, 18, 0.32);
+  --depth-shadow-raised: 0 12px 28px rgba(5, 10, 18, 0.4);
+  --depth-shadow-overlay: 0 16px 34px rgba(5, 10, 18, 0.46);
+  --depth-inner-glow: inset 0 1px 0 rgba(240, 248, 255, 0.08);
+  --edge-contrast-1: color-mix(in srgb, var(--divider) 62%, #d9e7f5 38%);
+  --edge-contrast-2: color-mix(in srgb, var(--divider) 48%, #eff6ff 52%);
+  --edge-contrast-accent-cyan: color-mix(
+    in srgb,
+    var(--color-accent-cyan) 52%,
+    var(--edge-contrast-2)
+  );
+  --edge-contrast-accent-green: color-mix(
+    in srgb,
+    var(--color-accent-green) 52%,
+    var(--edge-contrast-2)
+  );
 
   --radius-0: 0;
   --radius-1: 0.25rem;
   --radius-2: 0.5rem;
   --radius-3: 0.75rem;
+  --panel-radius-tight: var(--radius-2);
+  --panel-radius-roomy: 0.625rem;
+  --panel-space-1: 1rem;
+  --panel-space-2: 1.25rem;
+  --panel-space-3: 1.5rem;
 
   --theme-fg: #cdcecf;
   --text-primary: #cdcecf;

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -45,7 +45,7 @@
       <template #fallback>
         <section
           data-testid="net-overview-skeleton"
-          class="flex flex-col gap-4 bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 animate-pulse"
+          class="dashboard-skeleton-panel flex flex-col gap-4 bg-[var(--color-bg-sec)] ui-radius-2 border-2 border-[var(--edge-contrast-accent-cyan)] p-6 animate-pulse"
           aria-busy="true"
         >
           <div class="h-6 w-1/3 bg-[var(--divider)] rounded mb-2" />
@@ -85,7 +85,7 @@
         <template #fallback>
           <section
             data-testid="breakdown-skeleton"
-            class="bg-[var(--color-bg-sec)] rounded-2xl shadow-xl border-2 border-[var(--color-accent-cyan)] p-6 animate-pulse"
+            class="dashboard-skeleton-panel bg-[var(--color-bg-sec)] ui-radius-2 border-2 border-[var(--edge-contrast-accent-cyan)] p-6 animate-pulse"
           >
             <div class="h-6 w-40 bg-[var(--divider)] rounded mb-4" />
             <div class="grid grid-cols-2 gap-3">
@@ -738,6 +738,10 @@ watch(reviewFilters, (filters) => loadReviewCount(filters), { immediate: true })
     color-mix(in srgb, var(--color-accent-purple) 18%, var(--color-bg-sec)) 0%,
     color-mix(in srgb, var(--color-accent-cyan) 10%, var(--color-bg-sec)) 100%
   );
+}
+
+.dashboard-skeleton-panel {
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
 }
 
 .review-cta-grid {


### PR DESCRIPTION
### Motivation

- Reduce heavy, diffuse shadows and inconsistent radii on dashboard surfaces by introducing a restrained elevation system and stronger edge contrast to improve legibility and hierarchy.
- Replace decorative rounded gradient separators with angular dividers to simplify decorative elements and improve alignment with the tightened panel framing.

### Description

- Added depth and framing tokens in `frontend/src/styles/theme.css` (`--depth-shadow-*`, `--depth-inner-glow`, `--edge-contrast-*`, `--panel-radius-*`, `--panel-space-*`) to centralize elevation and edge-contrast decisions.
- Replaced large generic shadows and loose radii on shared cards and dashboard panels by switching `card` / `dashboard-panel` defaults in `frontend/src/assets/css/main.css` to use the new tokens and a subtle inner glow instead of heavy `shadow-xl`/`shadow-2xl` looks.
- Converted the Net overview hero and summary wrappers in `frontend/src/components/dashboard/NetOverviewSection.vue` to use tighter radii, 1px/2px accent borders, token-driven shadows, and swapped the gradient separators for an `angular-divider` element with clipped stepped accents.
- Standardized table and control shells by updating `frontend/src/components/tables/AccountsTable.vue` and `frontend/src/components/tables/TransactionsTable.vue` to the new spacing/radius rhythm and edge-contrast framing, and mapped `BasePanel` shadow presets to the tokenized shadow values in `frontend/src/components/base/BasePanel.vue`.
- Added documentation `docs/devnotes/elevation-vs-border-contrast.md` describing when to prefer border contrast vs elevation and linked it from `docs/index/INDEX.md`.
- Updated the affected snapshot `frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap` to reflect the structural/class changes.

### Testing

- Ran `pytest -q`; collection failed due to missing backend Python dependencies in the environment (for example `flask`, `flask_sqlalchemy`, `pdfplumber`) so backend tests could not be executed.
- Attempted to run `pre-commit run --all-files`; the `pre-commit` tool is not available in this environment so hooks could not be run.
- Ran `cd frontend && npm run lint`; lint reported many pre-existing repository-wide errors/warnings unrelated to these targeted CSS/class changes and did not pass cleanly.
- Ran frontend unit/E2E commands: `cd frontend && npm run test:unit` (Cypress component runner) failed because the environment lacks the system dependency `Xvfb`, and `npx vitest run src/components/dashboard/__tests__/DashboardSections.spec.ts` failed before test execution due to a Tailwind utility resolution error for an existing `ui-radius-3` utility in scope; these failures are environmental or pre-existing and not caused by the new depth tokens.

If you want, I can follow up to: (a) run a focused frontend test matrix in CI (where `Xvfb` and node deps are present), (b) fix remaining Tailwind utility tokens or expand the token mapping for `ui-radius-*` usage, or (c) run `eslint --fix` and address frontend lint errors incrementally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4c8c3aa48329b612c2f38c3d00d4)