### PR TITLE
refactor(frontend): use shared tokens for TabbedPageLayout tabs and rely on UiButton variants

### DIFF
--- a/docs/frontend/PageLayout.md
+++ b/docs/frontend/PageLayout.md
@@ -52,14 +52,14 @@ Refer to [PageHeader docs](PageHeader.md) for prop and slot details.
 ### Usage tips
 
 - Provide an ordered array of tab labels through the `tabs` prop and pair it with `v-model` to react to tab changes.
-- Keep tab labels short (one or two words) so they remain legible inside the pill-shaped buttons.
+- Keep tab labels short (one or two words) so they remain legible inside the compact angular buttons.
 - Avoid wrapping tall content inside the sidebar slot; the layout expects action panels or compact forms.
 
 ### Navigation styling
 
-The tab bar renders a frosted glass gradient container that mirrors the dashboard theme. Active tabs use a cyan-to-magenta gradient, while inactive tabs lean on a subtle midnight glaze.
+The tab bar uses shared surface tokens (`bg-surface-2`, `border-subtle`) and approved radius utilities (`ui-radius-3` container, `ui-radius-2` tabs) so route views inherit the same dark-surface framing and corner scale.
 
-- Do not override the `.tabbed-nav__button` class; instead, adjust accent colors via CSS variables when theming a specific view.
+- Do not override `.tabbed-nav__button` button-state colors. Active/inactive/hover/focus states come from `UiButton` variants to preserve accessibility and consistent contrast on dark surfaces.
 - Tabs automatically wrap on narrow breakpoints. To keep the flow balanced on mobile, limit the tab count to four.
 
 ## Contributor guidance

--- a/frontend/src/components/layout/TabbedPageLayout.vue
+++ b/frontend/src/components/layout/TabbedPageLayout.vue
@@ -3,13 +3,13 @@
     <slot name="header" />
     <div class="flex gap-8">
       <div class="flex-1">
-        <nav class="tabbed-nav" data-testid="tabbed-nav">
+        <nav class="tabbed-nav ui-radius-3 border border-subtle bg-surface-2" data-testid="tabbed-nav">
           <ul class="tabbed-nav__list">
             <li v-for="tab in normalizedTabs" :key="tab.slot">
               <UiButton
                 :variant="activeTab === tab.slot ? 'primary' : 'outline'"
-                :pill="true"
-                class="tabbed-nav__button"
+                :pill="false"
+                class="tabbed-nav__button ui-radius-2"
                 :disabled="tab.disabled"
                 @click="selectTab(tab.slot)"
               >
@@ -91,18 +91,7 @@ const sidebarWidthClass = computed(() => props.sidebarWidth || 'w-64')
 .tabbed-nav {
   margin-bottom: 1.5rem;
   padding: 0.75rem 1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(113, 156, 214, 0.35);
-  background:
-    linear-gradient(
-      135deg,
-      rgba(99, 205, 207, 0.08) 0%,
-      rgba(113, 156, 214, 0.12) 50%,
-      rgba(214, 122, 210, 0.08) 100%
-    ),
-    rgba(19, 24, 44, 0.65);
-  box-shadow: 0 18px 40px rgba(12, 17, 35, 0.45);
-  backdrop-filter: blur(8px);
+  box-shadow: var(--depth-inner-glow), var(--depth-shadow-resting);
 }
 
 .tabbed-nav__list {
@@ -117,52 +106,20 @@ const sidebarWidthClass = computed(() => props.sidebarWidth || 'w-64')
   font-weight: 600;
   letter-spacing: 0.02em;
   padding: 0.55rem 1.35rem;
-  border-radius: 999px;
   transition:
     transform 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease,
-    border-color 0.2s ease;
+    box-shadow 0.2s ease;
 }
 
 .tabbed-nav__button:hover {
   transform: translateY(-2px);
 }
 
-.tabbed-nav__button.btn-outline {
-  background: rgba(17, 23, 42, 0.35);
-  color: var(--color-accent-purple);
-  border-color: rgba(113, 156, 214, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(113, 156, 214, 0.25);
-}
-
-.tabbed-nav__button.btn-outline:hover {
-  background: rgba(113, 156, 214, 0.18);
-  border-color: rgba(113, 156, 214, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(214, 122, 210, 0.35);
-}
-
 .tabbed-nav__button.btn-primary {
-  background: linear-gradient(
-    135deg,
-    rgba(99, 205, 207, 0.95) 0%,
-    rgba(113, 156, 214, 0.95) 50%,
-    rgba(214, 122, 210, 0.95) 100%
-  );
-  border-color: transparent;
-  color: var(--color-bg-dark);
-  box-shadow: 0 12px 28px rgba(99, 205, 207, 0.32);
-}
-
-.tabbed-nav__button.btn-primary:hover {
-  box-shadow: 0 16px 34px rgba(99, 205, 207, 0.42);
+  box-shadow: var(--depth-shadow-raised);
 }
 
 @media (max-width: 768px) {
-  .tabbed-nav {
-    border-radius: 1.25rem;
-  }
-
   .tabbed-nav__list {
     justify-content: center;
   }

--- a/frontend/src/components/layout/TabbedPageLayout.vue
+++ b/frontend/src/components/layout/TabbedPageLayout.vue
@@ -3,7 +3,10 @@
     <slot name="header" />
     <div class="flex gap-8">
       <div class="flex-1">
-        <nav class="tabbed-nav ui-radius-3 border border-subtle bg-surface-2" data-testid="tabbed-nav">
+        <nav
+          class="tabbed-nav ui-radius-3 border border-subtle bg-surface-2"
+          data-testid="tabbed-nav"
+        >
           <ul class="tabbed-nav__list">
             <li v-for="tab in normalizedTabs" :key="tab.slot">
               <UiButton


### PR DESCRIPTION
### Motivation
- Replace local large pill radii and hardcoded rgba/gradient treatments in the tab rail with the design system surface/border tokens and approved radius scale to keep corner geometry and color treatment consistent across views.
- Convert decorative full-pill controls to angular radii so only semantics that require circles remain circular and decorative controls follow the allowed radius scale.
- Reuse existing `UiButton`/`BaseButton` variants for active/inactive/focus visuals to avoid duplicating or conflicting color/focus rules and preserve accessible contrast on dark surfaces.
- Update the layout docs so route views inherit the same tab styling contract and avoid accidental overrides.

### Description
- Updated `frontend/src/components/layout/TabbedPageLayout.vue` to apply shared utilities to the nav container (`ui-radius-3 border border-subtle bg-surface-2`) and to stop forcing pill geometry on `UiButton` by setting `:pill="false"` and adding `ui-radius-2` to the button class.
- Removed local CSS that supplied hardcoded gradient/background, oversized `border-radius: 999px`, and bespoke `btn-outline`/`btn-primary` color overrides; retained only layout motion/elevation using shared shadow tokens (`--depth-inner-glow`, `--depth-shadow-resting`, `--depth-shadow-raised`).
- Simplified button transition rules to avoid redefining background/border state handling that `UiButton` already owns and now rely on `UiButton` variants for active/inactive/hover/focus visuals.
- Updated `docs/frontend/PageLayout.md` to document the new tab styling contract, noting the shared token usage and that button-state colors should come from `UiButton` variants for consistent accessibility.

### Testing
- Ran `pytest -q`, which failed during collection in this environment because required backend Python dependencies (for example `flask`, `flask_sqlalchemy`, and `pdfplumber`) are not installed; failures are unrelated to the frontend change.
- Ran `cd frontend && npm run lint`, which reported existing repository-wide lint and parsing errors not introduced by this change; the TabbedPageLayout edits do not add new lint errors.
- Ran `cd frontend && npm run build`, which completed successfully and produced a production build without bundling/runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e21056bc83299f725e2534ad0e23)