### PR TITLE
fix(frontend): migrate Plaid refresh status styles to semantic tokens and add tests

### DIFF
--- a/frontend/docs/THEMING_GUIDE.md
+++ b/frontend/docs/THEMING_GUIDE.md
@@ -65,6 +65,26 @@ Additional variables such as `--color-accent-magenta`, `--color-accent-indigo`,
 `--liability-gradient-start`/`--liability-gradient-end` are used by specific
 charts and widgets. Review the default theme for the full list.
 
+## Status badge and alert pattern
+
+For account sync states and other inline status UI:
+
+- Use semantic status tokens only (`--color-success/error/warning/info` and matching `--color-bg-*`).
+- Build tinted backgrounds and readable foregrounds with `color-mix(...)` against `--surface-1` rather than hardcoded hex values.
+- Use `--radius-1` (or `ui-radius-1`) for decorative badges/pills.
+- Keep fully rounded corners (`rounded-full`) only for semantic circles (presence dots, avatars, and similar circular indicators).
+
+Example:
+
+```css
+.status-pill--ok {
+  background: color-mix(in srgb, var(--color-bg-success) 22%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-success) 38%, var(--border-subtle));
+  color: color-mix(in srgb, var(--color-success) 78%, var(--text-primary));
+  border-radius: var(--radius-1);
+}
+```
+
 ## How the Theme Loads
 
 `main.css` imports `global-colors.css` before Tailwind base layers. This ensures

--- a/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
+++ b/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
@@ -16,9 +16,39 @@ describe('RefreshPlaidControls', () => {
 
     mount(RefreshPlaidControls)
     cy.wait('@getAccounts')
-    cy.contains('button', 'Select Accounts').click()
+    cy.contains('button', 'All Linked Accounts').click()
     cy.get('.dropdown-menu label').should('have.length', 2)
     cy.get('.dropdown-menu').contains('Checking')
     cy.get('.dropdown-menu').contains('Savings')
+  })
+
+  it('applies success and error status classes for account pills', () => {
+    cy.intercept('GET', '/accounts/get_accounts*', {
+      statusCode: 200,
+      body: {
+        status: 'success',
+        accounts: [
+          { account_id: '1', name: 'Checking', institution_name: 'Bank A' },
+          { account_id: '2', name: 'Savings', institution_name: 'Bank A' },
+        ],
+      },
+    }).as('getAccounts')
+
+    cy.intercept('POST', '/accounts/refresh*', {
+      statusCode: 200,
+      body: {
+        status: 'success',
+        refreshed_counts: { 'Bank A': 2 },
+        errors: [{ plaid_error_code: 'ITEM_LOGIN_REQUIRED', account_ids: ['2'] }],
+      },
+    }).as('refreshAccounts')
+
+    mount(RefreshPlaidControls)
+    cy.wait('@getAccounts')
+    cy.contains('button', 'Sync Account Activity').click()
+    cy.wait('@refreshAccounts')
+
+    cy.contains('.account-row', 'Checking').find('.status-pill').should('have.class', 'pill-ok')
+    cy.contains('.account-row', 'Savings').find('.status-pill').should('have.class', 'pill-error')
   })
 })

--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -353,7 +353,7 @@ export default {
 }
 .institution-block {
   border: 1px solid var(--divider);
-  border-radius: 8px;
+  border-radius: var(--radius-2);
   padding: 0.5rem;
 }
 .institution-header {
@@ -387,25 +387,28 @@ export default {
 }
 .status-pill {
   padding: 0.1rem 0.5rem;
-  border-radius: 999px;
+  border-radius: var(--radius-1);
   font-size: 0.75rem;
+  border: 1px solid transparent;
 }
 .pill-ok {
-  background: #e6f9ef;
-  color: #0f5132;
+  background: color-mix(in srgb, var(--color-bg-success) 22%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-success) 38%, var(--border-subtle));
+  color: color-mix(in srgb, var(--color-success) 78%, var(--text-primary));
 }
 .pill-error {
-  background: #fde2e1;
-  color: #842029;
+  background: color-mix(in srgb, var(--color-bg-error) 22%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-error) 38%, var(--border-subtle));
+  color: color-mix(in srgb, var(--color-error) 78%, var(--text-primary));
 }
 .account-details {
   margin-top: 0.25rem;
 }
 .error-details {
-  background: #fff5f5;
-  border: 1px solid #fecaca;
-  color: #7f1d1d;
-  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-bg-error) 14%, var(--surface-1));
+  border: 1px solid color-mix(in srgb, var(--color-error) 42%, var(--border-subtle));
+  color: color-mix(in srgb, var(--color-error) 82%, var(--text-primary));
+  border-radius: var(--radius-1);
   padding: 0.5rem;
 }
 .error-title {
@@ -417,7 +420,7 @@ export default {
 }
 .tx-list {
   border: 1px solid var(--divider);
-  border-radius: 6px;
+  border-radius: var(--radius-1);
   padding: 0.25rem;
 }
 .tx-list.loading {


### PR DESCRIPTION
### Motivation
- Replace hardcoded success/error colors and numeric radii in the Plaid refresh UI with semantic theme tokens to align with the design system and the corner-radius migration guide. 
- Make decorative badges/pills follow the policy (no fully rounded decorative pills) and ensure visual regressions are caught by tests. 

### Description
- Replaced hardcoded color values in `frontend/src/components/widgets/RefreshPlaidControls.vue` with semantic token-driven styles using `--color-success/error/bg-*` and `color-mix(...)` for readable foregrounds and borders. 
- Replaced fixed numeric `border-radius` values with `--radius-2`/`--radius-1` tokens and added `border: 1px solid transparent` to pills for clearer state semantics. 
- Updated the Cypress component test `frontend/src/components/__tests__/RefreshPlaidControls.cy.js` to use the current dropdown label and to assert `pill-ok` / `pill-error` class assignment after a mocked refresh response. 
- Documented the status badge/alert styling pattern and corner guidance in `frontend/docs/THEMING_GUIDE.md` under a new "Status badge and alert pattern" section. 

### Testing
- Ran targeted ESLint on the modified files with `npx eslint frontend/src/components/widgets/RefreshPlaidControls.vue frontend/src/components/__tests__/RefreshPlaidControls.cy.js` which completed with warnings and no errors for those files. 
- Ran full frontend lint (`cd frontend && npm run lint`) which failed due to pre-existing, repo-wide lint and parsing errors outside this change set. 
- Attempted component tests with `cd frontend && npm run test:unit -- --component RefreshPlaidControls.cy.js` which failed in this environment because Cypress requires `Xvfb` (missing in the container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3361c8f5883298c1c9190d44c0cb2)