### PR TITLE
refactor(transactions): adopt tokenized surface styling

### DIFF
--- a/docs/frontend/component-review-tracker.md
+++ b/docs/frontend/component-review-tracker.md
@@ -76,7 +76,7 @@ This document consolidates **FileLegend.md** and **ProcessLegend.md** into a sin
 - **Files:** [TAS], [DNC], [CBC], [CWTB], [AS], [AT], [TT], [PC], [TM], [GCD], [D]
 
 Note: See `docs/frontend/sparklines.md` for AccountSparkline integration details used by [TAS].
-Also see `docs/frontend/transactions-ui.md` for recent transactions formatting rules used by [TAS].
+Also see `docs/frontend/transactions-ui.md` for recent transactions formatting rules used by [TAS] and the tokenized styling contract for `frontend/src/views/Transactions.vue`.
 
 ### 3.2 Scoped Slots/Reusable Headers
 

--- a/docs/frontend/transactions-ui.md
+++ b/docs/frontend/transactions-ui.md
@@ -2,6 +2,36 @@
 
 This document standardizes formatting and styling rules for recent transactions displayed under account details in TopAccountSnapshot.
 
+## Transactions View Styling Contract
+
+The route-level transactions view (`frontend/src/views/Transactions.vue`) now uses token-backed utility classes for control and summary surfaces.
+
+### Required semantic classes
+
+- Replace neutral Tailwind color shortcuts with theme-token utilities:
+  - `bg-surface-*` for backgrounds.
+  - `border-subtle` (or `border-strong` when needed) for borders.
+  - `text-primary`, `text-secondary`, and `text-muted` for foreground text.
+- Use radius tokens instead of one-off rounded values:
+  - `ui-radius-1`, `ui-radius-2`, `ui-radius-3`.
+
+### Shared primitives to reuse
+
+- Control and summary wrappers should favor `ui-panel` for elevated containers.
+- Nested metric/control cards should favor `ui-card`.
+- Inputs in control rows should reuse `ui-control-input` and add local spacing utilities only as needed.
+
+### Example class patterns
+
+- Top controls panel:
+  - `ui-panel p-6 ui-radius-3 space-y-4`
+- Dashed import/search containers:
+  - `ui-radius-2 border border-dashed border-subtle bg-surface-1`
+- Filter summary stat tile:
+  - `ui-card ui-radius-2 px-4 py-3 shadow-inner`
+- Summary label/value text:
+  - `text-muted` for labels and `text-primary` for metric values.
+
 ## Date Formatting
 
 - Use short, locale-friendly dates.

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -18,7 +18,7 @@
       </PageHeader>
     </template>
     <!-- Internal Transfer Scanner (moved to top) -->
-    <Card class="p-6 rounded-3xl card-surface">
+    <Card class="p-6 ui-radius-3 card-surface">
       <div class="flex items-center justify-between">
         <div>
           <p class="eyebrow">Automation</p>
@@ -39,8 +39,8 @@
     </Card>
 
     <!-- Top Controls -->
-    <Card v-if="showControls" id="top-controls" class="p-6 rounded-3xl card-surface space-y-4">
-      <div class="flex flex-wrap items-start justify-between gap-4 border-b border-slate-200 pb-4">
+    <Card v-if="showControls" id="top-controls" class="ui-panel p-6 ui-radius-3 space-y-4">
+      <div class="flex flex-wrap items-start justify-between gap-4 border-b border-subtle pb-4">
         <div class="space-y-1">
           <p class="eyebrow">Controls</p>
           <h3 class="text-lg font-semibold text-[var(--color-text-light)]">
@@ -53,27 +53,27 @@
         <span class="pill">Transactions</span>
       </div>
       <div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(260px,1fr)]">
-        <div class="rounded-2xl border border-dashed border-slate-200 bg-white/90 p-4 shadow-inner">
+        <div class="ui-radius-2 border border-dashed border-subtle bg-surface-1 p-4 shadow-inner">
           <ImportFileSelector />
         </div>
         <div
-          class="relative rounded-2xl border border-dashed border-slate-200 bg-white/80 shadow-inner"
+          class="relative ui-radius-2 border border-dashed border-subtle bg-surface-1 shadow-inner"
         >
-          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted">
             <Search class="w-4 h-4" />
           </span>
           <input
             v-model="searchQuery"
             type="text"
             placeholder="Search transactions..."
-            class="input w-full border-none bg-transparent pl-10 pr-4 py-3 focus:ring-2 focus:ring-[var(--color-accent-purple)] search-input"
+            class="input ui-control-input w-full border-none bg-transparent pl-10 pr-4 py-3 text-secondary focus:ring-2 focus:ring-[var(--color-accent-purple)] search-input"
           />
         </div>
       </div>
     </Card>
 
     <!-- Filter Controls -->
-    <Card class="p-6 rounded-3xl card-surface space-y-4">
+    <Card class="ui-panel p-6 ui-radius-3 space-y-4">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p class="eyebrow">Filters</p>
@@ -90,7 +90,7 @@
         </div>
       </div>
       <div class="grid w-full gap-3 md:grid-cols-3">
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
           <DateRangeSelector
             :start-date="startDate"
             :end-date="endDate"
@@ -99,10 +99,10 @@
             @update:endDate="endDate = $event"
           />
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
           <AccountFilter v-model="accountFilter" />
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
           <TypeSelector v-model="txType" />
         </div>
       </div>
@@ -110,7 +110,7 @@
 
     <Card
       v-if="hasActiveFilters && !isLoading && !error"
-      class="p-6 rounded-3xl card-surface space-y-4"
+      class="ui-panel p-6 ui-radius-3 space-y-4"
       data-testid="filter-summary"
     >
       <div>
@@ -120,51 +120,41 @@
         </h3>
       </div>
       <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-            Transactions
-          </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">Transactions</p>
+          <p class="text-2xl font-semibold text-primary">
             {{ filterSummary.transactionCount }}
           </p>
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-            Total amount
-          </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">Total amount</p>
+          <p class="text-2xl font-semibold text-primary">
             {{ formatCurrency(filterSummary.totalAmount) }}
           </p>
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-            Unique categories
-          </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">Unique categories</p>
+          <p class="text-2xl font-semibold text-primary">
             {{ filterSummary.uniqueCounts.categories }}
           </p>
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-            Unique merchants
-          </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">Unique merchants</p>
+          <p class="text-2xl font-semibold text-primary">
             {{ filterSummary.uniqueCounts.merchants }}
           </p>
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-            Unique accounts
-          </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">Unique accounts</p>
+          <p class="text-2xl font-semibold text-primary">
             {{ filterSummary.uniqueCounts.accounts }}
           </p>
         </div>
-        <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-inner">
-          <p class="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+        <div class="ui-card ui-radius-2 px-4 py-3 shadow-inner">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">
             Unique institutions
           </p>
-          <p class="text-2xl font-semibold text-[var(--color-text-light)]">
+          <p class="text-2xl font-semibold text-primary">
             {{ filterSummary.uniqueCounts.institutions }}
           </p>
         </div>
@@ -172,7 +162,7 @@
     </Card>
 
     <!-- Main Table -->
-    <Card class="p-6 space-y-4 rounded-3xl card-surface">
+    <Card class="p-6 space-y-4 ui-radius-3 card-surface">
       <div class="flex items-center justify-between">
         <h2 class="section-title">Recent Transactions</h2>
         <div class="flex items-center gap-2">
@@ -211,7 +201,7 @@
 
     <!-- Activity Tab -->
     <template #Activity>
-      <Card class="p-6 space-y-4 rounded-3xl card-surface">
+      <Card class="p-6 space-y-4 ui-radius-3 card-surface">
         <div class="flex items-center justify-between">
           <h2 class="section-title">Recent Transactions</h2>
           <button
@@ -257,7 +247,7 @@
 
     <!-- Recurring Tab -->
     <template #Recurring>
-      <Card class="p-6 space-y-4 rounded-3xl card-surface">
+      <Card class="p-6 space-y-4 ui-radius-3 card-surface">
         <h2 class="text-2xl font-bold text-[var(--color-text-light)]">Recurring Transactions</h2>
         <RecurringTransactionSection ref="recurringFormRef" provider="plaid" />
       </Card>
@@ -265,7 +255,7 @@
 
     <!-- Scanner Tab -->
     <template #Scanner>
-      <Card class="p-6 rounded-3xl card-surface">
+      <Card class="p-6 ui-radius-3 card-surface">
         <InternalTransferScanner />
       </Card>
     </template>
@@ -283,7 +273,6 @@ import { fetchTransactions as fetchTransactionsApi } from '@/api/transactions'
 import UpdateTransactionsTable from '@/components/tables/UpdateTransactionsTable.vue'
 import RecurringTransactionSection from '@/components/recurring/RecurringTransactionSection.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
-import UiButton from '@/components/ui/Button.vue'
 import Card from '@/components/ui/Card.vue'
 import { CreditCard, Search } from 'lucide-vue-next'
 import TabbedPageLayout from '@/components/layout/TabbedPageLayout.vue'
@@ -301,7 +290,6 @@ export default {
     UpdateTransactionsTable,
     RecurringTransactionSection,
     PageHeader,
-    UiButton,
     Card,
     TabbedPageLayout,
     InternalTransferScanner,
@@ -555,7 +543,8 @@ export default {
         let expectedTotal = 0
         const allRows = []
 
-        while (true) {
+        let shouldContinue = true
+        while (shouldContinue) {
           const response = await fetchTransactionsApi({
             ...activeFilters,
             page,
@@ -565,9 +554,13 @@ export default {
           expectedTotal = Number(response?.total || 0)
           allRows.push(...batch)
 
-          if (!batch.length) break
-          if (expectedTotal > 0 && allRows.length >= expectedTotal) break
-          page += 1
+          if (!batch.length) {
+            shouldContinue = false
+          } else if (expectedTotal > 0 && allRows.length >= expectedTotal) {
+            shouldContinue = false
+          } else {
+            page += 1
+          }
         }
 
         const search = searchQuery.value.trim().toLowerCase()

--- a/frontend/src/views/__tests__/Transactions.spec.js
+++ b/frontend/src/views/__tests__/Transactions.spec.js
@@ -151,6 +151,10 @@ describe('Transactions.vue', () => {
 
     const summary = wrapper.find('[data-testid="filter-summary"]')
     expect(summary.exists()).toBe(true)
+    expect(summary.classes()).toContain('ui-panel')
+    expect(summary.classes()).toContain('ui-radius-3')
+    expect(summary.find('.text-muted').exists()).toBe(true)
+    expect(summary.find('.text-primary').exists()).toBe(true)
     const text = summary.text()
 
     expect(text).toContain('Transactions')
@@ -171,5 +175,19 @@ describe('Transactions.vue', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-testid="filter-summary"]').exists()).toBe(false)
+  })
+
+  it('uses tokenized panel and surface classes for top controls', async () => {
+    const { wrapper } = mountView({ filtered: [{ transaction_id: 'tx-1', amount: 12 }] })
+
+    await flushPromises()
+
+    const controls = wrapper.find('#top-controls')
+    expect(controls.exists()).toBe(true)
+    expect(controls.classes()).toContain('ui-panel')
+    expect(controls.classes()).toContain('ui-radius-3')
+    expect(wrapper.find('#top-controls .bg-surface-1').exists()).toBe(true)
+    expect(wrapper.find('#top-controls .border-subtle').exists()).toBe(true)
+    expect(wrapper.find('#top-controls .text-muted').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
### Motivation

- Replace neutral Tailwind color and one-off radius utilities in the transactions view with semantic, token-backed utilities for consistent theming and easier maintenance.  
- Reuse existing shared primitives in `frontend/src/assets/css/main.css` so control/panel patterns are standardized across the frontend.

### Description

- Replaced neutral color and text utilities in `frontend/src/views/Transactions.vue` with semantic token utilities such as `bg-surface-*`, `border-subtle`, `text-primary`, `text-secondary`, and `text-muted`.  
- Replaced one-off rounded classes with token-backed geometry classes `ui-radius-1/2/3` and swapped card/control markup to use shared primitives `ui-panel`, `ui-card`, and `ui-control-input`.  
- Updated component tests in `frontend/src/views/__tests__/Transactions.spec.js` to assert presence of tokenized classes on the top controls and filter summary sections.  
- Added documentation for the styling contract in `docs/frontend/transactions-ui.md` and updated `docs/frontend/component-review-tracker.md`; also removed an unused `UiButton` registration and cleaned up the CSV export loop to remove a constant `while (true)` pattern.

### Testing

- Ran `pytest -q`; collection failed in this environment due to missing backend Python dependencies (e.g., `flask`, `flask_sqlalchemy`, `pdfplumber`) so backend tests could not complete.  
- Ran frontend lint via `cd frontend && npm run lint`; the command surfaced pre-existing repository-wide lint issues not introduced by this change (failed in CI here).  
- Attempted component unit runs: `cd frontend && npm run test:unit -- --spec src/views/__tests__/Transactions.spec.js` (Cypress) failed because the environment is missing `Xvfb`, and `cd frontend && npm run test -- src/views/__tests__/Transactions.spec.js` (Vitest) failed earlier due to a Tailwind utility-generation error in another component style during transform.  
- Static checks and formatting succeeded for the modified files: `npx eslint src/views/Transactions.vue src/views/__tests__/Transactions.spec.js` completed (warnings only) and `npx prettier --write` applied consistent formatting to changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ac61a6548329b2fa7ea7c3fda427)