### PR TITLE
feat(accounts): add Most Active Accounts breakdown panel

### DIFF
--- a/frontend/docs/accounts-data-loading.md
+++ b/frontend/docs/accounts-data-loading.md
@@ -54,6 +54,17 @@ Retry actions are scoped by panel:
 
 Top-level refresh buttons still request all three queries.
 
+## Most Active Accounts panel loading
+
+The Accounts Summary tab starts with a Most Active Accounts panel and uses a dedicated fetch path:
+
+- `loadActivityBreakdown()` calls `fetchRecentTransactions(accountId, 100)` for each linked account.
+- Requests run with `Promise.allSettled()` so one failing account does not block the full breakdown.
+- The panel exposes two ranking modes:
+  - **Most active by transaction count** (default)
+  - **Most active by total transaction value** (absolute amount sum)
+- Rankings are computed client-side from the normalized response and constrained to the top 5 accounts.
+
 ## Payload normalization
 
 All account-history payload shape handling is centralized in `useAccountHistory`.

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -58,7 +58,9 @@
             <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h2 class="accounts-panel-title">Most Active Accounts</h2>
-                <p class="text-sm text-muted">Ranked by recent transaction activity in the selected date range.</p>
+                <p class="text-sm text-muted">
+                  Ranked by recent transaction activity in the selected date range.
+                </p>
               </div>
 
               <select
@@ -85,16 +87,28 @@
                 class="accounts-activity-item rounded-xl p-4"
               >
                 <div class="flex items-center justify-between gap-3">
-                  <p class="text-sm font-semibold text-[var(--theme-fg)]">{{ index + 1 }}. {{ row.name }}</p>
-                  <span class="accounts-activity-score text-xs font-semibold">{{ row.primaryMetricLabel }}</span>
+                  <p class="text-sm font-semibold text-[var(--theme-fg)]">
+                    {{ index + 1 }}. {{ row.name }}
+                  </p>
+                  <span class="accounts-activity-score text-xs font-semibold">{{
+                    row.primaryMetricLabel
+                  }}</span>
                 </div>
                 <div class="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-2">
-                  <p>Transaction count: <span class="text-[var(--theme-fg)]">{{ row.transactionCount }}</span></p>
-                  <p>Total transaction value: <span class="text-[var(--theme-fg)]">{{ row.totalValueLabel }}</span></p>
+                  <p>
+                    Transaction count:
+                    <span class="text-[var(--theme-fg)]">{{ row.transactionCount }}</span>
+                  </p>
+                  <p>
+                    Total transaction value:
+                    <span class="text-[var(--theme-fg)]">{{ row.totalValueLabel }}</span>
+                  </p>
                 </div>
               </article>
             </div>
-            <p v-else class="text-sm text-muted">No activity data is available for the selected range.</p>
+            <p v-else class="text-sm text-muted">
+              No activity data is available for the selected range.
+            </p>
           </Card>
 
           <Card class="accounts-card accounts-card--primary space-y-6 rounded-2xl p-6 shadow-xl">
@@ -363,7 +377,9 @@ const mostActiveAccounts = computed(() => {
       ...row,
       totalValueLabel: formatAmount(row.totalValue),
       primaryMetricLabel:
-        metric === 'totalValue' ? `${formatAmount(row.totalValue)} total value` : `${row.transactionCount} transactions`,
+        metric === 'totalValue'
+          ? `${formatAmount(row.totalValue)} total value`
+          : `${row.transactionCount} transactions`,
     }))
 })
 

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -54,6 +54,49 @@
         </Card>
 
         <template v-else>
+          <Card class="accounts-card accounts-card--secondary space-y-6 rounded-2xl p-6 shadow-xl">
+            <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 class="accounts-panel-title">Most Active Accounts</h2>
+                <p class="text-sm text-muted">Ranked by recent transaction activity in the selected date range.</p>
+              </div>
+
+              <select
+                v-model="activityMode"
+                class="input w-full sm:w-72"
+                :disabled="loadingActivityBreakdown || !accountActivityBreakdown.length"
+              >
+                <option value="count">Most active by transaction count</option>
+                <option value="value">Most active by total transaction value</option>
+              </select>
+            </header>
+
+            <SkeletonCard v-if="loadingActivityBreakdown" />
+            <RetryError
+              v-else-if="activityBreakdownError"
+              message="Failed to load account activity"
+              @retry="loadActivityBreakdown"
+            />
+
+            <div v-else-if="mostActiveAccounts.length" class="accounts-activity-list">
+              <article
+                v-for="(row, index) in mostActiveAccounts"
+                :key="row.accountId"
+                class="accounts-activity-item rounded-xl p-4"
+              >
+                <div class="flex items-center justify-between gap-3">
+                  <p class="text-sm font-semibold text-[var(--theme-fg)]">{{ index + 1 }}. {{ row.name }}</p>
+                  <span class="accounts-activity-score text-xs font-semibold">{{ row.primaryMetricLabel }}</span>
+                </div>
+                <div class="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-2">
+                  <p>Transaction count: <span class="text-[var(--theme-fg)]">{{ row.transactionCount }}</span></p>
+                  <p>Total transaction value: <span class="text-[var(--theme-fg)]">{{ row.totalValueLabel }}</span></p>
+                </div>
+              </article>
+            </div>
+            <p v-else class="text-sm text-muted">No activity data is available for the selected range.</p>
+          </Card>
+
           <Card class="accounts-card accounts-card--primary space-y-6 rounded-2xl p-6 shadow-xl">
             <header class="flex justify-between items-center">
               <div>
@@ -235,6 +278,7 @@ const recentTransactions = ref([])
 
 const ranges = ['7d', '30d', '90d', '365d']
 const selectedRange = ref('30d')
+const activityMode = ref('count')
 
 const {
   history: accountHistory,
@@ -245,9 +289,12 @@ const {
 
 const loadingSummary = ref(false)
 const loadingTransactions = ref(false)
+const loadingActivityBreakdown = ref(false)
 
 const summaryError = ref(null)
 const transactionsError = ref(null)
+const activityBreakdownError = ref(null)
+const accountActivityBreakdown = ref([])
 
 const activeTab = ref('Summary')
 
@@ -296,6 +343,30 @@ const netSummaryStats = computed(() => [
   },
 ])
 
+/**
+ * Resolves a numeric amount from supported transaction response fields.
+ * @param {Record<string, any>} transaction
+ * @returns {number}
+ */
+function transactionAmount(transaction) {
+  const raw = transaction?.amount ?? transaction?.signed_amount ?? transaction?.value ?? 0
+  const normalized = Number(raw)
+  return Number.isFinite(normalized) ? normalized : 0
+}
+
+const mostActiveAccounts = computed(() => {
+  const metric = activityMode.value === 'value' ? 'totalValue' : 'transactionCount'
+  return [...accountActivityBreakdown.value]
+    .sort((left, right) => right[metric] - left[metric])
+    .slice(0, 5)
+    .map((row) => ({
+      ...row,
+      totalValueLabel: formatAmount(row.totalValue),
+      primaryMetricLabel:
+        metric === 'totalValue' ? `${formatAmount(row.totalValue)} total value` : `${row.transactionCount} transactions`,
+    }))
+})
+
 function handleAccountSelection(e) {
   accountId.value = e.target.value || null
 }
@@ -307,6 +378,44 @@ async function loadAccounts() {
     accounts.value = resp?.accounts || []
   } finally {
     accountsLoading.value = false
+  }
+}
+
+/**
+ * Loads account-level transaction activity and computes breakdown metrics for ranking.
+ * @returns {Promise<void>}
+ */
+async function loadActivityBreakdown() {
+  if (!hasAccounts.value) {
+    accountActivityBreakdown.value = []
+    return
+  }
+
+  loadingActivityBreakdown.value = true
+  activityBreakdownError.value = null
+
+  try {
+    const results = await Promise.allSettled(
+      accounts.value.map(async (account) => {
+        const response = await fetchRecentTransactions(account.account_id, 100)
+        const transactions = response?.transactions ?? []
+        return {
+          accountId: account.account_id,
+          name: account.display_name || account.name || 'Unnamed account',
+          transactionCount: transactions.length,
+          totalValue: transactions.reduce((sum, tx) => sum + Math.abs(transactionAmount(tx)), 0),
+        }
+      }),
+    )
+
+    accountActivityBreakdown.value = results
+      .filter((result) => result.status === 'fulfilled')
+      .map((result) => result.value)
+      .filter((row) => row.transactionCount > 0 || row.totalValue > 0)
+  } catch (error) {
+    activityBreakdownError.value = error
+  } finally {
+    loadingActivityBreakdown.value = false
   }
 }
 
@@ -378,11 +487,12 @@ onMounted(async () => {
   if (!accountId.value && accounts.value.length) {
     accountId.value = accounts.value[0].account_id
   }
-  await loadData()
+  await Promise.all([loadData(), loadActivityBreakdown()])
 })
 
 watch(accountId, loadData)
 watch(selectedRange, loadData)
+watch(selectedRange, loadActivityBreakdown)
 </script>
 <style scoped>
 .accounts-tab-panel {
@@ -434,6 +544,20 @@ watch(selectedRange, loadData)
 .accounts-kpi-card {
   border: 1px solid var(--themed-border);
   background: var(--table-surface);
+}
+
+.accounts-activity-list {
+  display: grid;
+  gap: var(--space-3, 0.75rem);
+}
+
+.accounts-activity-item {
+  border: 1px solid var(--table-border);
+  background: var(--table-surface);
+}
+
+.accounts-activity-score {
+  color: color-mix(in srgb, var(--color-accent-indigo) 70%, var(--theme-fg));
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/__tests__/Accounts.spec.js
+++ b/frontend/src/views/__tests__/Accounts.spec.js
@@ -32,7 +32,10 @@ vi.mock('vue-toastification', () => ({
 vi.mock('@/services/api', () => ({
   default: {
     getAccounts: vi.fn().mockResolvedValue({
-      accounts: [{ account_id: 'acc-1', name: 'Checking', display_name: 'Primary Checking' }],
+      accounts: [
+        { account_id: 'acc-1', name: 'Checking', display_name: 'Primary Checking' },
+        { account_id: 'acc-2', name: 'Savings', display_name: 'Rainy Day Savings' },
+      ],
     }),
   },
 }))
@@ -45,7 +48,12 @@ vi.mock('@/api/accounts', () => ({
   fetchNetChanges: vi
     .fn()
     .mockResolvedValue({ status: 'success', data: { income: 0, expense: 0, net: 0 } }),
-  fetchRecentTransactions: vi.fn().mockResolvedValue({ transactions: [] }),
+  fetchRecentTransactions: vi.fn(async (accountId) => {
+    if (accountId === 'acc-2') {
+      return { transactions: [{ amount: 500 }, { amount: -250 }] }
+    }
+    return { transactions: [{ amount: 100 }, { amount: -20 }, { amount: 10 }] }
+  }),
   rangeToDates: vi.fn().mockReturnValue({ start: '2024-01-01', end: '2024-01-30' }),
 }))
 
@@ -195,5 +203,35 @@ describe('Accounts.vue', () => {
 
     const chart = wrapper.getComponent({ name: 'AccountBalanceHistoryChart' })
     expect(chart.props('historyData')).toEqual(normalizedHistory.value)
+  })
+
+  it('defaults most-active ranking to transaction count and supports value toggle', async () => {
+    const wrapper = shallowMount(Accounts, {
+      global: {
+        stubs: {
+          TabbedPageLayout: { template: '<div><slot name="Summary" /></div>' },
+          AccountActionsSidebar: true,
+          LinkedAccountsSection: true,
+          Card: { template: '<div><slot /></div>' },
+          PageHeader: { template: '<div><slot name="title" /><slot name="subtitle" /></div>' },
+          UiButton: { template: '<button><slot /></button>' },
+          SkeletonCard: true,
+          RetryError: true,
+          AccountBalanceHistoryChart: true,
+          TransactionsTable: true,
+          NetYearComparisonChart: true,
+          AssetsBarTrended: true,
+          AccountsReorderChart: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    expect(wrapper.text()).toContain('1. Primary Checking')
+
+    const select = wrapper.find('select.input.w-full.sm\\:w-72')
+    await select.setValue('value')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('1. Rainy Day Savings')
   })
 })


### PR DESCRIPTION
### Motivation
- Surface the most active accounts up-front on the Accounts summary so users can quickly see which accounts have the most transaction activity. 
- Provide a toggle to rank by either transaction count or total transaction value to support different user priorities. 
- Keep the new UI aligned with the project's theme token system and resilient to partial API failures.

### Description
- Added a new Most Active Accounts panel to `frontend/src/views/Accounts.vue` that appears at the top of the Summary tab and exposes a selector defaulting to `count` with an option for `value`.
- Implemented client-side aggregation logic in `Accounts.vue`: `activityMode`, `transactionAmount()` normalizer, `loadActivityBreakdown()` fetching per-account recent transactions (uses `Promise.allSettled()`), and `mostActiveAccounts` computed ranking limited to the top 5.
- Wired lifecycle updates so the breakdown loads on mount (`onMounted`) and refreshes when the selected range changes (`watch(selectedRange, loadActivityBreakdown)`), and added loading/error/empty states in the template.
- Added lightweight scoped styles that use existing theme tokens (`--table-surface`, `--table-border`, `--color-accent-indigo`) to keep the panel consistent with theming rules.
- Added a unit test in `frontend/src/views/__tests__/Accounts.spec.js` to assert default ranking by transaction count and toggle behavior, and updated `frontend/docs/accounts-data-loading.md` to document the new panel.

### Testing
- Ran the focused frontend unit tests with Vitest: `cd frontend && npx vitest run src/views/__tests__/Accounts.spec.js`, and the test file passed (6 tests) ✅.
- Ran the full Python test suite with `pytest -q`, which failed during collection due to missing backend test environment/dependencies (e.g., `flask` not installed) and is unrelated to the frontend change ❌.
- Ran frontend lint (`cd frontend && npm run lint`), which surfaced pre-existing lint warnings/errors across the frontend codebase and did not pass globally; the new code follows project theming and style tokens but a broader lint cleanup remains outside this change ❌.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e199d1a88329a33ad6dcffdc7c49)