### PR TITLE
feat(settings): add command execution UI, tests, and inline feedback

### DIFF
--- a/frontend/docs/THEMING_GUIDE.md
+++ b/frontend/docs/THEMING_GUIDE.md
@@ -156,3 +156,7 @@ implemented simply by creating additional theme files and adjusting the import i
 ## Settings control primitives
 
 Settings screens must use shared base form primitives (`BaseSelect`, `BaseInput`, and related base controls) instead of raw `<select>` or `<input>` elements. This keeps spacing, radius, focus treatments, and token usage consistent with the shared style model.
+
+## Settings command interaction
+
+The Settings command panel submits the selected preset and trimmed task argument to `POST /api/codex/exec` using the backend contract `{ preset, task }`. The action remains disabled for blank task arguments and while a request is active, preventing duplicate submissions. Command completion, backend validation failures, and server errors are rendered inline so users can act on the result without relying on transient browser alerts.

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -47,11 +47,36 @@
         <BaseInput
           id="command-argument"
           v-model="commandArgument"
+          :disabled="commandLoading"
           placeholder="Enter command argument"
           class="settings-input"
           size="md"
           radius="md"
+          @enter="executeCommand"
         />
+        <BaseButton
+          data-testid="command-submit"
+          variant="solid"
+          tone="accent"
+          :disabled="!commandCanSubmit"
+          @click="executeCommand"
+        >
+          {{ commandLoading ? 'Running command…' : 'Run command' }}
+        </BaseButton>
+        <p
+          v-if="commandFeedback"
+          data-testid="command-feedback"
+          :class="[
+            'settings-command-feedback',
+            `settings-command-feedback--${commandFeedback.type}`,
+          ]"
+          role="status"
+        >
+          {{ commandFeedback.message }}
+        </p>
+        <pre v-if="commandOutput" data-testid="command-output" class="settings-command-output">{{
+          commandOutput
+        }}</pre>
       </div>
     </section>
 
@@ -67,6 +92,7 @@
 
 <script>
 import axios from 'axios'
+import BaseButton from '@/components/base/BaseButton.vue'
 import BaseInput from '@/components/base/BaseInput.vue'
 import BaseSelect from '@/components/base/BaseSelect.vue'
 import BasePageLayout from '@/components/layout/BasePageLayout.vue'
@@ -77,6 +103,7 @@ import { Settings as SettingsIcon } from 'lucide-vue-next'
 export default {
   name: 'Settings',
   components: {
+    BaseButton,
     BaseInput,
     BaseSelect,
     BasePageLayout,
@@ -94,8 +121,19 @@ export default {
       ],
       selectedCommandTemplate: 'refresh-balances',
       commandArgument: '',
+      commandLoading: false,
+      commandFeedback: null,
+      commandOutput: '',
       SettingsIcon,
     }
+  },
+  computed: {
+    /** Return whether the current command form can start a request. */
+    commandCanSubmit() {
+      return (
+        Boolean(this.selectedCommandTemplate && this.commandArgument.trim()) && !this.commandLoading
+      )
+    },
   },
   async created() {
     await this.fetchThemes()
@@ -108,6 +146,30 @@ export default {
         this.selectedTheme = response.data.current_theme
       } catch (error) {
         console.error('Failed to fetch themes:', error)
+      }
+    },
+    /** Submit the validated command form and expose the request result inline. */
+    async executeCommand() {
+      if (!this.commandCanSubmit) return
+
+      this.commandLoading = true
+      this.commandFeedback = null
+      this.commandOutput = ''
+
+      try {
+        const response = await axios.post('/api/codex/exec', {
+          preset: this.selectedCommandTemplate,
+          task: this.commandArgument.trim(),
+        })
+        this.commandFeedback = { type: 'success', message: 'Command completed successfully.' }
+        this.commandOutput = response.data.stdout || ''
+      } catch (error) {
+        this.commandFeedback = {
+          type: 'error',
+          message: error.response?.data?.error || 'Unable to run command. Please try again.',
+        }
+      } finally {
+        this.commandLoading = false
       }
     },
     async setTheme() {
@@ -158,7 +220,28 @@ export default {
 }
 
 .settings-select,
-.settings-input {
+.settings-input,
+.settings-command-fields > button {
   max-width: 18rem;
+}
+
+.settings-command-feedback {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.settings-command-feedback--success {
+  color: var(--color-accent-green);
+}
+
+.settings-command-feedback--error {
+  color: var(--color-accent-red);
+}
+
+.settings-command-output {
+  max-width: 100%;
+  overflow-x: auto;
+  color: var(--color-text-light);
+  white-space: pre-wrap;
 }
 </style>

--- a/frontend/src/views/__tests__/Settings.spec.js
+++ b/frontend/src/views/__tests__/Settings.spec.js
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { shallowMount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import axios from 'axios'
 import SettingsView from '../Settings.vue'
 
 vi.mock('axios', () => ({
@@ -13,30 +14,140 @@ vi.mock('axios', () => ({
       get: vi.fn(),
       post: vi.fn(),
     })),
-    get: vi.fn().mockResolvedValue({ data: { themes: [], current_theme: '' } }),
-    post: vi.fn().mockResolvedValue({}),
+    get: vi.fn(),
+    post: vi.fn(),
   },
 }))
 
-describe('Settings.vue', () => {
-  it('renders settings sections and refresh controls', async () => {
-    const wrapper = shallowMount(SettingsView, {
-      global: {
-        stubs: {
-          BasePageLayout: {
-            template: '<div><slot /></div>',
-          },
-          PageHeader: {
-            template: '<div><slot name="title" /><slot name="subtitle" /></div>',
-          },
-          SettingsIcon: true,
-          RefreshPlaidControls: true,
+/** Mount Settings with only route-level layout dependencies stubbed. */
+const mountSettings = () =>
+  mount(SettingsView, {
+    global: {
+      stubs: {
+        BasePageLayout: {
+          template: '<div><slot /></div>',
         },
+        PageHeader: {
+          template: '<div><slot name="title" /><slot name="subtitle" /></div>',
+        },
+        SettingsIcon: true,
+        RefreshPlaidControls: true,
       },
-    })
+    },
+  })
+
+/** Create a controllable promise for asserting in-flight request behavior. */
+const deferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+describe('Settings.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.get.mockResolvedValue({ data: { themes: ['dark'], current_theme: 'dark' } })
+  })
+
+  it('keeps Appearance and Connected Accounts sections intact', async () => {
+    const wrapper = mountSettings()
+
     await flushPromises()
+
     expect(wrapper.text()).toContain('Appearance')
     expect(wrapper.text()).toContain('Connected Accounts')
     expect(wrapper.find('refresh-plaid-controls-stub').exists()).toBe(true)
+  })
+
+  it('disables command execution until required fields are valid', async () => {
+    const wrapper = mountSettings()
+    const submit = wrapper.get('[data-testid="command-submit"]')
+
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    await wrapper.get('#command-argument').setValue('   ')
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    await wrapper.get('#command-argument').setValue('refresh checking balances')
+    expect(submit.attributes('disabled')).toBeUndefined()
+  })
+
+  it('sends the backend command payload and renders successful output', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { status: 'success', stdout: 'balances refreshed', stderr: '' },
+    })
+    const wrapper = mountSettings()
+
+    await wrapper.get('#command-template').setValue('sync-transactions')
+    await wrapper.get('#command-argument').setValue('  sync account 123  ')
+    await wrapper.get('[data-testid="command-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(axios.post).toHaveBeenCalledWith('/api/codex/exec', {
+      preset: 'sync-transactions',
+      task: 'sync account 123',
+    })
+    expect(wrapper.get('[data-testid="command-feedback"]').text()).toBe(
+      'Command completed successfully.',
+    )
+    expect(wrapper.get('[data-testid="command-output"]').text()).toBe('balances refreshed')
+  })
+
+  it('toggles loading state and prevents duplicate command submissions', async () => {
+    const request = deferred()
+    axios.post.mockReturnValueOnce(request.promise)
+    const wrapper = mountSettings()
+
+    await wrapper.get('#command-argument').setValue('refresh account balances')
+    const submit = wrapper.get('[data-testid="command-submit"]')
+    await submit.trigger('click')
+
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(submit.text()).toBe('Running command…')
+
+    await submit.trigger('click')
+    expect(axios.post).toHaveBeenCalledTimes(1)
+
+    request.resolve({ data: { status: 'success', stdout: '', stderr: '' } })
+    await flushPromises()
+
+    expect(submit.attributes('disabled')).toBeUndefined()
+    expect(submit.text()).toBe('Run command')
+  })
+
+  it('renders backend validation feedback', async () => {
+    axios.post.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: { status: 'error', error: 'task contains disallowed characters' },
+      },
+    })
+    const wrapper = mountSettings()
+
+    await wrapper.get('#command-argument').setValue('invalid task')
+    await wrapper.get('[data-testid="command-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="command-feedback"]').text()).toBe(
+      'task contains disallowed characters',
+    )
+  })
+
+  it('renders timeout feedback and allows the user to retry', async () => {
+    axios.post.mockRejectedValueOnce({
+      response: { status: 504, data: { status: 'error', error: 'command timed out' } },
+    })
+    const wrapper = mountSettings()
+
+    await wrapper.get('#command-argument').setValue('slow account refresh')
+    await wrapper.get('[data-testid="command-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="command-feedback"]').text()).toBe('command timed out')
+    expect(wrapper.get('[data-testid="command-submit"]').attributes('disabled')).toBeUndefined()
   })
 })


### PR DESCRIPTION
### Motivation

- Add a first-class command execution flow to the Settings view so admins can run constrained backend commands from the UI with proper validation and user feedback. 
- Provide deterministic unit tests that cover success, validation-failure, and timeout/error behaviors for the new command surface. 

### Description

- Implemented command execution state and behavior in `frontend/src/views/Settings.vue` by adding `commandLoading`, `commandFeedback`, `commandOutput`, a `commandCanSubmit` computed guard, and an `executeCommand` method that posts `{ preset, task }` to `/api/codex/exec`. 
- Added form controls and feedback UI: a submit `BaseButton`, disabled/enter handling for the `BaseInput`, inline success/error messages, and output rendering, and imported `BaseButton`. 
- Expanded `frontend/src/views/__tests__/Settings.spec.js` to mount the view, mock `axios` for success, validation error, and timeout/error responses, and assert disabled-state, payload shape, loading/duplicate-submit protection, and feedback rendering. 
- Documented the interaction contract in `frontend/docs/THEMING_GUIDE.md` under “Settings command interaction”. 

### Testing

- Ran the focused unit suite `vitest --run src/views/__tests__/Settings.spec.js` and all 6 new tests passed. 
- Built the frontend with `npm run build` which completed successfully. 
- Ran lint/format checks for the changed files and pre-commit hooks (`.venv/bin/pre-commit run --all-files`) and they passed while the repo retains unrelated existing lint warnings elsewhere. 
- Ran broader validation (`npm test -- --run` and `pytest -q`) which surfaced unrelated existing failures in other frontend and backend suites; these failures pre-existed and are outside the scope of the Settings change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c6dc7a17c8329a8797ca32756b6ca)