### PR TITLE
Add Safe-to-Spend service, API route, and dashboard widget

### DIFF
--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -2,8 +2,6 @@
 
 from datetime import datetime
 
-from flask import Blueprint, jsonify, request
-
 from app.config import logger
 from app.services import account_groups as account_group_service
 from app.services.account_snapshot import (
@@ -11,7 +9,12 @@ from app.services.account_snapshot import (
     update_snapshot_selection,
 )
 from app.services.dashboard_activity_status import generate_activity_status
-from app.services.safe_to_spend import DEFAULT_BUFFER_CENTS, SafeToSpendInputs, build_safe_to_spend_payload
+from app.services.safe_to_spend import (
+    DEFAULT_BUFFER_CENTS,
+    SafeToSpendInputs,
+    build_safe_to_spend_payload,
+)
+from flask import Blueprint, jsonify, request
 
 dashboard = Blueprint("dashboard", __name__)
 

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -11,6 +11,7 @@ from app.services.account_snapshot import (
     update_snapshot_selection,
 )
 from app.services.dashboard_activity_status import generate_activity_status
+from app.services.safe_to_spend import DEFAULT_BUFFER_CENTS, SafeToSpendInputs, build_safe_to_spend_payload
 
 dashboard = Blueprint("dashboard", __name__)
 
@@ -22,6 +23,35 @@ def _parse_iso_date_arg(name: str) -> datetime | None:
     if not raw:
         return None
     return datetime.strptime(raw, "%Y-%m-%d")
+
+
+@dashboard.route("/safe-to-spend", methods=["GET"])
+def get_safe_to_spend():
+    """Return today's spend guardrail and next-version horizon variants."""
+
+    try:
+        as_of = _parse_iso_date_arg("as_of")
+    except ValueError:
+        return jsonify({"status": "error", "message": "as_of must use YYYY-MM-DD"}), 400
+
+    raw_buffer = request.args.get("buffer_cents")
+    try:
+        buffer_cents = int(raw_buffer) if raw_buffer is not None else DEFAULT_BUFFER_CENTS
+    except ValueError:
+        return jsonify({"status": "error", "message": "buffer_cents must be an integer"}), 400
+
+    inputs = SafeToSpendInputs(
+        user_id=request.args.get("user_id"),
+        mode=request.args.get("mode") or "today",
+        as_of=as_of,
+        buffer_cents=buffer_cents,
+    )
+    try:
+        data = build_safe_to_spend_payload(inputs)
+        return jsonify({"status": "success", "data": data}), 200
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to build safe-to-spend payload: %s", exc, exc_info=True)
+        return jsonify({"status": "error", "message": str(exc)}), 500
 
 
 @dashboard.route("/account_snapshot", methods=["GET"])

--- a/backend/app/services/safe_to_spend.py
+++ b/backend/app/services/safe_to_spend.py
@@ -6,11 +6,10 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 
-from sqlalchemy import func, or_
-
 from app.extensions import db
 from app.models import Account, PlannedBill, PlanningScenario, Transaction
 from app.utils.finance_utils import normalize_account_balance
+from sqlalchemy import func, or_
 
 TWOPLACES = Decimal("0.01")
 DEFAULT_BUFFER_CENTS = 25_000

--- a/backend/app/services/safe_to_spend.py
+++ b/backend/app/services/safe_to_spend.py
@@ -1,0 +1,277 @@
+"""Safe-to-spend dashboard decisioning helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import func, or_
+
+from app.extensions import db
+from app.models import Account, PlannedBill, PlanningScenario, Transaction
+from app.utils.finance_utils import normalize_account_balance
+
+TWOPLACES = Decimal("0.01")
+DEFAULT_BUFFER_CENTS = 25_000
+DEFAULT_MODE = "today"
+MODE_WINDOWS = {
+    "today": 0,
+    "week": 6,
+    "until_payday": 14,
+}
+CASH_ACCOUNT_TOKENS = {
+    "cash",
+    "checking",
+    "savings",
+    "depository",
+    "prepaid",
+    "money market",
+    "money_market",
+}
+INCOME_CATEGORY_TOKENS = {"income", "payroll", "paycheck", "wages", "salary"}
+
+
+@dataclass(frozen=True)
+class SafeToSpendInputs:
+    """Normalized request inputs for safe-to-spend calculations."""
+
+    user_id: str | None = None
+    mode: str = DEFAULT_MODE
+    as_of: date | None = None
+    buffer_cents: int = DEFAULT_BUFFER_CENTS
+
+
+def _to_cents(value: Decimal | float | int | None) -> int:
+    """Convert a decimal dollar amount into integer cents."""
+
+    amount = Decimal(str(value or 0)).quantize(TWOPLACES, rounding=ROUND_HALF_UP)
+    return int((amount * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _normalize_mode(mode: str | None) -> str:
+    """Return a supported decision horizon, defaulting to today's view."""
+
+    normalized = (mode or DEFAULT_MODE).strip().lower()
+    return normalized if normalized in MODE_WINDOWS else DEFAULT_MODE
+
+
+def _coerce_date(value: date | datetime | str | None) -> date:
+    """Return ``value`` as a date, accepting ISO strings for route inputs."""
+
+    if value is None:
+        return date.today()
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+
+def _is_cash_account(account: Account) -> bool:
+    """Return True when an account should count toward daily spendable cash."""
+
+    if account.is_investment:
+        return False
+    fields = {str(account.type or "").lower(), str(account.subtype or "").lower(), str(account.name or "").lower()}
+    return any(token in field for field in fields for token in CASH_ACCOUNT_TOKENS)
+
+
+def _visible_accounts(user_id: str | None = None) -> list[Account]:
+    """Load visible accounts, optionally scoped by user."""
+
+    query = Account.query.filter(or_(Account.is_hidden.is_(False), Account.is_hidden.is_(None)))
+    if user_id:
+        query = query.filter(Account.user_id == user_id)
+    return query.all()
+
+
+def _cash_account_payload(accounts: list[Account]) -> tuple[int, list[dict]]:
+    """Build spendable-cash cents and source account metadata."""
+
+    total_cents = 0
+    payload = []
+    for account in accounts:
+        if not _is_cash_account(account):
+            continue
+        normalized = normalize_account_balance(account.balance, account.type, account_id=account.account_id)
+        balance_cents = max(_to_cents(normalized), 0)
+        total_cents += balance_cents
+        payload.append(
+            {
+                "account_id": account.account_id,
+                "name": account.display_name,
+                "type": account.type,
+                "subtype": account.subtype,
+                "balance_cents": balance_cents,
+            }
+        )
+    return total_cents, payload
+
+
+def _spent_between(start: date, end: date, user_id: str | None = None) -> int:
+    """Return posted non-internal outflows between inclusive date boundaries."""
+
+    start_dt = datetime.combine(start, datetime.min.time())
+    end_dt = datetime.combine(end, datetime.max.time())
+    query = (
+        db.session.query(func.coalesce(func.sum(func.abs(Transaction.amount)), 0))
+        .join(Account, Account.account_id == Transaction.account_id)
+        .filter(or_(Account.is_hidden.is_(False), Account.is_hidden.is_(None)))
+        .filter(Transaction.date >= start_dt, Transaction.date <= end_dt)
+        .filter(Transaction.amount < 0)
+        .filter(or_(Transaction.is_internal.is_(False), Transaction.is_internal.is_(None)))
+    )
+    if user_id:
+        query = query.filter(Transaction.user_id == user_id)
+    return _to_cents(query.scalar())
+
+
+def _looks_like_income(transaction: Transaction) -> bool:
+    """Return True when recent transaction metadata suggests wage income."""
+
+    fields = [transaction.category, transaction.category_slug, transaction.category_display, transaction.description]
+    pfc = transaction.personal_finance_category if isinstance(transaction.personal_finance_category, dict) else {}
+    fields.extend([pfc.get("primary"), pfc.get("detailed")])
+    haystack = " ".join(str(field or "").lower() for field in fields)
+    return any(token in haystack for token in INCOME_CATEGORY_TOKENS)
+
+
+def _next_income_date(as_of: date, user_id: str | None = None) -> date | None:
+    """Infer the next payday from recent income cadence when possible."""
+
+    lookback = datetime.combine(as_of - timedelta(days=90), datetime.min.time())
+    end = datetime.combine(as_of, datetime.max.time())
+    query = (
+        Transaction.query.join(Account, Account.account_id == Transaction.account_id)
+        .filter(or_(Account.is_hidden.is_(False), Account.is_hidden.is_(None)))
+        .filter(Transaction.date >= lookback, Transaction.date <= end)
+        .filter(Transaction.amount > 0)
+        .order_by(Transaction.date.asc())
+    )
+    if user_id:
+        query = query.filter(Transaction.user_id == user_id)
+
+    income_dates = []
+    for transaction in query.all():
+        if _looks_like_income(transaction):
+            raw_date = transaction.date.date() if isinstance(transaction.date, datetime) else transaction.date
+            income_dates.append(raw_date)
+
+    if len(income_dates) < 2:
+        return None
+
+    intervals = [
+        (right - left).days for left, right in zip(income_dates, income_dates[1:]) if 1 <= (right - left).days <= 45
+    ]
+    if not intervals:
+        return None
+    cadence = round(sum(intervals) / len(intervals))
+    next_date = income_dates[-1]
+    while next_date <= as_of:
+        next_date += timedelta(days=cadence)
+    return next_date
+
+
+def _horizon_end(mode: str, as_of: date, next_income_date: date | None) -> date:
+    """Resolve the inclusive planning horizon for the selected mode."""
+
+    if mode == "until_payday" and next_income_date:
+        return next_income_date
+    return as_of + timedelta(days=MODE_WINDOWS[mode])
+
+
+def _upcoming_bill_payload(as_of: date, horizon_end: date, user_id: str | None = None) -> tuple[int, list[dict]]:
+    """Return planned bills due within the decision horizon."""
+
+    query = PlannedBill.query.join(PlanningScenario).filter(
+        PlannedBill.due_date >= as_of, PlannedBill.due_date <= horizon_end
+    )
+    if user_id:
+        query = query.filter(
+            PlanningScenario.account_id.in_([account.account_id for account in _visible_accounts(user_id)])
+        )
+
+    total = 0
+    bills = []
+    for bill in query.order_by(PlannedBill.due_date.asc(), PlannedBill.name.asc()).all():
+        amount = int(bill.amount_cents or 0)
+        total += amount
+        bills.append(
+            {
+                "id": str(bill.id),
+                "name": bill.name,
+                "amount_cents": amount,
+                "due_date": bill.due_date.isoformat() if bill.due_date else None,
+                "frequency": bill.frequency,
+                "origin": bill.origin,
+            }
+        )
+    return total, bills
+
+
+def build_safe_to_spend_payload(inputs: SafeToSpendInputs | None = None) -> dict:
+    """Build the dashboard safe-to-spend decision payload.
+
+    Args:
+        inputs: Optional normalized request inputs controlling user scope,
+            horizon mode, effective date, and protected buffer.
+
+    Returns:
+        dict: API-serializable decision payload with component math and rationale.
+    """
+
+    inputs = inputs or SafeToSpendInputs()
+    mode = _normalize_mode(inputs.mode)
+    as_of = _coerce_date(inputs.as_of)
+    buffer_cents = max(int(inputs.buffer_cents or 0), 0)
+    accounts = _visible_accounts(inputs.user_id)
+    spendable_cash_cents, account_payload = _cash_account_payload(accounts)
+    next_income = _next_income_date(as_of, inputs.user_id)
+    horizon_end = _horizon_end(mode, as_of, next_income)
+    upcoming_outflows_cents, bills = _upcoming_bill_payload(as_of, horizon_end, inputs.user_id)
+    spent_today_cents = _spent_between(as_of, as_of, inputs.user_id)
+
+    raw_amount = spendable_cash_cents - upcoming_outflows_cents - buffer_cents - spent_today_cents
+    amount_cents = max(raw_amount, 0)
+    days = max((horizon_end - as_of).days + 1, 1)
+    per_day_cents = amount_cents // days
+
+    if raw_amount <= 0:
+        status = "do_not_spend"
+        message = "Hold discretionary spending until cash, bills, or buffer assumptions improve."
+    elif per_day_cents < 2_500:
+        status = "tight"
+        message = f"Keep discretionary spending under ${per_day_cents / 100:,.0f} per day for this horizon."
+    elif per_day_cents < 7_500:
+        status = "caution"
+        message = f"You have about ${per_day_cents / 100:,.0f} per day after known bills and buffer."
+    else:
+        status = "comfortable"
+        message = f"You have about ${per_day_cents / 100:,.0f} per day after known bills and buffer."
+
+    confidence = "ready" if account_payload else "limited"
+    if not bills:
+        confidence = "estimated"
+
+    return {
+        "amount_cents": amount_cents if mode == "today" else per_day_cents,
+        "total_horizon_cents": amount_cents,
+        "per_day_cents": per_day_cents,
+        "status": status,
+        "currency": "USD",
+        "mode": mode,
+        "as_of": as_of.isoformat(),
+        "horizon_end": horizon_end.isoformat(),
+        "next_income_date": next_income.isoformat() if next_income else None,
+        "confidence": confidence,
+        "components": {
+            "spendable_cash_cents": spendable_cash_cents,
+            "upcoming_outflows_cents": upcoming_outflows_cents,
+            "required_buffer_cents": buffer_cents,
+            "spent_today_cents": spent_today_cents,
+        },
+        "accounts": account_payload,
+        "upcoming_bills": bills,
+        "message": message,
+    }

--- a/docs/backend/app/routes/dashboard.md
+++ b/docs/backend/app/routes/dashboard.md
@@ -1,6 +1,6 @@
 ---
 Owner: Backend Team
-Last Updated: 2026-04-08
+Last Updated: 2026-07-12
 Status: Active
 ---
 
@@ -24,6 +24,7 @@ Serve dashboard configuration data including account snapshot selections and cus
 - `DELETE /api/dashboard/account-groups/<group_id>/accounts/<account_id>` – Detach an account from a group.
 - `POST /api/dashboard/account-groups/<group_id>/accounts/reorder` – Save the ordering of accounts within a group.
 - `GET /api/dashboard/activity-status` – Generate a parseable greeting status message from account balances and recent transactions.
+- `GET /api/dashboard/safe-to-spend` – Return immediate spend guidance for today, until payday, or the current week.
 
 ## Inputs/Outputs
 
@@ -36,6 +37,9 @@ Serve dashboard configuration data including account snapshot selections and cus
 - **Activity status endpoint**
   - **Inputs:** Optional `start_date`, `end_date` (YYYY-MM-DD), and `user_id` query params.
   - **Outputs:** `{ "status": "success", "data": { "status_key": str, "message": str, "source": "llm"|"fallback" } }`.
+- **Safe-to-spend endpoint**
+  - **Inputs:** Optional `mode`, `as_of` (YYYY-MM-DD), `buffer_cents`, and `user_id` query params.
+  - **Outputs:** `{ "status": "success", "data": { "amount_cents": int, "components": object, "message": str } }`.
 
 ## Auth
 
@@ -46,6 +50,7 @@ Serve dashboard configuration data including account snapshot selections and cus
 - `app.services.account_snapshot` helpers (`build_snapshot_payload`, `update_snapshot_selection`).
 - `app.services.account_groups` CRUD helpers for group and membership management.
 - `app.services.dashboard_activity_status` for LLM/fallback greeting generation.
+- `app.services.safe_to_spend` for cash, bill, buffer, and same-day spending guardrails.
 - Application logger for defensive error logging.
 
 ## Behaviors/Edge Cases

--- a/docs/backend/app/services/safe_to_spend.md
+++ b/docs/backend/app/services/safe_to_spend.md
@@ -1,0 +1,38 @@
+---
+Owner: Backend Team
+Last Updated: 2026-07-12
+Status: Active
+---
+
+# Safe-to-Spend Service (`safe_to_spend.py`)
+
+## Purpose
+
+Build the dashboard's immediate spending guardrail from visible cash accounts, planned bills, a protected buffer, and today's posted outflows.
+
+## Public API
+
+- `SafeToSpendInputs`: normalized service input dataclass for user scope, mode, as-of date, and buffer.
+- `build_safe_to_spend_payload(inputs)`: returns an API-serializable decision payload.
+
+## Calculation
+
+```text
+raw spend room = spendable cash - upcoming bills - protected buffer - spent today
+spend room = max(raw spend room, 0)
+```
+
+For `until_payday` and `week`, the service also divides the horizon amount into `per_day_cents`.
+
+## Data sources
+
+- Visible cash-like `Account` records for spendable cash.
+- `PlannedBill` records in the selected horizon.
+- Non-internal negative `Transaction` records on the as-of date for today's spending.
+- Recent income-like transactions to infer a likely next payday.
+
+## Edge cases
+
+- Unknown modes fall back to `today`.
+- Missing account data yields `confidence: limited` or `estimated` rather than failing the dashboard.
+- Negative spend room is clamped to zero and reported as `do_not_spend`.

--- a/docs/frontend/safe-to-spend.md
+++ b/docs/frontend/safe-to-spend.md
@@ -1,0 +1,71 @@
+# Safe to Spend Dashboard Widget
+
+_Last updated: 2026-07-12_
+
+## Purpose
+
+The Safe to Spend widget gives the dashboard an immediate daily decision surface: how much can be spent now while preserving a protected cash buffer and known near-term obligations.
+
+## Dashboard placement
+
+The widget lives in `frontend/src/components/dashboard/SafeToSpendCard.vue` and is composed by `NetOverviewSection` beside the account snapshot and Daily Net chart. This keeps it in the dashboard's current-position area rather than the retrospective category breakdown or lower drill-down tables.
+
+## API contract
+
+`GET /api/dashboard/safe-to-spend`
+
+Query params:
+
+- `mode`: `today`, `until_payday`, or `week`; unknown values fall back to `today`.
+- `as_of`: optional `YYYY-MM-DD` date. Defaults to the backend's current date.
+- `buffer_cents`: optional protected buffer in integer cents. Defaults to `$250.00`.
+- `user_id`: optional account/transaction scope.
+
+Response shape:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "amount_cents": 4200,
+    "total_horizon_cents": 4200,
+    "per_day_cents": 4200,
+    "status": "caution",
+    "currency": "USD",
+    "mode": "today",
+    "as_of": "2026-07-12",
+    "horizon_end": "2026-07-12",
+    "next_income_date": null,
+    "confidence": "ready",
+    "components": {
+      "spendable_cash_cents": 124000,
+      "upcoming_outflows_cents": 86000,
+      "required_buffer_cents": 25000,
+      "spent_today_cents": 8800
+    },
+    "accounts": [],
+    "upcoming_bills": [],
+    "message": "You have about $42 today."
+  }
+}
+```
+
+## Decision math
+
+The backend computes a horizon-level spend amount as:
+
+```text
+spendable cash - upcoming planned bills - protected buffer - spent today
+```
+
+The result is clamped to zero. `today` displays the whole clamped amount. `until_payday` and `week` display a per-day amount while preserving `total_horizon_cents` for drill-down copy.
+
+## Feature-complete next version
+
+The first implementation already includes the horizon controls planned for the next version:
+
+- Today
+- Until Payday
+- This Week
+
+Follow-up work should add user-editable buffer settings, richer bill-source attribution, and a drill-down detail drawer for included accounts, upcoming bills, today's transactions, and payday inference.

--- a/docs/index/INDEX.md
+++ b/docs/index/INDEX.md
@@ -26,6 +26,7 @@ All documentation lives in Markdown under `docs/` and mirrors the backend struct
 - [Codex](../codex/) – exploratory reports
 - [Latest](../latest/) – recent drafts and experiments
 - [Financial Summary Detailed](../frontend/FINANCIAL_SUMMARY_DETAILED.md) – DailyNetChart + FinancialSummary wiring details
+- [Safe to Spend Dashboard Widget](../frontend/safe-to-spend.md) – daily spend guardrail API, placement, and next-version horizons.
 - [Component Migration Guide](../frontend/component-migration.md) – frontend component organization strategy
 - [Tailwind + Vite Style Reference](../frontend/tailwind-vite-style-reference.md) – CSS utilities and build notes
 - [Corner Radius Migration Guide](../frontend/corner-radius-migration-guide.md) – token scale and allowed corner usage by component type.

--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -84,6 +84,7 @@ declare module 'vue' {
     RetryError: typeof import('./components/errors/RetryError.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    SafeToSpendCard: typeof import('./components/dashboard/SafeToSpendCard.vue')['default']
     Settings: typeof import('./components/unused/Settings.vue')['default']
     SkeletonCard: typeof import('./components/ui/SkeletonCard.vue')['default']
     SpendingInsights: typeof import('./components/SpendingInsights.vue')['default']

--- a/frontend/src/components/dashboard/NetOverviewSection.vue
+++ b/frontend/src/components/dashboard/NetOverviewSection.vue
@@ -35,10 +35,23 @@
       />
     </div>
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
-      <div
-        class="net-overview-panel net-overview-panel--accent-green col-span-1 bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col"
-      >
-        <TopAccountSnapshot />
+      <div class="col-span-1 flex flex-col gap-6">
+        <div
+          class="net-overview-panel net-overview-panel--accent-green bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col"
+        >
+          <TopAccountSnapshot />
+        </div>
+        <div
+          class="net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col"
+        >
+          <SafeToSpendCard
+            :payload="safeToSpend"
+            :loading="safeToSpendLoading"
+            :error="safeToSpendError"
+            :selected-mode="safeToSpendMode"
+            @update:mode="emit('update:safe-to-spend-mode', $event)"
+          />
+        </div>
       </div>
       <div
         class="daily-net-chart-panel net-overview-panel net-overview-panel--accent-cyan md:col-span-2 bg-[var(--color-bg-sec)] ui-radius-2 p-5 md:p-6 flex flex-col gap-3 relative"
@@ -140,6 +153,7 @@ import DailyNetChart from '@/components/charts/DailyNetChart.vue'
 import ChartDetailsSidebar from '@/components/charts/ChartDetailsSidebar.vue'
 import DateRangeSelector from '@/components/DateRangeSelector.vue'
 import TopAccountSnapshot from '@/components/widgets/TopAccountSnapshot.vue'
+import SafeToSpendCard from '@/components/dashboard/SafeToSpendCard.vue'
 import FinancialSummary from '@/components/statistics/FinancialSummary.vue'
 import { formatAmount } from '@/utils/format'
 
@@ -173,6 +187,10 @@ const props = defineProps({
   showAvgExpenses: { type: Boolean, default: false },
   showComparisonOverlay: { type: Boolean, default: false },
   comparisonMode: { type: String, default: 'prior_month_to_date' },
+  safeToSpend: { type: Object, default: null },
+  safeToSpendLoading: { type: Boolean, default: false },
+  safeToSpendError: { type: String, default: '' },
+  safeToSpendMode: { type: String, default: 'today' },
 })
 
 const emit = defineEmits([
@@ -186,6 +204,7 @@ const emit = defineEmits([
   'update:show-comparison-overlay',
   'update:comparison-mode',
   'update:net-timeframe',
+  'update:safe-to-spend-mode',
   'net-summary-change',
   'net-data-change',
   'net-bar-click',

--- a/frontend/src/components/dashboard/SafeToSpendCard.vue
+++ b/frontend/src/components/dashboard/SafeToSpendCard.vue
@@ -1,0 +1,254 @@
+<!--
+  SafeToSpendCard.vue
+  Shows a glanceable daily spend guardrail with horizon controls and rationale.
+-->
+<template>
+  <section class="safe-spend-card" aria-labelledby="safe-spend-title">
+    <div class="safe-spend-card__header">
+      <div>
+        <p class="safe-spend-card__kicker">Daily Decision</p>
+        <h2 id="safe-spend-title" class="safe-spend-card__title">Safe to Spend</h2>
+      </div>
+      <span class="safe-spend-card__status" :class="`safe-spend-card__status--${statusClass}`">
+        {{ statusLabel }}
+      </span>
+    </div>
+
+    <div class="safe-spend-card__modes" aria-label="Safe to spend horizon">
+      <button
+        v-for="option in modeOptions"
+        :key="option.value"
+        class="accent-toggle-btn angular-chart-chip safe-spend-card__mode"
+        :class="{
+          'accent-toggle-btn--active angular-chart-chip--active': selectedMode === option.value,
+        }"
+        type="button"
+        :aria-pressed="selectedMode === option.value"
+        @click="emit('update:mode', option.value)"
+      >
+        {{ option.label }}
+      </button>
+    </div>
+
+    <div v-if="loading" class="safe-spend-card__empty" role="status">Calculating spend room…</div>
+    <div v-else-if="error" class="safe-spend-card__empty safe-spend-card__empty--error">
+      {{ error }}
+    </div>
+    <template v-else-if="payload">
+      <div class="safe-spend-card__amount-row">
+        <span class="safe-spend-card__amount">{{ formatCents(primaryAmount) }}</span>
+        <span class="safe-spend-card__amount-copy">{{ amountCopy }}</span>
+      </div>
+      <p class="safe-spend-card__message">{{ payload.message }}</p>
+
+      <dl class="safe-spend-card__components">
+        <div>
+          <dt>Spendable cash</dt>
+          <dd>{{ formatCents(payload.components?.spendable_cash_cents) }}</dd>
+        </div>
+        <div>
+          <dt>Upcoming bills</dt>
+          <dd>-{{ formatCents(payload.components?.upcoming_outflows_cents) }}</dd>
+        </div>
+        <div>
+          <dt>Protected buffer</dt>
+          <dd>-{{ formatCents(payload.components?.required_buffer_cents) }}</dd>
+        </div>
+        <div>
+          <dt>Spent today</dt>
+          <dd>-{{ formatCents(payload.components?.spent_today_cents) }}</dd>
+        </div>
+      </dl>
+
+      <div class="safe-spend-card__footer">
+        <span>{{ horizonLabel }}</span>
+        <span class="safe-spend-card__confidence">{{ confidenceLabel }}</span>
+      </div>
+    </template>
+    <div v-else class="safe-spend-card__empty">No spend guidance is available yet.</div>
+  </section>
+</template>
+
+<script setup>
+/**
+ * Glanceable dashboard widget for day-of spending decisions.
+ */
+import { computed } from 'vue'
+
+const modeOptions = [
+  { value: 'today', label: 'Today' },
+  { value: 'until_payday', label: 'Until Payday' },
+  { value: 'week', label: 'This Week' },
+]
+
+const props = defineProps({
+  payload: { type: Object, default: null },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+  selectedMode: { type: String, default: 'today' },
+})
+
+const emit = defineEmits(['update:mode'])
+
+const primaryAmount = computed(() => props.payload?.amount_cents ?? 0)
+const statusClass = computed(() => props.payload?.status || 'unknown')
+const statusLabel = computed(() => String(props.payload?.status || 'unknown').replace(/_/g, ' '))
+const amountCopy = computed(() => (props.selectedMode === 'today' ? 'available today' : 'per day'))
+const horizonLabel = computed(() => {
+  if (!props.payload?.horizon_end) return 'Horizon unavailable'
+  if (props.selectedMode === 'today') return `As of ${props.payload.as_of}`
+  return `Through ${props.payload.horizon_end}`
+})
+const confidenceLabel = computed(() => `Confidence: ${props.payload?.confidence || 'unknown'}`)
+
+/**
+ * Format integer cents as a compact USD amount.
+ *
+ * @param {number | null | undefined} cents Amount in cents.
+ * @returns {string} Localized USD currency string.
+ */
+function formatCents(cents) {
+  const dollars = Number(cents || 0) / 100
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: dollars % 1 === 0 ? 0 : 2,
+  }).format(dollars)
+}
+</script>
+
+<style scoped>
+.safe-spend-card {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.safe-spend-card__header,
+.safe-spend-card__amount-row,
+.safe-spend-card__footer,
+.safe-spend-card__components div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.safe-spend-card__kicker {
+  margin: 0 0 0.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.safe-spend-card__title {
+  margin: 0;
+  color: var(--color-text-light);
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.safe-spend-card__status {
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.55rem;
+  text-transform: uppercase;
+}
+
+.safe-spend-card__status--comfortable {
+  border-color: var(--color-accent-green);
+  color: var(--color-accent-green);
+}
+
+.safe-spend-card__status--caution,
+.safe-spend-card__status--tight {
+  border-color: var(--color-accent-yellow);
+  color: var(--color-accent-yellow);
+}
+
+.safe-spend-card__status--do_not_spend {
+  border-color: var(--color-accent-red);
+  color: var(--color-accent-red);
+}
+
+.safe-spend-card__modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.safe-spend-card__mode {
+  font-size: 0.72rem;
+  padding: 0.35rem 0.55rem;
+}
+
+.safe-spend-card__amount {
+  color: var(--color-accent-cyan);
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.safe-spend-card__amount-copy,
+.safe-spend-card__footer,
+.safe-spend-card__message,
+.safe-spend-card__empty {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.safe-spend-card__message {
+  line-height: 1.45;
+  margin: 0;
+}
+
+.safe-spend-card__components {
+  border-top: 1px solid var(--divider);
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding-top: 0.85rem;
+}
+
+.safe-spend-card__components dt,
+.safe-spend-card__components dd {
+  margin: 0;
+}
+
+.safe-spend-card__components dt {
+  color: var(--color-text-muted);
+}
+
+.safe-spend-card__components dd {
+  color: var(--color-text-light);
+  font-weight: 800;
+}
+
+.safe-spend-card__confidence {
+  text-transform: capitalize;
+}
+
+.safe-spend-card__empty {
+  align-items: center;
+  border: 1px dashed var(--divider);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  min-height: 9rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.safe-spend-card__empty--error {
+  border-color: var(--color-accent-red);
+  color: var(--color-accent-red);
+}
+</style>

--- a/frontend/src/components/dashboard/__tests__/DashboardSections.spec.ts
+++ b/frontend/src/components/dashboard/__tests__/DashboardSections.spec.ts
@@ -31,6 +31,14 @@ const DailyNetChartStub = {
     '<div class="daily-net-chart" @click="$emit(\'bar-click\', startDate)"><div class="daily-net-chart__title-shell"><slot name="title" /></div><div class="daily-net-chart__controls-shell"><slot name="controls" /></div></div>',
 }
 
+const SafeToSpendCardStub = {
+  name: 'SafeToSpendCard',
+  props: ['payload', 'loading', 'error', 'selectedMode'],
+  emits: ['update:mode'],
+  template:
+    '<button class="safe-spend-stub" @click="$emit(\'update:mode\', \'week\')">Safe Spend</button>',
+}
+
 const FinancialSummaryStub = {
   name: 'FinancialSummary',
   template: '<div class="financial-summary-stub" />',
@@ -88,6 +96,8 @@ describe('Dashboard section components', () => {
         zoomedOut: false,
         netSummary: { totalIncome: 10, totalExpenses: 1, totalNet: 9 },
         chartData: [],
+        safeToSpend: { amount_cents: 4200, status: 'caution' },
+        safeToSpendMode: 'today',
       },
       global: {
         stubs: {
@@ -95,6 +105,7 @@ describe('Dashboard section components', () => {
           ChartDetailsSidebar: ChartDetailsSidebarStub,
           TopAccountSnapshot: true,
           DailyNetChart: DailyNetChartStub,
+          SafeToSpendCard: SafeToSpendCardStub,
           FinancialSummary: FinancialSummaryStub,
         },
       },
@@ -114,6 +125,10 @@ describe('Dashboard section components', () => {
     expect(wrapper.findComponent(DailyNetChartStub).props()).toMatchObject({
       startDate: '2025-01-01',
       endDate: '2025-01-31',
+    })
+    expect(wrapper.findComponent(SafeToSpendCardStub).props()).toMatchObject({
+      payload: { amount_cents: 4200, status: 'caution' },
+      selectedMode: 'today',
     })
 
     const timeframeButtons = wrapper.findAll(
@@ -156,10 +171,10 @@ describe('Dashboard section components', () => {
       },
     })
 
-    const [categoryButton, merchantButton] = wrapper.findAll('button')
-    await categoryButton.trigger('click')
-    await merchantButton.trigger('click')
-    await wrapper.find('button.btn').trigger('click')
+    const buttons = wrapper.findAllComponents(BaseButtonStub)
+    await buttons[0].vm.$emit('click')
+    await buttons[1].vm.$emit('click')
+    await buttons[2].vm.$emit('click')
 
     expect(wrapper.find('.after-total').exists()).toBe(true)
     expect(wrapper.emitted('change-breakdown')?.[0]).toEqual(['category'])

--- a/frontend/src/components/dashboard/__tests__/SafeToSpendCard.spec.ts
+++ b/frontend/src/components/dashboard/__tests__/SafeToSpendCard.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SafeToSpendCard from '../SafeToSpendCard.vue'
+
+const payload = {
+  amount_cents: 4200,
+  total_horizon_cents: 4200,
+  per_day_cents: 4200,
+  status: 'caution',
+  mode: 'today',
+  as_of: '2026-07-12',
+  horizon_end: '2026-07-12',
+  confidence: 'ready',
+  message: 'You have about $42 today.',
+  components: {
+    spendable_cash_cents: 124000,
+    upcoming_outflows_cents: 86000,
+    required_buffer_cents: 25000,
+    spent_today_cents: 8800,
+  },
+}
+
+describe('SafeToSpendCard', () => {
+  it('renders spend guidance and component math', () => {
+    const wrapper = mount(SafeToSpendCard, {
+      props: { payload, selectedMode: 'today' },
+    })
+
+    expect(wrapper.text()).toContain('Safe to Spend')
+    expect(wrapper.text()).toContain('$42')
+    expect(wrapper.text()).toContain('Spendable cash')
+    expect(wrapper.text()).toContain('$1,240')
+    expect(wrapper.text()).toContain('Confidence: ready')
+  })
+
+  it('emits mode changes for next-version horizons', async () => {
+    const wrapper = mount(SafeToSpendCard, {
+      props: { payload, selectedMode: 'today' },
+    })
+
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(wrapper.emitted('update:mode')?.[0]).toEqual(['until_payday'])
+  })
+
+  it('shows loading and error states', () => {
+    const loading = mount(SafeToSpendCard, { props: { loading: true } })
+    expect(loading.text()).toContain('Calculating spend room')
+
+    const error = mount(SafeToSpendCard, { props: { error: 'Unavailable' } })
+    expect(error.text()).toContain('Unavailable')
+  })
+})

--- a/frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap
+++ b/frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Dashboard section components > renders net overview content and forwards slot content 1`] = `
 "<section data-v-26cbed55="" class="flex flex-col gap-6">
   <div data-v-26cbed55="" class="angular-divider mb-2" aria-hidden="true"><span data-v-26cbed55="" class="angular-divider__rule"></span><span data-v-26cbed55="" class="angular-divider__step"></span></div>
-  <div data-v-26cbed55="" class="net-overview-hero w-full mb-8 bg-[var(--color-bg-sec)] rounded-lg p-6 md:p-7 flex flex-col items-center gap-2">
+  <div data-v-26cbed55="" class="net-overview-hero w-full mb-8 bg-[var(--color-bg-sec)] ui-radius-2 p-6 md:p-7 flex flex-col items-center gap-2">
     <h1 data-v-26cbed55="" class="text-4xl md:text-5xl font-extrabold tracking-wide text-[var(--color-accent-cyan)] mb-2 drop-shadow"> Welcome, <span data-v-26cbed55="" class="username">Casey</span>! </h1>
     <p data-v-26cbed55="" class="text-lg text-muted">Today is January 1, 2025</p>
     <p data-v-26cbed55="" class="italic text-muted">In the black</p>
@@ -13,14 +13,18 @@ exports[`Dashboard section components > renders net overview content and forward
     <div data-v-26cbed55="" class="date-range-stub"></div>
   </div>
   <div data-v-26cbed55="" class="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
-    <div data-v-26cbed55="" class="net-overview-panel net-overview-panel--accent-green col-span-1 bg-[var(--color-bg-sec)] rounded-lg p-4 flex flex-col">
-      <top-account-snapshot-stub data-v-26cbed55="" accountsubtype="" usespectrum="false" iseditinggroups="false"></top-account-snapshot-stub>
+    <div data-v-26cbed55="" class="col-span-1 flex flex-col gap-6">
+      <div data-v-26cbed55="" class="net-overview-panel net-overview-panel--accent-green bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col">
+        <top-account-snapshot-stub data-v-26cbed55="" accountsubtype="" usespectrum="false" iseditinggroups="false"></top-account-snapshot-stub>
+      </div>
+      <div data-v-26cbed55="" class="net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] ui-radius-2 p-4 flex flex-col"><button data-v-26cbed55="" class="safe-spend-stub">Safe Spend</button></div>
     </div>
-    <div data-v-26cbed55="" class="daily-net-chart-panel net-overview-panel net-overview-panel--accent-cyan md:col-span-2 bg-[var(--color-bg-sec)] rounded-lg p-5 md:p-6 flex flex-col gap-3 relative">
+    <div data-v-26cbed55="" class="daily-net-chart-panel net-overview-panel net-overview-panel--accent-cyan md:col-span-2 bg-[var(--color-bg-sec)] ui-radius-2 p-5 md:p-6 flex flex-col gap-3 relative">
       <div data-v-26cbed55="" class="daily-net-chart" show7-day="false" show30-day="false" show-avg-income="false" show-avg-expenses="false" show-comparison-overlay="false" comparison-mode="prior_month_to_date" timeframe="mtd">
         <div class="daily-net-chart__title-shell">
           <div data-v-26cbed55="" class="daily-net-chart-title-block">
             <h2 data-v-26cbed55="" class="daily-net-chart-title"><span data-v-26cbed55="" class="title-text">Net Income</span><span data-v-26cbed55="" class="title-subtitle">(Daily)</span></h2>
+            <p data-v-26cbed55="" class="daily-net-chart-totals"> Income $10.00 · Expenses $1.00</p>
           </div>
         </div>
         <div class="daily-net-chart__controls-shell">
@@ -33,7 +37,7 @@ exports[`Dashboard section components > renders net overview content and forward
       </div>
     </div>
   </div>
-  <div data-v-26cbed55="" class="net-overview-summary-panel net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] rounded-lg p-5 md:p-6">
+  <div data-v-26cbed55="" class="net-overview-summary-panel net-overview-panel net-overview-panel--accent-cyan bg-[var(--color-bg-sec)] ui-radius-2 p-5 md:p-6">
     <div class="summary-slot">Custom Summary</div>
   </div>
 </section>"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -80,6 +80,11 @@ export default {
     return response.data
   },
 
+  async fetchSafeToSpend(params = {}) {
+    const response = await apiClient.get('/dashboard/safe-to-spend', { params })
+    return response.data
+  },
+
   async fetchRsaMonitorStatus() {
     const response = await apiClient.get('/rsa-monitor/status')
     return response.data

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -26,6 +26,10 @@
           :show-avg-expenses="showAvgExpenses"
           :show-comparison-overlay="showComparisonOverlay"
           :comparison-mode="comparisonMode"
+          :safe-to-spend="safeToSpend"
+          :safe-to-spend-loading="safeToSpendLoading"
+          :safe-to-spend-error="safeToSpendError"
+          :safe-to-spend-mode="safeToSpendMode"
           @update:start-date="dateRange.start = $event"
           @update:end-date="dateRange.end = $event"
           @update:zoomed-out="zoomedOut = $event"
@@ -36,6 +40,7 @@
           @update:show-comparison-overlay="showComparisonOverlay = $event"
           @update:comparison-mode="comparisonMode = $event"
           @update:net-timeframe="netTimeframe = $event"
+          @update:safe-to-spend-mode="setSafeToSpendMode"
           @net-summary-change="netSummary = $event"
           @net-data-change="chartData = $event"
           @net-bar-click="onNetBarClick"
@@ -364,7 +369,12 @@ const showAvgExpenses = ref(false)
 const showComparisonOverlay = ref(false)
 const comparisonMode = ref('prior_month_to_date')
 const netTimeframe = ref('mtd')
+const safeToSpend = ref(null)
+const safeToSpendLoading = ref(false)
+const safeToSpendError = ref('')
+const safeToSpendMode = ref('today')
 let activeLoadToken = 0
+let safeToSpendToken = 0
 
 const netRange = computed(() => {
   const today = new Date()
@@ -469,11 +479,48 @@ async function loadReviewCount(filters = reviewFilters.value) {
 }
 
 /**
+ * Refresh the safe-to-spend decision card for the selected horizon.
+ *
+ * @returns {Promise<void>} Resolves when guidance is loaded or an inline error is set.
+ */
+async function loadSafeToSpend() {
+  const token = ++safeToSpendToken
+  safeToSpendLoading.value = true
+  safeToSpendError.value = ''
+
+  try {
+    const result = await api.fetchSafeToSpend({
+      mode: safeToSpendMode.value,
+      user_id: plaidUserId || undefined,
+    })
+    if (token !== safeToSpendToken) return
+    if (result?.status === 'success') {
+      safeToSpend.value = result.data
+    } else {
+      safeToSpendError.value = result?.message || 'Unable to calculate spend room.'
+    }
+  } catch (error) {
+    if (token !== safeToSpendToken) return
+    console.error('Failed to load safe-to-spend guidance:', error)
+    safeToSpendError.value = 'Unable to calculate spend room.'
+  } finally {
+    if (token === safeToSpendToken) {
+      safeToSpendLoading.value = false
+    }
+  }
+}
+
+function setSafeToSpendMode(mode) {
+  safeToSpendMode.value = mode
+  loadSafeToSpend()
+}
+
+/**
  * Perform the dashboard's initial data load in parallel so hero, breakdown,
- * and transaction widgets all start with fresh data. Applies a shared fallback
- * message when any fetch fails so the UI surfaces a consistent error tone. The
- * optional range argument enables debounced refreshes without overlapping the
- * results from earlier requests.
+ * transaction widgets, and decision guidance all start with fresh data. Applies
+ * a shared fallback message when any fetch fails so the UI surfaces a consistent
+ * error tone. The optional range argument enables debounced refreshes without
+ * overlapping the results from earlier requests.
  *
  * @param {{ start: string; end: string }} [range] - Date boundaries to apply to
  *   option and transaction requests.
@@ -500,6 +547,7 @@ async function loadDashboardData(range = debouncedRange.value) {
         refreshOptions(params).catch(recordFailure),
         loadTransactions(1, { force: true }).catch(recordFailure),
         api.fetchDashboardActivityStatus(params).catch(recordFailure),
+        loadSafeToSpend().catch(recordFailure),
       ])
     loadReviewCount(reviewFilters.value)
 

--- a/tests/test_dashboard_activity_status_route.py
+++ b/tests/test_dashboard_activity_status_route.py
@@ -44,6 +44,28 @@ activity_stub.generate_activity_status = lambda **_: {
 }
 sys.modules["app.services.dashboard_activity_status"] = activity_stub
 
+safe_to_spend_stub = types.ModuleType("app.services.safe_to_spend")
+safe_to_spend_stub.DEFAULT_BUFFER_CENTS = 25000
+
+
+class SafeToSpendInputs:
+    def __init__(self, user_id=None, mode="today", as_of=None, buffer_cents=25000):
+        self.user_id = user_id
+        self.mode = mode
+        self.as_of = as_of
+        self.buffer_cents = buffer_cents
+
+
+safe_to_spend_stub.SafeToSpendInputs = SafeToSpendInputs
+safe_to_spend_stub.build_safe_to_spend_payload = lambda inputs: {
+    "amount_cents": 4200,
+    "status": "caution",
+    "mode": inputs.mode,
+    "components": {"required_buffer_cents": inputs.buffer_cents},
+    "message": "You have about $42 today.",
+}
+sys.modules["app.services.safe_to_spend"] = safe_to_spend_stub
+
 ROUTE_PATH = os.path.join(BASE_BACKEND, "app", "routes", "dashboard.py")
 spec = importlib.util.spec_from_file_location("app.routes.dashboard", ROUTE_PATH)
 dashboard_module = importlib.util.module_from_spec(spec)
@@ -72,3 +94,25 @@ def test_activity_status_returns_parseable_payload():
     assert payload["status"] == "success"
     assert payload["data"]["status_key"] == "largest_expense"
     assert "message" in payload["data"]
+
+
+def test_safe_to_spend_validates_inputs():
+    client = _build_client()
+    response = client.get("/api/dashboard/safe-to-spend?as_of=07-12-2026")
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "as_of must use YYYY-MM-DD"
+
+    response = client.get("/api/dashboard/safe-to-spend?buffer_cents=twenty")
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "buffer_cents must be an integer"
+
+
+def test_safe_to_spend_returns_decision_payload():
+    client = _build_client()
+    response = client.get("/api/dashboard/safe-to-spend?mode=until_payday&buffer_cents=30000")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["data"]["amount_cents"] == 4200
+    assert payload["data"]["mode"] == "until_payday"
+    assert payload["data"]["components"]["required_buffer_cents"] == 30000

--- a/tests/test_safe_to_spend_service.py
+++ b/tests/test_safe_to_spend_service.py
@@ -1,0 +1,108 @@
+"""Tests for safe-to-spend service math and serialization."""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import date
+from decimal import Decimal
+
+BASE_BACKEND = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, BASE_BACKEND)
+sys.modules.pop("app", None)
+
+config_stub = types.ModuleType("app.config")
+config_stub.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
+sys.modules["app.config"] = config_stub
+
+extensions_stub = types.ModuleType("app.extensions")
+extensions_stub.db = types.SimpleNamespace(session=types.SimpleNamespace(query=lambda *a, **k: None))
+sys.modules["app.extensions"] = extensions_stub
+
+
+class Account:
+    def __init__(self, account_id="acct", balance=Decimal("0"), account_type="depository", subtype="checking"):
+        self.account_id = account_id
+        self.balance = balance
+        self.type = account_type
+        self.subtype = subtype
+        self.name = "Checking"
+        self.is_hidden = False
+        self.is_investment = False
+
+    @property
+    def display_name(self):
+        return self.name
+
+
+class Transaction:
+    pass
+
+
+class PlannedBill:
+    pass
+
+
+class PlanningScenario:
+    pass
+
+
+models_stub = types.ModuleType("app.models")
+models_stub.Account = Account
+models_stub.Transaction = Transaction
+models_stub.PlannedBill = PlannedBill
+models_stub.PlanningScenario = PlanningScenario
+sys.modules["app.models"] = models_stub
+
+utils_pkg = types.ModuleType("app.utils")
+sys.modules["app.utils"] = utils_pkg
+finance_stub = types.ModuleType("app.utils.finance_utils")
+finance_stub.normalize_account_balance = lambda balance, account_type, account_id=None: balance
+sys.modules["app.utils.finance_utils"] = finance_stub
+
+SERVICE_PATH = os.path.join(BASE_BACKEND, "app", "services", "safe_to_spend.py")
+spec = importlib.util.spec_from_file_location("app.services.safe_to_spend", SERVICE_PATH)
+service = importlib.util.module_from_spec(spec)
+sys.modules["app.services.safe_to_spend"] = service
+spec.loader.exec_module(service)
+
+
+def test_build_safe_to_spend_payload_today(monkeypatch):
+    monkeypatch.setattr(service, "_visible_accounts", lambda user_id=None: [Account(balance=Decimal("500.00"))])
+    monkeypatch.setattr(
+        service,
+        "_upcoming_bill_payload",
+        lambda as_of, horizon_end, user_id=None: (15_000, [{"name": "Power", "amount_cents": 15_000}]),
+    )
+    monkeypatch.setattr(service, "_spent_between", lambda start, end, user_id=None: 2_500)
+    monkeypatch.setattr(service, "_next_income_date", lambda as_of, user_id=None: date(2026, 7, 19))
+
+    payload = service.build_safe_to_spend_payload(
+        service.SafeToSpendInputs(as_of=date(2026, 7, 12), buffer_cents=25_000)
+    )
+
+    assert payload["amount_cents"] == 7_500
+    assert payload["components"] == {
+        "spendable_cash_cents": 50_000,
+        "upcoming_outflows_cents": 15_000,
+        "required_buffer_cents": 25_000,
+        "spent_today_cents": 2_500,
+    }
+    assert payload["status"] == "comfortable"
+    assert payload["confidence"] == "ready"
+
+
+def test_build_safe_to_spend_payload_until_payday_per_day(monkeypatch):
+    monkeypatch.setattr(service, "_visible_accounts", lambda user_id=None: [Account(balance=Decimal("300.00"))])
+    monkeypatch.setattr(service, "_upcoming_bill_payload", lambda as_of, horizon_end, user_id=None: (10_000, []))
+    monkeypatch.setattr(service, "_spent_between", lambda start, end, user_id=None: 0)
+    monkeypatch.setattr(service, "_next_income_date", lambda as_of, user_id=None: date(2026, 7, 14))
+
+    payload = service.build_safe_to_spend_payload(
+        service.SafeToSpendInputs(mode="until_payday", as_of=date(2026, 7, 12), buffer_cents=5_000)
+    )
+
+    assert payload["total_horizon_cents"] == 15_000
+    assert payload["amount_cents"] == 5_000
+    assert payload["horizon_end"] == "2026-07-14"
+    assert payload["confidence"] == "estimated"


### PR DESCRIPTION
### Motivation

- Provide an immediate spend-guidance decision surface on the dashboard that preserves a protected buffer and accounts for upcoming bills and today's outflows, with horizon controls for `today`, `week`, and `until_payday`.

### Description

- Add a new backend service `app.services.safe_to_spend` implementing `SafeToSpendInputs`, `DEFAULT_BUFFER_CENTS`, and `build_safe_to_spend_payload` with cash-account, bill, today-spend, and payday-inference logic.
- Expose `GET /api/dashboard/safe-to-spend` in `backend/app/routes/dashboard.py` with validation for `as_of` and `buffer_cents`, defensive logging, and usage of `SafeToSpendInputs` and `DEFAULT_BUFFER_CENTS`.
- Add a new frontend widget `SafeToSpendCard.vue`, integrate it into `NetOverviewSection.vue` and `Dashboard.vue`, add `api.fetchSafeToSpend` client call, and export the component type in `frontend/src/components.d.ts`.
- Update documentation under `docs/` to describe the route, service, and frontend widget, and update the docs index to include the new widget.
- Add unit tests and stubs for backend route/service and frontend component tests, and update snapshots to reflect layout and styling changes.

### Testing

- Ran backend tests for the route and service: `tests/test_safe_to_spend_service.py` and updated `tests/test_dashboard_activity_status_route.py` executed and passed.
- Ran frontend unit tests including `frontend/src/components/dashboard/__tests__/SafeToSpendCard.spec.ts` and updated `DashboardSections.spec.ts` with snapshot refresh under Vitest and they passed.
- Snapshot updated: `frontend/src/components/dashboard/__tests__/__snapshots__/DashboardSections.spec.ts.snap` was refreshed to reflect the new widget and layout changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53dac564748329892694b34867bd8d)