### PR TITLE
feat(dashboard): add LLM-backed activity status greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For auto-reloading during collaborative work, run the watcher from the project r
 ## Configuration
 
 - `ENABLE_ARBIT_DASHBOARD` – set to `true` to enable the experimental arbitrage dashboard.
+- `OPENAI_API_KEY` – optional key used by `GET /api/dashboard/activity-status` to generate a single parseable dashboard greeting tip from balances and recent transactions. When omitted, the backend uses a deterministic fallback message.
 
 ### Discord arbitrage feed
 

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -2,12 +2,14 @@
 
 from datetime import datetime
 
-from flask import Blueprint, jsonify, request
-
 from app.config import logger
 from app.services import account_groups as account_group_service
-from app.services.account_snapshot import build_snapshot_payload, update_snapshot_selection
+from app.services.account_snapshot import (
+    build_snapshot_payload,
+    update_snapshot_selection,
+)
 from app.services.dashboard_activity_status import generate_activity_status
+from flask import Blueprint, jsonify, request
 
 dashboard = Blueprint("dashboard", __name__)
 

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -1,12 +1,24 @@
 """Dashboard-specific API routes."""
 
+from datetime import datetime
+
 from flask import Blueprint, jsonify, request
 
 from app.config import logger
 from app.services import account_groups as account_group_service
 from app.services.account_snapshot import build_snapshot_payload, update_snapshot_selection
+from app.services.dashboard_activity_status import generate_activity_status
 
 dashboard = Blueprint("dashboard", __name__)
+
+
+def _parse_iso_date_arg(name: str) -> datetime | None:
+    """Parse an optional ``YYYY-MM-DD`` query arg into a datetime."""
+
+    raw = request.args.get(name)
+    if not raw:
+        return None
+    return datetime.strptime(raw, "%Y-%m-%d")
 
 
 @dashboard.route("/account_snapshot", methods=["GET"])
@@ -18,6 +30,25 @@ def get_account_snapshot():
         return jsonify({"status": "success", "data": data}), 200
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.error("Failed to load account snapshot preferences: %s", exc, exc_info=True)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@dashboard.route("/activity-status", methods=["GET"])
+def get_activity_status():
+    """Return a parseable dashboard greeting status generated from recent activity."""
+
+    try:
+        start_date = _parse_iso_date_arg("start_date")
+        end_date = _parse_iso_date_arg("end_date")
+    except ValueError:
+        return jsonify({"status": "error", "message": "start_date and end_date must use YYYY-MM-DD"}), 400
+
+    user_id = request.args.get("user_id")
+    try:
+        data = generate_activity_status(start_date=start_date, end_date=end_date, user_id=user_id)
+        return jsonify({"status": "success", "data": data}), 200
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to generate dashboard activity status: %s", exc, exc_info=True)
         return jsonify({"status": "error", "message": str(exc)}), 500
 
 

--- a/backend/app/services/dashboard_activity_status.py
+++ b/backend/app/services/dashboard_activity_status.py
@@ -1,0 +1,193 @@
+"""Generate dashboard activity-status guidance from account and transaction context."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import requests
+from sqlalchemy import or_
+
+from app.config import logger
+from app.extensions import db
+from app.models import Account, Transaction
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
+MAX_ACCOUNTS_IN_PROMPT = 12
+MAX_TRANSACTIONS_IN_PROMPT = 25
+
+
+def _to_float(value: Decimal | int | float | None) -> float:
+    """Safely convert numeric values to float for JSON serialization."""
+
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _load_accounts(user_id: str | None = None) -> list[dict[str, Any]]:
+    """Load visible accounts for dashboard activity context."""
+
+    query = Account.query.filter(or_(Account.is_hidden.is_(False), Account.is_hidden.is_(None)))
+    if user_id:
+        query = query.filter(Account.user_id == user_id)
+    accounts = query.order_by(Account.balance.desc()).limit(MAX_ACCOUNTS_IN_PROMPT).all()
+    return [
+        {
+            "account_id": account.account_id,
+            "name": account.display_name,
+            "type": account.account_type,
+            "balance": _to_float(account.balance),
+        }
+        for account in accounts
+    ]
+
+
+def _load_transactions(
+    start_date: datetime,
+    end_date: datetime,
+    user_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load recent transactions for dashboard activity context."""
+
+    query = Transaction.query.filter(
+        Transaction.date >= start_date,
+        Transaction.date <= end_date,
+        or_(Transaction.is_internal.is_(False), Transaction.is_internal.is_(None)),
+    )
+    if user_id:
+        query = query.filter(Transaction.user_id == user_id)
+    transactions = (
+        query.order_by(Transaction.date.desc(), Transaction.transaction_id.desc())
+        .limit(MAX_TRANSACTIONS_IN_PROMPT)
+        .all()
+    )
+    return [
+        {
+            "transaction_id": tx.transaction_id,
+            "date": tx.date.date().isoformat(),
+            "description": tx.description or tx.merchant_name or "Unknown transaction",
+            "amount": _to_float(tx.amount),
+            "account_id": tx.account_id,
+        }
+        for tx in transactions
+    ]
+
+
+def _build_fallback_message(accounts: list[dict[str, Any]], transactions: list[dict[str, Any]]) -> dict[str, str]:
+    """Build deterministic fallback guidance when the LLM is unavailable."""
+
+    if not transactions:
+        return {
+            "status_key": "no_recent_activity",
+            "message": "No recent activity was found. Review linked accounts to make sure data is syncing.",
+        }
+
+    largest_expense = min((tx for tx in transactions), key=lambda tx: tx["amount"], default=None)
+    if largest_expense and largest_expense["amount"] < 0:
+        amount = abs(largest_expense["amount"])
+        return {
+            "status_key": "largest_expense",
+            "message": (
+                f"Your largest recent expense was ${amount:,.2f}. "
+                "Verify that this charge is expected and tag it if needed."
+            ),
+        }
+
+    total_balance = sum(account["balance"] for account in accounts)
+    return {
+        "status_key": "balance_check",
+        "message": f"Your visible accounts total ${total_balance:,.2f}. Confirm that this matches your expected cash position.",
+    }
+
+
+def _call_openai_for_status(payload: dict[str, Any]) -> dict[str, str]:
+    """Request a single parseable status message from OpenAI."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not configured")
+
+    model = os.getenv("OPENAI_DASHBOARD_MODEL", DEFAULT_OPENAI_MODEL)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    response = requests.post(
+        OPENAI_API_URL,
+        headers=headers,
+        timeout=15,
+        json={
+            "model": model,
+            "temperature": 0.2,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a personal finance dashboard assistant. "
+                        "Return strict JSON with keys: status_key, message. "
+                        "The message must be one concise sentence with exactly one practical suggestion."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Analyze this activity context and provide one useful suggestion:\n"
+                        f"{json.dumps(payload, separators=(',', ':'))}"
+                    ),
+                },
+            ],
+        },
+    )
+    response.raise_for_status()
+    body = response.json()
+    raw_content = body["choices"][0]["message"]["content"]
+    parsed = json.loads(raw_content)
+    return {
+        "status_key": str(parsed.get("status_key") or "activity_tip"),
+        "message": str(parsed.get("message") or "").strip(),
+    }
+
+
+def generate_activity_status(
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any]:
+    """Generate dashboard activity status text for the greeting area.
+
+    Args:
+        start_date: Optional UTC datetime lower bound for transaction context.
+        end_date: Optional UTC datetime upper bound for transaction context.
+        user_id: Optional user scope identifier.
+
+    Returns:
+        Parseable response payload with a single guidance message and context metadata.
+    """
+
+    resolved_end = end_date or datetime.now(UTC)
+    resolved_start = start_date or (resolved_end - timedelta(days=30))
+    accounts = _load_accounts(user_id=user_id)
+    transactions = _load_transactions(start_date=resolved_start, end_date=resolved_end, user_id=user_id)
+    payload = {
+        "range": {
+            "start_date": resolved_start.date().isoformat(),
+            "end_date": resolved_end.date().isoformat(),
+        },
+        "accounts": accounts,
+        "transactions": transactions,
+    }
+
+    try:
+        generated = _call_openai_for_status(payload)
+        if generated.get("message"):
+            return {**generated, "source": "llm"}
+    except Exception as exc:  # pragma: no cover - network + provider fallback
+        logger.warning("Falling back to deterministic activity status: %s", exc)
+
+    return {**_build_fallback_message(accounts, transactions), "source": "fallback"}

--- a/backend/app/services/dashboard_activity_status.py
+++ b/backend/app/services/dashboard_activity_status.py
@@ -9,11 +9,10 @@ from decimal import Decimal
 from typing import Any
 
 import requests
-from sqlalchemy import or_
-
 from app.config import logger
 from app.extensions import db
 from app.models import Account, Transaction
+from sqlalchemy import or_
 
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"

--- a/docs/backend/app/routes/dashboard.md
+++ b/docs/backend/app/routes/dashboard.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-16
+Last Updated: 2026-04-08
 Status: Active
 ---
 
@@ -21,6 +21,7 @@ Serve dashboard configuration data including account snapshot selections and cus
 - `POST /api/dashboard/account-groups/<group_id>/accounts` – Attach an account to a group.
 - `DELETE /api/dashboard/account-groups/<group_id>/accounts/<account_id>` – Detach an account from a group.
 - `POST /api/dashboard/account-groups/<group_id>/accounts/reorder` – Save the ordering of accounts within a group.
+- `GET /api/dashboard/activity-status` – Generate a parseable greeting status message from account balances and recent transactions.
 
 ## Inputs/Outputs
 - **Snapshot endpoints**
@@ -29,6 +30,9 @@ Serve dashboard configuration data including account snapshot selections and cus
 - **Group endpoints**
   - **Inputs:** JSON bodies with identifiers (`group_id`, `group_ids`, `account_id`) and metadata to create, reorder, or update groups.
   - **Outputs:** Success payloads mirroring the request structure or updated group objects.
+- **Activity status endpoint**
+  - **Inputs:** Optional `start_date`, `end_date` (YYYY-MM-DD), and `user_id` query params.
+  - **Outputs:** `{ "status": "success", "data": { "status_key": str, "message": str, "source": "llm"|"fallback" } }`.
 
 ## Auth
 - Requires authenticated context; selections are stored per user.
@@ -36,6 +40,7 @@ Serve dashboard configuration data including account snapshot selections and cus
 ## Dependencies
 - `app.services.account_snapshot` helpers (`build_snapshot_payload`, `update_snapshot_selection`).
 - `app.services.account_groups` CRUD helpers for group and membership management.
+- `app.services.dashboard_activity_status` for LLM/fallback greeting generation.
 - Application logger for defensive error logging.
 
 ## Behaviors/Edge Cases

--- a/docs/backend/app/routes/dashboard.md
+++ b/docs/backend/app/routes/dashboard.md
@@ -7,9 +7,11 @@ Status: Active
 # Dashboard Route (`dashboard.py`)
 
 ## Purpose
+
 Serve dashboard configuration data including account snapshot selections and customizable account groups to power personalized views.
 
 ## Endpoints
+
 - `GET /api/dashboard/account_snapshot` – Return the persisted snapshot selection and hydrated account metadata.
 - `PUT /api/dashboard/account_snapshot` – Validate and persist account snapshot selections.
 - `GET /api/dashboard/account-groups` – Load all account groups and the active preference.
@@ -24,6 +26,7 @@ Serve dashboard configuration data including account snapshot selections and cus
 - `GET /api/dashboard/activity-status` – Generate a parseable greeting status message from account balances and recent transactions.
 
 ## Inputs/Outputs
+
 - **Snapshot endpoints**
   - **Inputs:** Optional `user_id` in query/body for scoping.
   - **Outputs:** `{ "status": "success", "data": { ...snapshot payload... } }`.
@@ -35,20 +38,24 @@ Serve dashboard configuration data including account snapshot selections and cus
   - **Outputs:** `{ "status": "success", "data": { "status_key": str, "message": str, "source": "llm"|"fallback" } }`.
 
 ## Auth
+
 - Requires authenticated context; selections are stored per user.
 
 ## Dependencies
+
 - `app.services.account_snapshot` helpers (`build_snapshot_payload`, `update_snapshot_selection`).
 - `app.services.account_groups` CRUD helpers for group and membership management.
 - `app.services.dashboard_activity_status` for LLM/fallback greeting generation.
 - Application logger for defensive error logging.
 
 ## Behaviors/Edge Cases
+
 - Falls back to default scope when no `user_id` is provided.
 - Validation rejects missing or incorrectly typed payloads before delegating to services.
 - Errors from the service layer are surfaced with `status: error` while logging the underlying exception.
 
 ## Sample Request/Response
+
 ```http
 PUT /api/dashboard/account-groups/reorder HTTP/1.1
 Content-Type: application/json

--- a/docs/backend/app/services/dashboard_activity_status.md
+++ b/docs/backend/app/services/dashboard_activity_status.md
@@ -1,0 +1,25 @@
+# `dashboard_activity_status.py`
+
+## Purpose
+
+Build the dashboard greeting/status payload from account balances and recent transactions, then request one parseable suggestion from an LLM when configured.
+
+## Key behaviors
+
+- Loads visible accounts and recent non-internal transactions for a configurable date range (default: trailing 30 days).
+- Sends compact JSON context to OpenAI Chat Completions when `OPENAI_API_KEY` is present.
+- Enforces a strict parseable response contract:
+  - `status_key` (stable machine-friendly key)
+  - `message` (single user-facing actionable sentence)
+- Falls back to deterministic local guidance when API credentials are missing or the provider call fails.
+
+## Public API
+
+- `generate_activity_status(start_date=None, end_date=None, user_id=None) -> dict`
+  - Returns `{ status_key, message, source }` where `source` is `llm` or `fallback`.
+
+## Operational notes
+
+- Optional model override: `OPENAI_DASHBOARD_MODEL` (default `gpt-4.1-mini`).
+- Provider timeout is short (15s) so dashboard rendering can recover quickly.
+- Route consumers should treat the payload as best-effort and preserve existing fallback copy.

--- a/docs/backend/app/services/index.md
+++ b/docs/backend/app/services/index.md
@@ -11,6 +11,7 @@
 - [`enhanced_account_history.py`](enhanced_account_history.md): Cache-aware wrapper that orchestrates history recomputation and storage.
 - [`account_snapshot.py`](account_snapshot.md): Manage preferred snapshot selections for dashboard widgets.
 - [`account_groups.py`](account_groups.md): CRUD and ordering logic for customizable dashboard account groups.
+- [`dashboard_activity_status.py`](dashboard_activity_status.md): LLM-backed (with fallback) dashboard greeting guidance from balances and transaction activity.
 - [`accounts_service.py`](accounts_service.md): Lightweight Plaid account fetch adapter used by refresh routes.
 
 ### Forecasting

--- a/docs/frontend/dashboard-component-spec.md
+++ b/docs/frontend/dashboard-component-spec.md
@@ -156,6 +156,8 @@
   - **Acceptance criteria:** Components load data in correct order, no dependency conflicts
 - [x] **Synchronize net overview range and fallback messaging** - Keep the hero chart aligned to the active net range while surfacing unified load failures.
   - **Acceptance criteria:** `frontend/src/components/dashboard/NetOverviewSection.vue` consumes the `netRange` override for hero charts and summaries, and `frontend/src/views/Dashboard.vue` surfaces a single fallback string when the initial Promise.all load fails.
+- [x] **Power dashboard greeting with parseable activity status** - Replace static net-worth quips with one actionable insight generated from account balances plus recent transactions.
+  - **Acceptance criteria:** `frontend/src/views/Dashboard.vue` requests `/api/dashboard/activity-status` during dashboard loads, forwards the returned single-message tip into `NetOverviewSection`, and keeps the existing fallback copy when API loads fail.
 
 ### UI/UX Refactoring
 

--- a/frontend/docs/dashboard-greeting-status.md
+++ b/frontend/docs/dashboard-greeting-status.md
@@ -1,0 +1,28 @@
+# Dashboard Greeting Status
+
+## Overview
+
+The main dashboard greeting now uses a backend-generated status message instead of a static net-worth quip. The status is designed to be parseable and display one practical suggestion to help the user act on recent activity.
+
+## API contract
+
+- Frontend request: `GET /api/dashboard/activity-status`
+- Optional query params: `start_date`, `end_date`, `user_id`
+- Expected success shape:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "status_key": "largest_expense",
+    "message": "Review your largest recent expense for accuracy.",
+    "source": "llm"
+  }
+}
+```
+
+## Frontend behavior
+
+- `Dashboard.vue` fetches activity status alongside other initial dashboard requests.
+- `NetOverviewSection.vue` displays the `message` in the greeting block.
+- If the request fails, existing dashboard fallback messaging remains in place.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -70,6 +70,11 @@ export default {
     return response.data
   },
 
+  async fetchDashboardActivityStatus(params = {}) {
+    const response = await apiClient.get('/dashboard/activity-status', { params })
+    return response.data
+  },
+
   async updateTransaction(transactionData) {
     const response = await apiClient.put('/transactions/update', transactionData)
     return response.data

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -12,7 +12,7 @@
         <NetOverviewSection
           :user-name="userName"
           :current-date="currentDate"
-          :net-worth-message="netWorthMessage"
+          :net-worth-message="greetingMessage"
           :date-range="dateRange"
           :debounced-range="debouncedRange"
           :net-range="netRange"
@@ -331,10 +331,12 @@ const currentDate = new Date().toLocaleDateString(undefined, {
 })
 const netWorth = ref(0)
 const loadErrorMessage = ref('')
-const netWorthMessage = computed(() => {
+const activityStatusMessage = ref('')
+const greetingMessage = computed(() => {
   if (loadErrorMessage.value) {
     return loadErrorMessage.value
   }
+  if (activityStatusMessage.value) return activityStatusMessage.value
   if (netWorth.value < 0) return '... and things are looking quite bleak.'
   if (netWorth.value > 1000) return 'Ahh... well in the black.'
   return 'Uhh... keep up the... whatever this is.'
@@ -485,10 +487,11 @@ async function loadDashboardData(range = debouncedRange.value) {
   }
 
   try {
-    const [netAssetsResult, categoriesResult, transactionsResult] = await Promise.all([
+    const [netAssetsResult, categoriesResult, transactionsResult, activityStatusResult] = await Promise.all([
       api.fetchNetAssets().catch(recordFailure),
       refreshOptions(params).catch(recordFailure),
       loadTransactions(1, { force: true }).catch(recordFailure),
+      api.fetchDashboardActivityStatus(params).catch(recordFailure),
     ])
     loadReviewCount(reviewFilters.value)
 
@@ -497,14 +500,20 @@ async function loadDashboardData(range = debouncedRange.value) {
     }
 
     const hadFailure =
-      [categoriesResult, transactionsResult].some((result) => result && '__error' in result) ||
-      (netAssetsResult && '__error' in netAssetsResult)
+      [categoriesResult, transactionsResult, activityStatusResult].some(
+        (result) => result && '__error' in result,
+      ) || (netAssetsResult && '__error' in netAssetsResult)
 
     if (netAssetsResult?.status === 'success' && Array.isArray(netAssetsResult.data)) {
       const lastPoint = netAssetsResult.data[netAssetsResult.data.length - 1]
       netWorth.value = lastPoint?.net_assets ?? 0
     } else {
       loadErrorMessage.value = fallback
+    }
+    if (activityStatusResult?.status === 'success' && activityStatusResult.data?.message) {
+      activityStatusMessage.value = activityStatusResult.data.message
+    } else if (!loadErrorMessage.value) {
+      activityStatusMessage.value = ''
     }
 
     if (hadFailure) {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -487,12 +487,13 @@ async function loadDashboardData(range = debouncedRange.value) {
   }
 
   try {
-    const [netAssetsResult, categoriesResult, transactionsResult, activityStatusResult] = await Promise.all([
-      api.fetchNetAssets().catch(recordFailure),
-      refreshOptions(params).catch(recordFailure),
-      loadTransactions(1, { force: true }).catch(recordFailure),
-      api.fetchDashboardActivityStatus(params).catch(recordFailure),
-    ])
+    const [netAssetsResult, categoriesResult, transactionsResult, activityStatusResult] =
+      await Promise.all([
+        api.fetchNetAssets().catch(recordFailure),
+        refreshOptions(params).catch(recordFailure),
+        loadTransactions(1, { force: true }).catch(recordFailure),
+        api.fetchDashboardActivityStatus(params).catch(recordFailure),
+      ])
     loadReviewCount(reviewFilters.value)
 
     if (loadToken !== activeLoadToken) {
@@ -502,7 +503,8 @@ async function loadDashboardData(range = debouncedRange.value) {
     const hadFailure =
       [categoriesResult, transactionsResult, activityStatusResult].some(
         (result) => result && '__error' in result,
-      ) || (netAssetsResult && '__error' in netAssetsResult)
+      ) ||
+      (netAssetsResult && '__error' in netAssetsResult)
 
     if (netAssetsResult?.status === 'success' && Array.isArray(netAssetsResult.data)) {
       const lastPoint = netAssetsResult.data[netAssetsResult.data.length - 1]

--- a/frontend/src/views/__tests__/Dashboard.spec.ts
+++ b/frontend/src/views/__tests__/Dashboard.spec.ts
@@ -12,9 +12,10 @@ import { fetchTransactions } from '@/api/transactions'
 vi.mock('@/services/api', () => ({
   default: {
     fetchNetAssets: vi.fn().mockResolvedValue({ status: 'success', data: [] }),
-    fetchDashboardActivityStatus: vi
-      .fn()
-      .mockResolvedValue({ status: 'success', data: { message: 'Review your largest recent expense for accuracy.' } }),
+    fetchDashboardActivityStatus: vi.fn().mockResolvedValue({
+      status: 'success',
+      data: { message: 'Review your largest recent expense for accuracy.' },
+    }),
   },
 }))
 

--- a/frontend/src/views/__tests__/Dashboard.spec.ts
+++ b/frontend/src/views/__tests__/Dashboard.spec.ts
@@ -10,7 +10,12 @@ import { fetchTransactions } from '@/api/transactions'
 
 // Mock modules used by Dashboard.vue
 vi.mock('@/services/api', () => ({
-  default: { fetchNetAssets: vi.fn().mockResolvedValue({ status: 'success', data: [] }) },
+  default: {
+    fetchNetAssets: vi.fn().mockResolvedValue({ status: 'success', data: [] }),
+    fetchDashboardActivityStatus: vi
+      .fn()
+      .mockResolvedValue({ status: 'success', data: { message: 'Review your largest recent expense for accuracy.' } }),
+  },
 }))
 
 const mockFetchTransactions = vi.fn().mockResolvedValue({})
@@ -562,7 +567,7 @@ describe('Dashboard.vue', () => {
     const wrapper = createWrapper()
     await resolveAsyncSections(wrapper)
 
-    expect(wrapper.vm.netWorthMessage).toContain('Unable to refresh dashboard data')
+    expect(wrapper.vm.greetingMessage).toContain('Unable to refresh dashboard data')
   })
 
   it('runs a single fetch cycle when the date range changes', async () => {

--- a/tests/test_dashboard_activity_status_route.py
+++ b/tests/test_dashboard_activity_status_route.py
@@ -1,0 +1,74 @@
+"""Tests for dashboard activity-status route behavior."""
+
+import importlib.util
+import os
+import sys
+import types
+
+from flask import Flask
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+)
+sys.modules["app.config"] = config_stub
+
+services_pkg = types.ModuleType("app.services")
+sys.modules["app.services"] = services_pkg
+
+account_groups_stub = types.ModuleType("app.services.account_groups")
+account_groups_stub.DEFAULT_USER_SCOPE = "default-user"
+sys.modules["app.services.account_groups"] = account_groups_stub
+services_pkg.account_groups = account_groups_stub
+
+account_snapshot_stub = types.ModuleType("app.services.account_snapshot")
+account_snapshot_stub.build_snapshot_payload = lambda user_id=None: {"user_id": user_id, "accounts": []}
+account_snapshot_stub.update_snapshot_selection = lambda selected_ids, user_id=None: {
+    "selected_account_ids": selected_ids,
+    "user_id": user_id,
+}
+sys.modules["app.services.account_snapshot"] = account_snapshot_stub
+
+activity_stub = types.ModuleType("app.services.dashboard_activity_status")
+activity_stub.generate_activity_status = lambda **_: {
+    "status_key": "largest_expense",
+    "message": "Review your largest recent expense for accuracy.",
+    "source": "fallback",
+}
+sys.modules["app.services.dashboard_activity_status"] = activity_stub
+
+ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "dashboard.py")
+spec = importlib.util.spec_from_file_location("app.routes.dashboard", ROUTE_PATH)
+dashboard_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dashboard_module)
+
+
+def _build_client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(dashboard_module.dashboard, url_prefix="/api/dashboard")
+    return app.test_client()
+
+
+def test_activity_status_validates_date_format():
+    client = _build_client()
+    response = client.get("/api/dashboard/activity-status?start_date=04-01-2026")
+    assert response.status_code == 400
+    assert response.get_json()["status"] == "error"
+
+
+def test_activity_status_returns_parseable_payload():
+    client = _build_client()
+    response = client.get("/api/dashboard/activity-status?start_date=2026-04-01&end_date=2026-04-08")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["data"]["status_key"] == "largest_expense"
+    assert "message" in payload["data"]


### PR DESCRIPTION
### Motivation
- Replace the static dashboard greeting with a single, parseable, actionable tip generated from the user's account balances and recent transactions so the hero message is context-aware and useful. 
- Prefer an LLM-provided suggestion when `OPENAI_API_KEY` is configured while preserving a deterministic local fallback when the provider or credentials are unavailable.

### Description
- Add a new backend service `backend/app/services/dashboard_activity_status.py` that collects visible account balances and recent non-internal transactions, calls OpenAI Chat Completions when `OPENAI_API_KEY` is set (configurable model via `OPENAI_DASHBOARD_MODEL`), and provides a deterministic fallback message when needed. 
- Expose `GET /api/dashboard/activity-status` in `backend/app/routes/dashboard.py`, accepting optional `start_date`, `end_date` (YYYY-MM-DD) and `user_id`, and returning `{ status_key, message, source }`.
- Wire the frontend to fetch the activity status in parallel with other dashboard requests by adding `fetchDashboardActivityStatus` to `frontend/src/services/api.js`, requesting it during dashboard load in `frontend/src/views/Dashboard.vue`, and showing the message in the top greeting (`greetingMessage`) passed into `NetOverviewSection`. 
- Add docs and tests: backend service docs (`docs/backend/app/services/dashboard_activity_status.md`), frontend docs (`frontend/docs/dashboard-greeting-status.md`), README note about `OPENAI_API_KEY`, update dashboard route/service docs, and add `tests/test_dashboard_activity_status_route.py` plus adjustments to `frontend` tests to mock the new API.

### Testing
- Ran the full backend test run with `pytest -q`, which failed to collect due to missing runtime dependencies in this environment (errors: `ModuleNotFoundError: No module named 'flask'`, `flask_sqlalchemy`, `pdfplumber`, etc.), so the suite could not be executed end‑to‑end here. 
- Ran frontend lint (`cd frontend && npm run lint` / `npx eslint`), which surfaced many pre-existing frontend lint issues and a few parsing errors in the current environment unrelated to the new integration. 
- Executed the frontend unit spec for the Dashboard (`npx vitest run src/views/__tests__/Dashboard.spec.ts`), which ran but reported multiple failing tests (15 failed / 4 passed) and one unhandled error in the existing test harness; failures appear to be due to existing test/mocking expectations and not the new API alone. 
- Ran the new route unit test in isolation during development but it could not complete under the container's missing dependency constraints (`flask` not installed). 
- Ran code formatting with `black` on modified files which reformatted the test file successfully; `pre-commit` was not available in this environment.

Notes: the OpenAI call is guarded by `OPENAI_API_KEY` and times out quickly (15s) to avoid blocking dashboard rendering; when credentials are absent the service returns a deterministic single-sentence tip. Continuous-integration execution with full Python and Node environments (including installing test dependencies) is required to verify the full test matrix and lint fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d670b69b9c8329a2da7d53756dfe2b)