### PR TITLE
refactor(frontend): align RefreshPlaidControls status styling with semantic tokens and radii

### DIFF
--- a/docs/frontend/corner-radius-migration-guide.md
+++ b/docs/frontend/corner-radius-migration-guide.md
@@ -40,3 +40,12 @@ For phased delivery expectations and route-level capture requirements, follow:
 
 Any PR changing frontend surface geometry should include the visual QA template and before/after captures.
 
+
+## Status surface token pattern
+
+For status indicators and alert surfaces, use semantic status tokens rather than hardcoded hex values.
+
+- Use `--color-success`, `--color-error`, `--color-warning`, and `--color-info` for semantic foreground/border intent.
+- Use matching background tokens (`--color-bg-success`, `--color-bg-error`, `--color-bg-warning`, `--color-bg-info`) blended with surfaces for dark-mode-safe contrast.
+- Prefer component-level status class names such as `status-pill--success` and `status-pill--error` that map to semantic tokens.
+- For badge/chip geometry, use `--radius-1` (or `ui-radius-1`). Do not use fully rounded pills except semantic circles.

--- a/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
+++ b/frontend/src/components/__tests__/RefreshPlaidControls.cy.js
@@ -48,7 +48,7 @@ describe('RefreshPlaidControls', () => {
     cy.contains('button', 'Sync Account Activity').click()
     cy.wait('@refreshAccounts')
 
-    cy.contains('.account-row', 'Checking').find('.status-pill').should('have.class', 'pill-ok')
-    cy.contains('.account-row', 'Savings').find('.status-pill').should('have.class', 'pill-error')
+    cy.contains('.account-row', 'Checking').find('.status-pill').should('have.class', 'status-pill--success')
+    cy.contains('.account-row', 'Savings').find('.status-pill').should('have.class', 'status-pill--error')
   })
 })

--- a/frontend/src/components/widgets/RefreshPlaidControls.vue
+++ b/frontend/src/components/widgets/RefreshPlaidControls.vue
@@ -55,7 +55,7 @@
               <span class="account-name">{{ acct.name }}</span>
               <span
                 class="status-pill"
-                :class="errorByAccountId[acct.account_id] ? 'pill-error' : 'pill-ok'"
+                :class="errorByAccountId[acct.account_id] ? 'status-pill--error' : 'status-pill--success'"
               >
                 {{ errorByAccountId[acct.account_id] ? 'Needs Attention' : 'OK' }}
               </span>
@@ -302,7 +302,7 @@ export default {
   background-color: var(--themed-bg);
   color: var(--color-text-light);
   border: 1px solid var(--color-border-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-2);
   padding: 1rem;
   box-shadow: 0 2px 8px var(--shadow);
   width: 100%;
@@ -335,7 +335,7 @@ export default {
 .error-badge {
   margin-top: 1rem;
   padding: 0.5rem 1rem;
-  border-radius: 6px;
+  border-radius: var(--radius-1);
   font-weight: bold;
   color: #fff;
 }
@@ -391,12 +391,12 @@ export default {
   font-size: 0.75rem;
   border: 1px solid transparent;
 }
-.pill-ok {
+.status-pill--success {
   background: color-mix(in srgb, var(--color-bg-success) 22%, var(--surface-1));
   border-color: color-mix(in srgb, var(--color-success) 38%, var(--border-subtle));
   color: color-mix(in srgb, var(--color-success) 78%, var(--text-primary));
 }
-.pill-error {
+.status-pill--error {
   background: color-mix(in srgb, var(--color-bg-error) 22%, var(--surface-1));
   border-color: color-mix(in srgb, var(--color-error) 38%, var(--border-subtle));
   color: color-mix(in srgb, var(--color-error) 78%, var(--text-primary));
@@ -439,7 +439,7 @@ export default {
   font-size: 0.9rem;
 }
 .tx-date {
-  color: #6b7280;
+  color: var(--text-muted);
 }
 .tx-name {
   overflow: hidden;
@@ -450,7 +450,7 @@ export default {
   font-variant-numeric: tabular-nums;
 }
 .empty {
-  color: #6b7280;
+  color: var(--text-muted);
   font-style: italic;
   padding: 0.25rem;
 }


### PR DESCRIPTION
### Motivation

- Move component status visuals away from hardcoded hex values and ad-hoc radii to the design system’s semantic tokens for consistent theming and dark-mode safety.
- Ensure status badges/pills follow the corner-radius migration policy so decorative pills use `--radius-1` while only semantic circles keep `rounded-full`.
- Prevent regressions by updating component tests to assert the new semantic class names.

### Description

- Replaced account status classes `pill-ok` / `pill-error` with semantic `status-pill--success` / `status-pill--error` and mapped their styles to `--color-success/error` and `--color-bg-success/error` tokens in `frontend/src/components/widgets/RefreshPlaidControls.vue`.
- Replaced fixed numeric radius values with design tokens (`--radius-2`, `--radius-1`) and swapped hardcoded muted color hexes to `--text-muted` in the component’s scoped styles.
- Updated Cypress component test assertions in `frontend/src/components/__tests__/RefreshPlaidControls.cy.js` to expect the new `status-pill--success` / `status-pill--error` classes.
- Added documentation for the status-surface token pattern to `docs/frontend/corner-radius-migration-guide.md` describing token usage and badge radius guidance.

### Testing

- Ran `cd frontend && npm run lint`; the linter executed but failed due to existing repo-wide ESLint errors unrelated to this change (repo has multiple warnings and some errors outside the modified files).
- Attempted `cd frontend && npm run test:unit -- --spec src/components/__tests__/RefreshPlaidControls.cy.js`; test run was blocked in this environment because Cypress requires `Xvfb` (dependency missing), so component tests could not be executed here.
- Ran backend tests with `pytest -q`; collection failed in this environment due to missing Python dependencies (e.g., `flask`) so backend test execution was not possible in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e20e5984832988b47e58d349349c)