### PR TITLE
feat(backend): add admin-only /api/codex/exec route with safe execution service

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,14 +3,13 @@
 import logging
 import os
 
-from flask import Flask
-from flask_cors import CORS
-from flask_migrate import Migrate
-
 from app.cli.sync import sync_accounts
 from app.config import DB_IDENTITY, DB_SCHEMA, IS_DEV, IS_TEST, logger, plaid_client
 from app.database.schema import ensure_schema
 from app.extensions import db
+from flask import Flask
+from flask_cors import CORS
+from flask_migrate import Migrate
 
 
 def create_app():
@@ -31,8 +30,8 @@ def create_app():
     # Always register routes (for all environments)
     from app.routes.accounts import accounts
     from app.routes.categories import categories
-    from app.routes.codex_exec import codex_exec
     from app.routes.charts import charts
+    from app.routes.codex_exec import codex_exec
     from app.routes.dashboard import dashboard
     from app.routes.docs import docs
     from app.routes.export import export

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -31,6 +31,7 @@ def create_app():
     # Always register routes (for all environments)
     from app.routes.accounts import accounts
     from app.routes.categories import categories
+    from app.routes.codex_exec import codex_exec
     from app.routes.charts import charts
     from app.routes.dashboard import dashboard
     from app.routes.docs import docs
@@ -56,6 +57,7 @@ def create_app():
     app.register_blueprint(dashboard, url_prefix="/api/dashboard")
     app.register_blueprint(docs, url_prefix="/api/docs")
     app.register_blueprint(categories, url_prefix="/api/categories")
+    app.register_blueprint(codex_exec, url_prefix="/api/codex")
     app.register_blueprint(transactions, url_prefix="/api/transactions")
     app.register_blueprint(rules_bp, url_prefix="/api/rules")
     app.register_blueprint(accounts, url_prefix="/api/accounts")

--- a/backend/app/routes/codex_exec.py
+++ b/backend/app/routes/codex_exec.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, jsonify, request
-
 from app.services.codex_exec_service import (
     CodexExecAuthorizationError,
     CodexExecValidationError,
@@ -12,6 +10,7 @@ from app.services.codex_exec_service import (
     log_exec_audit,
     validate_task,
 )
+from flask import Blueprint, jsonify, request
 
 codex_exec = Blueprint("codex_exec", __name__)
 
@@ -36,14 +35,23 @@ def execute_codex_task():
     try:
         task = validate_task(payload.get("task"))
     except CodexExecValidationError as exc:
-        log_exec_audit(requester=requester, task="", preset=preset if isinstance(preset, str) else None, status="invalid")
+        log_exec_audit(
+            requester=requester, task="", preset=preset if isinstance(preset, str) else None, status="invalid"
+        )
         return jsonify({"status": "error", "error": str(exc)}), 400
 
     result = execute_task(task)
-    log_exec_audit(requester=requester, task=task, preset=preset if isinstance(preset, str) else None, status=result.status)
+    log_exec_audit(
+        requester=requester, task=task, preset=preset if isinstance(preset, str) else None, status=result.status
+    )
 
     if result.status == "timeout":
-        return jsonify({"status": "error", "error": "command timed out", "stdout": result.stdout, "stderr": result.stderr}), 504
+        return (
+            jsonify(
+                {"status": "error", "error": "command timed out", "stdout": result.stdout, "stderr": result.stderr}
+            ),
+            504,
+        )
     if result.status == "execution_unavailable":
         return jsonify({"status": "error", "error": "execution backend unavailable"}), 503
     if result.status == "failed":

--- a/backend/app/routes/codex_exec.py
+++ b/backend/app/routes/codex_exec.py
@@ -1,0 +1,55 @@
+"""Admin-only route for constrained Codex command execution."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from app.services.codex_exec_service import (
+    CodexExecAuthorizationError,
+    CodexExecValidationError,
+    ensure_admin_authorized,
+    execute_task,
+    log_exec_audit,
+    validate_task,
+)
+
+codex_exec = Blueprint("codex_exec", __name__)
+
+
+@codex_exec.route("/exec", methods=["POST"])
+def execute_codex_task():
+    """Run a validated Codex task using strict command and auth controls."""
+
+    requester = request.headers.get("X-Requester", "unknown")
+    preset = None
+    task = ""
+
+    try:
+        ensure_admin_authorized(request.headers.get("X-Admin-Token"))
+    except CodexExecAuthorizationError as exc:
+        log_exec_audit(requester=requester, task="", preset=None, status="unauthorized")
+        return jsonify({"status": "error", "error": str(exc)}), 403
+
+    payload = request.get_json(silent=True) or {}
+    preset = payload.get("preset")
+
+    try:
+        task = validate_task(payload.get("task"))
+    except CodexExecValidationError as exc:
+        log_exec_audit(requester=requester, task="", preset=preset if isinstance(preset, str) else None, status="invalid")
+        return jsonify({"status": "error", "error": str(exc)}), 400
+
+    result = execute_task(task)
+    log_exec_audit(requester=requester, task=task, preset=preset if isinstance(preset, str) else None, status=result.status)
+
+    if result.status == "timeout":
+        return jsonify({"status": "error", "error": "command timed out", "stdout": result.stdout, "stderr": result.stderr}), 504
+    if result.status == "execution_unavailable":
+        return jsonify({"status": "error", "error": "execution backend unavailable"}), 503
+    if result.status == "failed":
+        return (
+            jsonify({"status": "error", "error": "command failed", "stdout": result.stdout, "stderr": result.stderr}),
+            500,
+        )
+
+    return jsonify({"status": "success", "stdout": result.stdout, "stderr": result.stderr}), 200

--- a/backend/app/services/codex_exec_service.py
+++ b/backend/app/services/codex_exec_service.py
@@ -1,0 +1,129 @@
+"""Service helpers for safely executing constrained Codex commands."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from app.config import logger
+
+MAX_TASK_LENGTH = 400
+MAX_OUTPUT_CHARS = 8000
+EXEC_TIMEOUT_SECONDS = 15
+_ALLOWED_TASK_PATTERN = re.compile(r"^[A-Za-z0-9 _.,:@/+-]+$")
+
+
+class CodexExecValidationError(ValueError):
+    """Raised when the request payload or task content is invalid."""
+
+
+class CodexExecAuthorizationError(PermissionError):
+    """Raised when admin authorization checks fail."""
+
+
+@dataclass(frozen=True)
+class CodexExecResult:
+    """Structured result for a safe Codex execution request."""
+
+    status: str
+    command: list[str]
+    stdout: str
+    stderr: str
+    return_code: int | None
+
+
+def validate_task(task: Any) -> str:
+    """Validate and normalize a task string for safe command construction."""
+
+    if not isinstance(task, str):
+        raise CodexExecValidationError("task must be a string")
+
+    normalized = task.strip()
+    if not normalized:
+        raise CodexExecValidationError("task must not be empty")
+    if len(normalized) > MAX_TASK_LENGTH:
+        raise CodexExecValidationError(f"task exceeds max length of {MAX_TASK_LENGTH}")
+    if not _ALLOWED_TASK_PATTERN.fullmatch(normalized):
+        raise CodexExecValidationError("task contains disallowed characters")
+
+    return normalized
+
+
+def ensure_admin_authorized(admin_token: str | None) -> None:
+    """Require an explicit admin token to execute privileged commands."""
+
+    configured_token = os.getenv("CODEX_EXEC_ADMIN_TOKEN", "").strip()
+    provided = (admin_token or "").strip()
+    if not configured_token or provided != configured_token:
+        raise CodexExecAuthorizationError("admin authorization required")
+
+
+def build_command(task: str) -> list[str]:
+    """Build the only approved command shape from validated task input."""
+
+    return ["codex", "exec", task]
+
+
+def _bounded_text(value: str | None, limit: int = MAX_OUTPUT_CHARS) -> str:
+    text = value or ""
+    return text[:limit]
+
+
+def execute_task(task: str) -> CodexExecResult:
+    """Execute a validated Codex task with bounded runtime and output."""
+
+    command = build_command(task)
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=EXEC_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CodexExecResult(
+            status="timeout",
+            command=command,
+            stdout=_bounded_text(exc.stdout),
+            stderr=_bounded_text(exc.stderr),
+            return_code=None,
+        )
+    except OSError:
+        return CodexExecResult(
+            status="execution_unavailable",
+            command=command,
+            stdout="",
+            stderr="codex executable not available",
+            return_code=None,
+        )
+
+    status = "success" if completed.returncode == 0 else "failed"
+    return CodexExecResult(
+        status=status,
+        command=command,
+        stdout=_bounded_text(completed.stdout),
+        stderr=_bounded_text(completed.stderr),
+        return_code=completed.returncode,
+    )
+
+
+def log_exec_audit(*, requester: str, task: str, preset: str | None, status: str) -> None:
+    """Emit structured audit logs without exposing raw task content."""
+
+    task_hash = hashlib.sha256(task.encode("utf-8")).hexdigest()
+    preset_hash = hashlib.sha256((preset or "").encode("utf-8")).hexdigest() if preset else None
+    payload = {
+        "event": "codex_exec",
+        "requester": requester,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "task_hash": task_hash,
+        "preset_hash": preset_hash,
+        "status": status,
+    }
+    logger.info("codex_exec_audit %s", payload)

--- a/docs/backend/app/routes/codex_exec.md
+++ b/docs/backend/app/routes/codex_exec.md
@@ -1,0 +1,82 @@
+---
+Owner: Backend Team
+Last Updated: 2026-05-21
+Status: Active
+---
+
+# codex_exec Route
+
+## Purpose
+
+Expose an admin-only execution endpoint for constrained Codex tasks with strict input validation, command construction, and audit logging.
+
+## Endpoint
+
+- **POST** `/api/codex/exec`
+
+## Request Schema
+
+```json
+{
+  "task": "<required text>",
+  "preset": "<optional id>"
+}
+```
+
+### Request Validation Rules
+
+- `task` must be a non-empty string after trimming.
+- `task` length must be `<= 400` characters.
+- `task` must only use approved characters (`A-Z`, `a-z`, `0-9`, spaces, and `_. , : @ / + -`).
+- Shell metacharacters and raw command strings are rejected.
+- The service always constructs the command as `codex exec <task>` using argument arrays; callers cannot supply direct raw command arguments.
+
+## Authorization
+
+- Requires `X-Admin-Token` request header that matches server environment variable `CODEX_EXEC_ADMIN_TOKEN`.
+- Unauthorized requests return HTTP `403`.
+
+## Execution and Safety Controls
+
+- Uses subprocess invocation with argument arrays (no `shell=True`).
+- Applies timeout (`15s`).
+- Captures and truncates stdout/stderr to bounded output limits.
+- Maps execution failures to explicit HTTP statuses:
+  - `400`: invalid input payload/task.
+  - `403`: failed admin authorization.
+  - `500`: command returned non-zero exit code.
+  - `503`: execution backend unavailable (`codex` executable missing).
+  - `504`: command timeout.
+
+## Audit Logging
+
+- Emits structured log event with:
+  - requester (`X-Requester` header or `unknown`)
+  - UTC timestamp
+  - SHA-256 hash of task
+  - SHA-256 hash of preset (if provided)
+  - final execution status
+- Raw task content and secrets are not logged.
+
+## Response Schema
+
+### Success (`200`)
+
+```json
+{
+  "status": "success",
+  "stdout": "...",
+  "stderr": "..."
+}
+```
+
+### Failure (`4xx/5xx`)
+
+```json
+{
+  "status": "error",
+  "error": "human-readable reason",
+  "stdout": "optional bounded output",
+  "stderr": "optional bounded output"
+}
+```

--- a/docs/backend/app/routes/index.md
+++ b/docs/backend/app/routes/index.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-03-04
+Last Updated: 2026-05-21
 Status: Active
 ---
 
@@ -64,6 +64,7 @@ Use the links below to open a specific route reference.
 
 ### Integrations & Sync
 
+- [codex_exec.md](codex_exec.md) – Admin-only constrained Codex task execution endpoint.
 - [plaid_transactions.md](plaid_transactions.md) – Plaid transaction sync APIs.
 - [investments.md](investments.md) – Persisted investment accounts, holdings, and transaction queries.
 - [plaid_investments.md](plaid_investments.md) – Plaid investments link and refresh flows.

--- a/docs/backend/app/services/codex_exec_service.md
+++ b/docs/backend/app/services/codex_exec_service.md
@@ -1,0 +1,31 @@
+---
+Owner: Backend Team
+Last Updated: 2026-05-21
+Status: Active
+---
+
+# codex_exec_service
+
+## Purpose
+
+Provide a constrained service layer for validating and executing Codex commands with strict safety and audit controls.
+
+## Public API
+
+- `validate_task(task)` validates task type, emptiness, size, and allowed character set.
+- `ensure_admin_authorized(admin_token)` enforces admin-token based execution gate.
+- `build_command(task)` constructs the only allowed command: `['codex', 'exec', task]`.
+- `execute_task(task)` runs subprocess execution with timeout and bounded output.
+- `log_exec_audit(...)` emits structured audit logs with hashes instead of raw task content.
+
+## Safety Controls
+
+- No shell interpolation (`shell=True` is never used).
+- Input task characters are allowlisted.
+- Runtime timeout and output length limits are enforced.
+- Errors are normalized into explicit status buckets (`success`, `failed`, `timeout`, `execution_unavailable`).
+
+## Audit Behavior
+
+- Logs include requester, timestamp, task hash, preset hash, and status.
+- Logs avoid raw task/preset values to limit secret leakage risk.

--- a/docs/backend/app/services/index.md
+++ b/docs/backend/app/services/index.md
@@ -28,6 +28,7 @@
 
 ### Synchronization & Storage
 
+- [`codex_exec_service.py`](codex_exec_service.md): Validates and executes constrained `codex exec` tasks with auth and audit controls.
 - [`plaid_sync.py`](plaid_sync.md): Plaid `/transactions/sync` integration and reconciliation logic.
 - [`sync_service.py`](sync_service.md): Orchestrates transaction ingestion from APIs or files.
 - [`transactions.py`](transactions.md): Core logic for interacting with transaction data.

--- a/tests/test_codex_exec_route.py
+++ b/tests/test_codex_exec_route.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from flask import Flask
-
 from app.routes.codex_exec import codex_exec
+from flask import Flask
 
 
 def _build_client():

--- a/tests/test_codex_exec_route.py
+++ b/tests/test_codex_exec_route.py
@@ -1,0 +1,52 @@
+"""Tests for the admin Codex execution endpoint."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+from app.routes.codex_exec import codex_exec
+
+
+def _build_client():
+    app = Flask(__name__)
+    app.register_blueprint(codex_exec, url_prefix="/api/codex")
+    return app.test_client()
+
+
+def test_codex_exec_rejects_missing_admin_token():
+    client = _build_client()
+
+    response = client.post("/api/codex/exec", json={"task": "status"})
+
+    assert response.status_code == 403
+    assert response.get_json()["error"] == "admin authorization required"
+
+
+def test_codex_exec_rejects_disallowed_task_characters(monkeypatch):
+    monkeypatch.setenv("CODEX_EXEC_ADMIN_TOKEN", "secret")
+    client = _build_client()
+
+    response = client.post(
+        "/api/codex/exec",
+        headers={"X-Admin-Token": "secret"},
+        json={"task": "status; rm -rf /"},
+    )
+
+    assert response.status_code == 400
+    assert "disallowed" in response.get_json()["error"]
+
+
+def test_codex_exec_success(monkeypatch):
+    monkeypatch.setenv("CODEX_EXEC_ADMIN_TOKEN", "secret")
+    client = _build_client()
+
+    response = client.post(
+        "/api/codex/exec",
+        headers={"X-Admin-Token": "secret", "X-Requester": "admin@example.com"},
+        json={"task": "show status", "preset": "default"},
+    )
+
+    # Route should not crash even when codex is unavailable in test env.
+    assert response.status_code in {200, 503, 500, 504}
+    body = response.get_json()
+    assert body["status"] in {"success", "error"}


### PR DESCRIPTION
### Motivation

- Provide a tightly-scoped admin endpoint to run constrained `codex exec <task>` work without exposing shell access or secrets and to centralize execution logic in the service layer.

### Description

- Add `backend/app/services/codex_exec_service.py` implementing input validation, admin-token authorization, argument-array command construction, subprocess execution with timeout and bounded output, and structured audit logging using hashes.
- Add admin-only route `POST /api/codex/exec` in `backend/app/routes/codex_exec.py` that validates the JSON payload, enforces `X-Admin-Token`, delegates execution to the service, and maps execution outcomes to explicit HTTP statuses.
- Register the new blueprint in `create_app()` (`backend/app/__init__.py`) under the `/api/codex` prefix and create `tests/test_codex_exec_route.py` with unit cases for missing token, disallowed characters, and general success/error shape.
- Add documentation files `docs/backend/app/routes/codex_exec.md` and `docs/backend/app/services/codex_exec_service.md`, and update the nearest route/service indexes to reference the new docs per repository guidelines.

### Testing

- Added `tests/test_codex_exec_route.py` which exercises missing admin token, disallowed task characters, and general success/error behaviors for the route.
- Ran repository checks during commit (route linter and docs verification) and they succeeded according to the commit output which reports documentation coverage verified.
- Executed the full test suite with `pytest -q`, which aborted during collection due to missing runtime/test environment dependencies (e.g., `flask`, `flask_sqlalchemy`, and other optional packages) in the current environment, so the new tests were not fully executed in this run.
- Recommend running `pytest -q` in a prepared environment (installing test dependencies or running `bash scripts/setup.sh`) to validate the new unit tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6e8ef8a4832994c6c9dcf244e905)