### PR TITLE
docs(frontend): add phased radius/depth rollout plan, QA checklist, and PR guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Summary
+
+- Describe what changed and why.
+- List impacted areas (backend/frontend/tests/docs).
+
+## Validation
+
+- [ ] `pytest -q`
+- [ ] `pre-commit run --all-files`
+- [ ] Frontend checks run (`npm run lint`, plus targeted UI tests as needed)
+
+## Radius/Depth Visual QA (required for frontend surface changes)
+
+### Screenshots (before/after)
+
+- Route: `<route>`
+  - Before: `<image/link>`
+  - After: `<image/link>`
+  - Viewport: `<width>x<height>`
+
+### Checklist
+
+- [ ] Corner usage reviewed (token scale only; semantic `rounded-full` exceptions only)
+- [ ] Border contrast reviewed (approved edge/depth tokens)
+- [ ] Spacing rhythm reviewed (panel spacing rhythm maintained)
+- [ ] Focus visibility reviewed (keyboard focus remains visible and unclipped)
+
+## Rounded utility review gate
+
+- [ ] I did not introduce new arbitrary `rounded-*` classes.
+- [ ] If I introduced `rounded-*`, I documented business/UX justification and follow-up cleanup task.
+- [ ] I confirmed existing radius helpers/tokens could not satisfy the requirement before using any exception.
+
+## Documentation
+
+- [ ] Updated docs in `docs/frontend/` when frontend behavior/patterns changed.
+- [ ] Updated docs in `docs/devnotes/` with implementation notes and QA rationale.
+- [ ] Updated `docs/index/INDEX.md` for any new docs pages.

--- a/docs/devnotes/radius-rollout-visual-qa.md
+++ b/docs/devnotes/radius-rollout-visual-qa.md
@@ -1,0 +1,60 @@
+# Radius/Depth Rollout Visual QA Checklist
+
+Use this checklist when reviewing any phase in `docs/frontend/radius-rollout-phases.md`.
+
+## Capture protocol
+
+For each impacted route in the active phase:
+
+1. Capture one **before** screenshot from the base branch (or prior release commit).
+2. Capture one **after** screenshot from the proposed changes.
+3. Use the same viewport per route (desktop and/or mobile) and note viewport dimensions in PR notes.
+4. Include interaction captures when relevant (hover/focus/modal-open states).
+
+## Required QA checklist
+
+Mark each item pass/fail and include notes for failures:
+
+### 1) Corner usage
+
+- [ ] Surfaces use approved radius tokens from `theme.css` and helper classes.
+- [ ] `rounded-full` appears only for semantic circles (avatars/status dots).
+- [ ] No arbitrary `rounded-*` utility appears without documented justification.
+
+### 2) Border contrast
+
+- [ ] Panel borders use approved edge-contrast tokens.
+- [ ] Hero/accent surfaces use approved stronger border tokens only where intended.
+- [ ] Border contrast is still distinguishable against adjacent surfaces.
+
+### 3) Spacing rhythm
+
+- [ ] Internal panel spacing follows the shared panel spacing rhythm.
+- [ ] Adjacent section spacing is consistent across sibling surfaces.
+- [ ] Dense controls maintain consistent vertical rhythm.
+
+### 4) Focus visibility
+
+- [ ] Keyboard focus indicators are visible on all interactive controls.
+- [ ] Focus rings are not clipped by parent overflow or radius settings.
+- [ ] Focus styles remain distinct against both base and elevated surfaces.
+
+## Review output template
+
+Use this block in PR descriptions:
+
+```md
+## Radius/Depth Visual QA
+
+### Screenshots
+- Route: `<route>`
+  - Before: `<image/link>`
+  - After: `<image/link>`
+  - Viewport: `<width>x<height>`
+
+### Checklist
+- Corner usage: Pass/Fail - `<notes>`
+- Border contrast: Pass/Fail - `<notes>`
+- Spacing rhythm: Pass/Fail - `<notes>`
+- Focus visibility: Pass/Fail - `<notes>`
+```

--- a/docs/frontend/corner-radius-migration-guide.md
+++ b/docs/frontend/corner-radius-migration-guide.md
@@ -30,3 +30,13 @@ Defined in `frontend/src/styles/theme.css`:
 2. Prefer `.ui-radius-*` helpers from `frontend/src/assets/css/main.css` in templates.
 3. Keep `rounded-full` only for semantic circles; convert decorative pills to `--radius-1`.
 4. During review, verify new components do not introduce larger radii outside this scale.
+
+## Rollout governance
+
+For phased delivery expectations and route-level capture requirements, follow:
+
+- `docs/frontend/radius-rollout-phases.md`
+- `docs/devnotes/radius-rollout-visual-qa.md`
+
+Any PR changing frontend surface geometry should include the visual QA template and before/after captures.
+

--- a/docs/frontend/radius-rollout-phases.md
+++ b/docs/frontend/radius-rollout-phases.md
@@ -1,0 +1,90 @@
+# Corner/Depth System Rollout Plan
+
+## Purpose
+
+This plan breaks the corner-radius and depth/border standardization work into three delivery phases and defines required artifacts for each phase.
+
+## Global Requirements (apply to every phase)
+
+Each phase is considered incomplete until all of the following are attached in the PR:
+
+1. Before/after screen captures for the key routes listed in that phase.
+2. A completed visual QA checklist that covers:
+   - corner usage,
+   - border contrast,
+   - spacing rhythm,
+   - focus visibility.
+3. Documentation updates in both:
+   - `docs/frontend/`
+   - `docs/devnotes/`
+
+## Phase 1 (Foundation)
+
+### Scope
+
+- Finalize design tokens for corner geometry and spacing rhythm.
+- Finalize radius scale mapping to component tiers.
+- Finalize depth and border-contrast token pairings.
+- Update primitive components so they consume tokenized radius/depth values only.
+
+### Key routes for required captures
+
+- `/dashboard` (hero shell + at least one primitive-powered control)
+- `/transactions` (primitive buttons/inputs/selects in active use)
+- `/settings` (form controls + focus states)
+
+### Exit criteria
+
+- No new primitive ships with arbitrary `rounded-*` classes.
+- Primitive components expose documented radius/depth variants backed by tokens.
+- Token usage guidance is published and linked from docs index.
+
+## Phase 2 (Core surfaces)
+
+### Scope
+
+- Migrate dashboard hero surfaces to approved radius/depth tiers.
+- Migrate chart panels to approved surface tokens.
+- Migrate table shells and sticky/table wrappers to approved radius/border rules.
+- Migrate modal shells and modal action rows to approved radius/focus rules.
+
+### Key routes for required captures
+
+- `/dashboard` (hero + chart panels + summary cards)
+- `/transactions` (table shells and modal open state)
+- `/accounts` (table/list container surfaces)
+
+### Exit criteria
+
+- Hero, chart, table, and modal surfaces use only approved token combinations.
+- Border contrast remains legible in light/dark contexts where supported.
+- Focus rings remain visible against all migrated surfaces.
+
+## Phase 3 (Secondary surfaces)
+
+### Scope
+
+- Migrate widgets and utility cards.
+- Migrate forms not covered in phase 1 primitives or phase 2 core surfaces.
+- Migrate utility screens and lower-traffic routes.
+
+### Key routes for required captures
+
+- `/investments` (secondary cards/widgets)
+- `/planning` (form-heavy utilities)
+- `/forecast` (supporting surfaces/widgets)
+
+### Exit criteria
+
+- Secondary routes match the same radius/depth hierarchy used on core routes.
+- No regressions in focus visibility or spacing rhythm on utility screens.
+- Any remaining exceptions are documented with rationale and follow-up owner.
+
+## PR review gate (all phases)
+
+PRs that touch frontend surfaces should be blocked from approval when any of these are missing:
+
+- Missing before/after captures for impacted key routes.
+- Missing visual QA checklist completion.
+- Missing docs updates (`docs/frontend/` and `docs/devnotes/`).
+- New arbitrary `rounded-*` usage without explicit justification and follow-up task.

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -21,12 +21,14 @@ All documentation lives in Markdown under `docs/` and mirrors the backend struct
 - [Stake Cleanup Audit](../integrations/stake_cleanup.md) – confirmation that the legacy Stake integration has no remaining code paths
 - [Devnotes](../devnotes/) – working notes and scratch references
 - [Elevation vs Border Contrast](../devnotes/elevation-vs-border-contrast.md) – dashboard depth and framing rules for consistent panel hierarchy.
+- [Radius Rollout Visual QA Checklist](../devnotes/radius-rollout-visual-qa.md) – required before/after capture protocol and review checklist for corner, border, spacing, and focus.
 - [Codex](../codex/) – exploratory reports
 - [Latest](../latest/) – recent drafts and experiments
 - [Financial Summary Detailed](../frontend/FINANCIAL_SUMMARY_DETAILED.md) – DailyNetChart + FinancialSummary wiring details
 - [Component Migration Guide](../frontend/component-migration.md) – frontend component organization strategy
 - [Tailwind + Vite Style Reference](../frontend/tailwind-vite-style-reference.md) – CSS utilities and build notes
 - [Corner Radius Migration Guide](../frontend/corner-radius-migration-guide.md) – token scale and allowed corner usage by component type.
+- [Radius/Depth Rollout Plan](../frontend/radius-rollout-phases.md) – three-phase rollout for tokens, core surfaces, and secondary surfaces with required captures and QA gates.
 - [Forecast Frontend Components](../frontend/src/components/forecast/ForecastComponent.md) – forecast layout, summary, chart, and adjustment component docs.
 - [Environment Reference](../ENVIRONMENT_REFERENCE.md) – env vars, setup, troubleshooting
 


### PR DESCRIPTION
### Motivation

- Establish a controlled, three-phase rollout for corner radius and depth/border standardization across the frontend so surface geometry is consistent and reviewable.
- Prevent reintroduction of arbitrary Tailwind `rounded-*` utilities by enforcing token-backed radius usage and a review gate for exceptions.
- Provide a reproducible visual QA process with required before/after captures and checklist items so reviewers can validate spacing, border contrast, corner usage, and focus visibility.

### Description

- Add `docs/frontend/radius-rollout-phases.md` which defines Phase 1 (Foundation), Phase 2 (Core surfaces), and Phase 3 (Secondary surfaces) with scope, key routes, and exit criteria.
- Add `docs/devnotes/radius-rollout-visual-qa.md` which provides the capture protocol, a pass/fail checklist (corner usage, border contrast, spacing rhythm, focus visibility), and a PR review template block.
- Update `docs/frontend/corner-radius-migration-guide.md` to include rollout governance links and require the visual QA artifacts for PRs that change surface geometry.
- Update `docs/index/INDEX.md` to surface the new plan and QA checklist and add a new `.github/PULL_REQUEST_TEMPLATE.md` that includes validation steps and a rounded-utility review gate.

### Testing

- Ran `pytest -q`, which failed during collection in this environment due to missing Python dependencies such as `flask`, `flask_sqlalchemy`, and `pdfplumber` (test failure not related to these docs-only changes).
- Ran `npm run lint` in `frontend/`, which reported existing lint/parsing errors unrelated to the documentation and template additions.
- Ran `pre-commit run --all-files`, which could not be executed in the current environment because the `pre-commit` command is not available.
- This change is docs/process-only and does not modify runtime code or frontend components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc34dd0eb883298d3fa45e4449379e)