### PR TITLE
test(forecast): support aspect-specific series and include debt component datasets

### DIFF
--- a/frontend/src/components/forecast/ForecastChart.vue
+++ b/frontend/src/components/forecast/ForecastChart.vue
@@ -84,6 +84,8 @@ const ASPECT_STYLES = {
   manual_adjustments: { color: '#7C3AED', type: 'bar', axis: 'yFlow' },
   spending: { color: '#DC2626', type: 'bar', axis: 'yFlow' },
   debt_totals: { color: '#F59E0B', type: 'line', axis: 'yBalance' },
+  debt_interest: { color: '#F97316', type: 'bar', axis: 'yFlow' },
+  debt_new_spending: { color: '#EF4444', type: 'bar', axis: 'yFlow' },
 }
 const ASPECT_SERIES_ID_BY_SELECTION = {
   realized_income: 'realized_income',
@@ -91,6 +93,7 @@ const ASPECT_SERIES_ID_BY_SELECTION = {
   spending: 'spending',
   debt: 'debt_totals',
 }
+const DEBT_COMPONENT_SERIES_IDS = ['debt_interest', 'debt_new_spending']
 
 const props = defineProps({
   timeline: {
@@ -136,6 +139,11 @@ const activeSeries = computed(() => {
   const seriesId = ASPECT_SERIES_ID_BY_SELECTION[props.selectedAspect]
   return props.series?.[seriesId] ?? null
 })
+const activeDebtComponentSeries = computed(() =>
+  DEBT_COMPONENT_SERIES_IDS.map((seriesId) => props.series?.[seriesId]).filter(
+    (seriesEntry) => seriesEntry && Array.isArray(seriesEntry.points),
+  ),
+)
 
 const axisDates = computed(() => {
   const dateSet = new Set()
@@ -143,6 +151,9 @@ const axisDates = computed(() => {
   props.realizedHistory.forEach((point) => dateSet.add(point.date || point.label))
   props.timeline.forEach((point) => dateSet.add(point.date || point.label))
   activeSeries.value?.points.forEach((point) => dateSet.add(point.date || point.label))
+  activeDebtComponentSeries.value.forEach((seriesEntry) => {
+    seriesEntry.points.forEach((point) => dateSet.add(point.date || point.label))
+  })
 
   return Array.from(dateSet).sort((left, right) => left.localeCompare(right))
 })
@@ -277,29 +288,31 @@ function buildBalanceDatasets() {
  * Build the active non-balance aspect dataset from backend-typed series payloads.
  */
 function buildAspectDatasets() {
-  const seriesEntry = activeSeries.value
-  if (!seriesEntry) {
+  const seriesEntries = [activeSeries.value, ...activeDebtComponentSeries.value].filter(Boolean)
+  if (seriesEntries.length === 0) {
     return []
   }
 
-  const style = ASPECT_STYLES[seriesEntry.id]
-  if (!style) {
-    return []
-  }
+  return seriesEntries
+    .map((seriesEntry) => {
+      const style = ASPECT_STYLES[seriesEntry.id]
+      if (!style) {
+        return null
+      }
 
-  return [
-    {
-      type: style.type,
-      label: seriesEntry.label,
-      data: alignSeriesValues(seriesEntry.points),
-      borderColor: style.color,
-      backgroundColor: toRgba(style.color, style.type === 'bar' ? 0.45 : 0.15),
-      yAxisID: style.axis,
-      tension: style.type === 'line' ? 0.25 : 0,
-      borderDash: seriesEntry.id === 'debt_totals' ? [4, 4] : [],
-      spanGaps: true,
-    },
-  ]
+      return {
+        type: style.type,
+        label: seriesEntry.label,
+        data: alignSeriesValues(seriesEntry.points),
+        borderColor: style.color,
+        backgroundColor: toRgba(style.color, style.type === 'bar' ? 0.45 : 0.15),
+        yAxisID: style.axis,
+        tension: style.type === 'line' ? 0.25 : 0,
+        borderDash: seriesEntry.id === 'debt_totals' ? [4, 4] : [],
+        spanGaps: true,
+      }
+    })
+    .filter(Boolean)
 }
 
 /**

--- a/frontend/src/components/forecast/__tests__/ForecastChart.spec.ts
+++ b/frontend/src/components/forecast/__tests__/ForecastChart.spec.ts
@@ -52,8 +52,18 @@ const baseProps = {
     },
     debt_totals: {
       id: 'debt_totals' as const,
-      label: 'Debt totals',
+      label: 'Total debt',
       points: [{ date: '2024-01-02', label: '2024-01-02', value: 40 }],
+    },
+    debt_interest: {
+      id: 'debt_interest' as const,
+      label: 'Debt interest',
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 9 }],
+    },
+    debt_new_spending: {
+      id: 'debt_new_spending' as const,
+      label: 'Debt from new spending',
+      points: [{ date: '2024-01-02', label: '2024-01-02', value: 31 }],
     },
   },
   computeMeta: {
@@ -110,16 +120,43 @@ describe('ForecastChart', () => {
     ])
   })
 
-  it('renders the selected typed series without reconstructing from cashflows', () => {
+  it('changes rendered datasets when the aspect changes while keeping the active timeframe', async () => {
     const wrapper = mount(ForecastChart, {
       props: {
         ...baseProps,
-        selectedAspect: 'realized_income',
-        graphMode: 'historical',
+        selectedAspect: 'manual_adjustments',
       },
     })
 
-    expect(wrapper.text()).toContain('Month · Realized income')
+    expect(wrapper.text()).toContain('Month · Manual adjustments')
+    expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
+      expect.objectContaining({
+        label: 'Manual adjustments',
+        data: [null, 5],
+      }),
+    ])
+
+    await wrapper.setProps({
+      selectedAspect: 'spending',
+    })
+
+    expect(wrapper.text()).toContain('Month · Spending')
+    expect(chartConstructor.mock.calls.at(-1)?.[1].data.datasets).toEqual([
+      expect.objectContaining({
+        label: 'Spending',
+        data: [null, -12],
+      }),
+    ])
+  })
+
+  it('renders realized income labels and values from typed backend series', () => {
+    mount(ForecastChart, {
+      props: {
+        ...baseProps,
+        selectedAspect: 'realized_income',
+      },
+    })
+
     expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
       expect.objectContaining({
         label: 'Realized income used for auto-calculation',
@@ -128,7 +165,7 @@ describe('ForecastChart', () => {
     ])
   })
 
-  it('renders debt totals from the backend series', () => {
+  it('renders debt totals and debt components from backend series', () => {
     const wrapper = mount(ForecastChart, {
       props: {
         ...baseProps,
@@ -139,9 +176,17 @@ describe('ForecastChart', () => {
     expect(wrapper.text()).toContain('Month · Debt composition')
     expect(chartConstructor.mock.calls[0][1].data.datasets).toEqual([
       expect.objectContaining({
-        label: 'Debt totals',
+        label: 'Total debt',
         data: [null, 40],
         borderDash: [4, 4],
+      }),
+      expect.objectContaining({
+        label: 'Debt interest',
+        data: [null, 9],
+      }),
+      expect.objectContaining({
+        label: 'Debt from new spending',
+        data: [null, 31],
       }),
     ])
   })

--- a/frontend/src/components/forecast/__tests__/ForecastLayout.spec.ts
+++ b/frontend/src/components/forecast/__tests__/ForecastLayout.spec.ts
@@ -165,26 +165,29 @@ describe('ForecastLayout', () => {
 
   it('opens and closes the cashflow details modal for selected breakdown items', async () => {
     useForecastDataMock.mockReturnValue(
-      buildUseForecastDataReturn([], [
-        {
-          date: '2026-03-25',
-          label: 'Employer Payroll',
-          amount: 1200,
-          category: 'Income',
-          source: 'recurring',
-          confidence: 0.88,
-          sources: [
-            {
-              type: 'recurring_rule',
-              transaction_id: 'txn-100',
-              date: '2026-03-12',
-              description: 'Employer Payroll',
-              category_display: 'Income - Wages',
-              tags: ['payroll'],
-            },
-          ],
-        },
-      ]),
+      buildUseForecastDataReturn(
+        [],
+        [
+          {
+            date: '2026-03-25',
+            label: 'Employer Payroll',
+            amount: 1200,
+            category: 'Income',
+            source: 'recurring',
+            confidence: 0.88,
+            sources: [
+              {
+                type: 'recurring_rule',
+                transaction_id: 'txn-100',
+                date: '2026-03-12',
+                description: 'Employer Payroll',
+                category_display: 'Income - Wages',
+                tags: ['payroll'],
+              },
+            ],
+          },
+        ],
+      ),
     )
 
     const wrapper = mount(ForecastLayout, {})
@@ -205,22 +208,27 @@ describe('ForecastLayout', () => {
 
   it('shows an empty source state when selected cashflow item has no attached sources', async () => {
     useForecastDataMock.mockReturnValue(
-      buildUseForecastDataReturn([], [
-        {
-          date: '2026-03-25',
-          label: 'Uncategorized delta',
-          amount: -20,
-          category: 'Uncategorized',
-          source: 'uncategorized',
-          confidence: 0.3,
-        },
-      ]),
+      buildUseForecastDataReturn(
+        [],
+        [
+          {
+            date: '2026-03-25',
+            label: 'Uncategorized delta',
+            amount: -20,
+            category: 'Uncategorized',
+            source: 'uncategorized',
+            confidence: 0.3,
+          },
+        ],
+      ),
     )
 
     const wrapper = mount(ForecastLayout, {})
     await flushPromises()
     await wrapper.get('.line-item-button').trigger('click')
 
-    expect(wrapper.text()).toContain('No source transactions or events are attached to this forecast item.')
+    expect(wrapper.text()).toContain(
+      'No source transactions or events are attached to this forecast item.',
+    )
   })
 })

--- a/frontend/src/composables/__tests__/useForecastData.spec.ts
+++ b/frontend/src/composables/__tests__/useForecastData.spec.ts
@@ -56,6 +56,21 @@ describe('useForecastData', () => {
             label: 'Manual adjustments',
             points: [{ date: '2024-01-01', label: '2024-01-01', value: 200 }],
           },
+          debt_totals: {
+            id: 'debt_totals',
+            label: 'Total debt',
+            points: [{ date: '2024-01-01', label: '2024-01-01', value: 1200 }],
+          },
+          debt_interest: {
+            id: 'debt_interest',
+            label: 'Debt interest',
+            points: [{ date: '2024-01-01', label: '2024-01-01', value: 42 }],
+          },
+          debt_new_spending: {
+            id: 'debt_new_spending',
+            label: 'Debt from new spending',
+            points: [{ date: '2024-01-01', label: '2024-01-01', value: 18 }],
+          },
         },
         metadata: {
           included_account_ids: ['acc-1', 'acc-2'],
@@ -111,6 +126,15 @@ describe('useForecastData', () => {
     expect(cashflows.value).toEqual([{ label: 'Manual bonus', amount: 200 }])
     expect(series.value.manual_adjustments?.points).toEqual([
       { date: '2024-01-01', label: '2024-01-01', value: 200 },
+    ])
+    expect(series.value.debt_totals?.points).toEqual([
+      { date: '2024-01-01', label: '2024-01-01', value: 1200 },
+    ])
+    expect(series.value.debt_interest?.points).toEqual([
+      { date: '2024-01-01', label: '2024-01-01', value: 42 },
+    ])
+    expect(series.value.debt_new_spending?.points).toEqual([
+      { date: '2024-01-01', label: '2024-01-01', value: 18 },
     ])
   })
 

--- a/frontend/src/composables/useForecastData.ts
+++ b/frontend/src/composables/useForecastData.ts
@@ -2,7 +2,13 @@ import { computed, ref, type Ref } from 'vue'
 
 export type ForecastViewType = 'Month' | 'Year'
 export type ForecastGraphMode = 'combined' | 'forecast' | 'historical'
-export type ForecastSeriesId = 'realized_income' | 'manual_adjustments' | 'spending' | 'debt_totals'
+export type ForecastSeriesId =
+  | 'realized_income'
+  | 'manual_adjustments'
+  | 'spending'
+  | 'debt_totals'
+  | 'debt_interest'
+  | 'debt_new_spending'
 
 export type ForecastAdjustmentInput = {
   label: string


### PR DESCRIPTION
### Motivation
- The forecast compute response now includes aspect-specific `series` entries (for `realized_income`, `manual_adjustments`, `spending`, `debt_totals`, and debt components), and the frontend must consume these directly instead of reconstructing series from flat cashflows. 
- The chart UI needs to display both the total debt series and the debt component breakdown (interest vs new spending) when the debt aspect is selected. 

### Description
- Extended the `ForecastSeriesId` typing to include `debt_interest` and `debt_new_spending` so the composable types cover the new response shape. 
- Updated `ForecastChart.vue` to register styles for the new debt component series, collect component series via a new computed `activeDebtComponentSeries`, include their dates in the shared axis, and render the total debt line together with the component bar series in `buildAspectDatasets()`. 
- Expanded `useForecastData` unit test (`frontend/src/composables/__tests__/useForecastData.spec.ts`) to assert mapping of `debt_totals`, `debt_interest`, and `debt_new_spending` from the mocked compute response. 
- Added/updated `ForecastChart` tests to verify aspect switching preserves the timeframe, that realized income/manual adjustments/spending aspects render expected labels and values, and that the debt aspect renders the total debt series plus the two component series; minor formatting updates applied to `ForecastLayout` tests. 

### Testing
- Ran the composable unit tests with `npx vitest run src/composables/__tests__/useForecastData.spec.ts` and they passed. 
- Attempted `npx vitest run src/components/forecast/__tests__/ForecastLayout.spec.ts src/components/forecast/__tests__/ForecastChart.spec.ts`, but the run failed before executing the suites due to an existing Tailwind utility resolution error (`ui-radius-3`) in the repo environment. 
- Ran `npm run lint` and `npm test` in the frontend; both reported pre-existing lint/test failures unrelated to the changes (the Tailwind utility issue and other existing lint errors across the codebase), so those full-suite checks did not greenlight here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7c89d2688329b67ad8e1647d6995)