### PR TITLE
feat(settings): use base form primitives for settings command controls

### DIFF
--- a/frontend/docs/THEMING_GUIDE.md
+++ b/frontend/docs/THEMING_GUIDE.md
@@ -152,3 +152,7 @@ This guide establishes a foundation for consistent theming. By defining all
 colors and common surfaces in a dedicated theme file, future designs can be
 implemented simply by creating additional theme files and adjusting the import in
 `global-colors.css`.
+
+## Settings control primitives
+
+Settings screens must use shared base form primitives (`BaseSelect`, `BaseInput`, and related base controls) instead of raw `<select>` or `<input>` elements. This keeps spacing, radius, focus treatments, and token usage consistent with the shared style model.

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -8,11 +8,47 @@
     <section class="settings-panel">
       <h2 class="settings-panel-title">Appearance</h2>
       <label for="themes" class="settings-label">Theme</label>
-      <select id="themes" v-model="selectedTheme" class="input settings-select" @change="setTheme">
+      <BaseSelect
+        id="themes"
+        v-model="selectedTheme"
+        class="settings-select"
+        size="md"
+        radius="md"
+        @change="setTheme"
+      >
         <option v-for="theme in themes" :key="theme" :value="theme">
           {{ theme }}
         </option>
-      </select>
+      </BaseSelect>
+    </section>
+
+    <section class="settings-panel">
+      <h2 class="settings-panel-title">Command</h2>
+      <p class="settings-panel-copy">Choose a command template and provide task-specific input.</p>
+      <div class="settings-command-fields">
+        <label for="command-template" class="settings-label">Template</label>
+        <BaseSelect
+          id="command-template"
+          v-model="selectedCommandTemplate"
+          class="settings-select"
+          size="md"
+          radius="md"
+        >
+          <option v-for="template in commandTemplates" :key="template.value" :value="template.value">
+            {{ template.label }}
+          </option>
+        </BaseSelect>
+
+        <label for="command-argument" class="settings-label">Task argument</label>
+        <BaseInput
+          id="command-argument"
+          v-model="commandArgument"
+          placeholder="Enter command argument"
+          class="settings-input"
+          size="md"
+          radius="md"
+        />
+      </div>
     </section>
 
     <section class="settings-panel">
@@ -27,6 +63,8 @@
 
 <script>
 import axios from 'axios'
+import BaseInput from '@/components/base/BaseInput.vue'
+import BaseSelect from '@/components/base/BaseSelect.vue'
 import BasePageLayout from '@/components/layout/BasePageLayout.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
 import RefreshPlaidControls from '@/components/widgets/RefreshPlaidControls.vue'
@@ -35,6 +73,8 @@ import { Settings as SettingsIcon } from 'lucide-vue-next'
 export default {
   name: 'Settings',
   components: {
+    BaseInput,
+    BaseSelect,
     BasePageLayout,
     PageHeader,
     RefreshPlaidControls,
@@ -43,6 +83,13 @@ export default {
     return {
       themes: [],
       selectedTheme: '',
+      commandTemplates: [
+        { label: 'Refresh account balances', value: 'refresh-balances' },
+        { label: 'Sync transaction history', value: 'sync-transactions' },
+        { label: 'Rebuild reporting cache', value: 'rebuild-cache' },
+      ],
+      selectedCommandTemplate: 'refresh-balances',
+      commandArgument: '',
       SettingsIcon,
     }
   },
@@ -100,7 +147,14 @@ export default {
   color: var(--color-text-muted);
 }
 
-.settings-select {
+.settings-command-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-select,
+.settings-input {
   max-width: 18rem;
 }
 </style>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -34,7 +34,11 @@
           size="md"
           radius="md"
         >
-          <option v-for="template in commandTemplates" :key="template.value" :value="template.value">
+          <option
+            v-for="template in commandTemplates"
+            :key="template.value"
+            :value="template.value"
+          >
             {{ template.label }}
           </option>
         </BaseSelect>


### PR DESCRIPTION
### Motivation

- Align settings controls with the shared style model so spacing, radius, and focus treatments are consistent across the app. 
- Replace raw form elements used for command selection/input with shared base primitives to reduce styling divergence. 
- Provide a small, discoverable command entry area in settings for predefined command templates and a free-text argument.

### Description

- Updated `frontend/src/views/Settings.vue` to import and register `BaseSelect` and `BaseInput` and replaced the raw theme `<select>` with `BaseSelect` using `size="md"` and `radius="md"`.
- Added a new "Command" section in the existing `settings-panel` that contains a `BaseSelect` for predefined command templates and a `BaseInput` for a free-text task argument, both using the shared size/radius props.
- Added minimal scoped CSS (`.settings-command-fields`, `.settings-select`, `.settings-input`) to preserve layout and max-width inside the existing `settings-panel` structure without introducing new layout patterns.
- Documented the requirement in `frontend/docs/THEMING_GUIDE.md` that settings screens must use base form primitives (`BaseSelect`, `BaseInput`) instead of raw `<select>`/`<input>` elements.

### Testing

- Ran `pytest -q`; collection failed in this environment because backend runtime dependencies are not installed (errors like `ModuleNotFoundError: No module named 'flask'`), so backend tests could not be executed here.
- Ran `cd frontend && npm run lint`; the lint command failed due to pre-existing frontend ESLint errors across the repo unrelated to this change, so no new lint failures attributable to the `Settings.vue` edits were detected.
- Verified the modified files are syntactically valid and that `BaseSelect`/`BaseInput` usage follows the existing primitives' API (`v-model`, `size`, `radius`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6f4b69b08329a7b5734d2081d7c9)