### PR TITLE
fix(dashboard): standardize amount polarity styling

### DIFF
--- a/docs/frontend/CURRENCY_FORMAT_GUIDE.md
+++ b/docs/frontend/CURRENCY_FORMAT_GUIDE.md
@@ -10,9 +10,8 @@ Transactions displayed on the dashboard use a consistent accounting style.
 Example:
 
 ```js
-formatAmount(42.5)   // "$42.50"
-formatAmount(-20.1)  // "($20.10)"
+formatAmount(42.5); // "$42.50"
+formatAmount(-20.1); // "($20.10)"
 ```
 
 Use `amountPolarityClass` from `src/utils/format.js` for sitewide amount color semantics. It returns `amount-positive`, `amount-negative`, or `amount-neutral`, which map through theme variables to green, red, or inherited text color. Apply the helper anywhere a signed money value is rendered so dashboard detail views, tables, and summary panels stay consistent.
-

--- a/docs/frontend/CURRENCY_FORMAT_GUIDE.md
+++ b/docs/frontend/CURRENCY_FORMAT_GUIDE.md
@@ -14,5 +14,5 @@ formatAmount(42.5)   // "$42.50"
 formatAmount(-20.1)  // "($20.10)"
 ```
 
-Apply the `text-red-400` class to negative amounts to ensure visual emphasis.
+Use `amountPolarityClass` from `src/utils/format.js` for sitewide amount color semantics. It returns `amount-positive`, `amount-negative`, or `amount-neutral`, which map through theme variables to green, red, or inherited text color. Apply the helper anywhere a signed money value is rendered so dashboard detail views, tables, and summary panels stay consistent.
 

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -94,6 +94,18 @@
   color: var(--text-muted);
 }
 
+@utility amount-positive {
+  color: var(--color-accent-green);
+}
+
+@utility amount-negative {
+  color: var(--color-accent-red);
+}
+
+@utility amount-neutral {
+  color: inherit;
+}
+
 @utility hover-surface {
   &:hover {
     background-color: var(--interactive-hover);

--- a/frontend/src/components/statistics/DailySpendingPanel.vue
+++ b/frontend/src/components/statistics/DailySpendingPanel.vue
@@ -36,7 +36,7 @@
             <li v-for="row in averageDisplayRows" :key="row.label" class="average-breakdown-row">
               <span class="average-breakdown-rank">{{ row.rank }}</span>
               <span class="average-breakdown-label">{{ row.label }}</span>
-              <span class="average-breakdown-amount">
+              <span class="average-breakdown-amount" :class="amountPolarityClass(row.amount)">
                 {{ formatAmount(row.amount) }}
                 <span class="average-breakdown-percent"> {{ row.percentage.toFixed(1) }}% </span>
               </span>
@@ -58,7 +58,9 @@
               <span class="transaction-name">{{ transactionLabel(transaction) }}</span>
               <span class="transaction-date">{{ formatTransactionDate(transaction.date) }}</span>
             </div>
-            <span class="transaction-amount">{{ formatAmount(transaction.amount) }}</span>
+            <span class="transaction-amount" :class="amountPolarityClass(transaction.amount)">{{
+              formatAmount(transaction.amount)
+            }}</span>
           </li>
         </ul>
       </div>
@@ -71,7 +73,7 @@ import { ref, computed, watch, onUnmounted, nextTick } from 'vue'
 import { Chart } from 'chart.js/auto'
 import { fetchCategoryBreakdownTree } from '@/api/charts'
 import { fetchTransactions } from '@/api/transactions'
-import { formatAmount } from '@/utils/format'
+import { amountPolarityClass, formatAmount } from '@/utils/format'
 import { getAccentColor } from '@/utils/colors'
 
 /**
@@ -751,6 +753,14 @@ onUnmounted(() => {
   font-size: 0.85rem;
   font-weight: 700;
   color: var(--color-text-light);
+}
+
+.transaction-amount.amount-positive {
+  color: var(--color-accent-green);
+}
+
+.transaction-amount.amount-negative {
+  color: var(--color-accent-red);
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/components/statistics/FinancialSummary.vue
+++ b/frontend/src/components/statistics/FinancialSummary.vue
@@ -26,15 +26,21 @@
     <div class="basic-stats">
       <div class="stat-item stat-income">
         <span class="stat-label">Income:</span>
-        <span class="stat-value">{{ formatAmount(detailSummary.totalIncome) }}</span>
+        <span class="stat-value" :class="amountPolarityClass(detailSummary.totalIncome)">{{
+          formatAmount(detailSummary.totalIncome)
+        }}</span>
       </div>
       <div class="stat-item stat-expenses">
         <span class="stat-label">Expenses:</span>
-        <span class="stat-value">{{ formatAmount(detailSummary.totalExpenses) }}</span>
+        <span class="stat-value" :class="amountPolarityClass(detailSummary.totalExpenses)">{{
+          formatAmount(detailSummary.totalExpenses)
+        }}</span>
       </div>
       <div class="stat-item stat-net" :class="netPolarityClass">
         <span class="stat-label">Net Total:</span>
-        <span class="stat-value">{{ formatAmount(detailSummary.totalNet) }}</span>
+        <span class="stat-value" :class="amountPolarityClass(detailSummary.totalNet)">{{
+          formatAmount(detailSummary.totalNet)
+        }}</span>
       </div>
     </div>
 
@@ -107,24 +113,38 @@
             <div class="subsection-title">Daily</div>
             <div class="stat-item">
               <span class="stat-label">Income:</span>
-              <span class="stat-value">{{ formatAmount(extendedMetrics.avgDailyIncome) }}</span>
+              <span
+                class="stat-value"
+                :class="amountPolarityClass(extendedMetrics.avgDailyIncome)"
+                >{{ formatAmount(extendedMetrics.avgDailyIncome) }}</span
+              >
             </div>
             <div class="stat-item">
               <span class="stat-label">Expenses:</span>
-              <span class="stat-value">{{ formatAmount(extendedMetrics.avgDailyExpenses) }}</span>
+              <span
+                class="stat-value"
+                :class="amountPolarityClass(extendedMetrics.avgDailyExpenses)"
+                >{{ formatAmount(extendedMetrics.avgDailyExpenses) }}</span
+              >
             </div>
             <div class="stat-item">
               <span class="stat-label">Net:</span>
-              <span class="stat-value">{{ formatAmount(extendedMetrics.avgDailyNet) }}</span>
+              <span class="stat-value" :class="amountPolarityClass(extendedMetrics.avgDailyNet)">{{
+                formatAmount(extendedMetrics.avgDailyNet)
+              }}</span>
             </div>
             <div class="subsection-title">Moving Averages</div>
             <div class="stat-item">
               <span class="stat-label">7-Day:</span>
-              <span class="stat-value">{{ formatAmount(extendedMetrics.netMA7) }}</span>
+              <span class="stat-value" :class="amountPolarityClass(extendedMetrics.netMA7)">{{
+                formatAmount(extendedMetrics.netMA7)
+              }}</span>
             </div>
             <div class="stat-item">
               <span class="stat-label">30-Day:</span>
-              <span class="stat-value">{{ formatAmount(extendedMetrics.netMA30) }}</span>
+              <span class="stat-value" :class="amountPolarityClass(extendedMetrics.netMA30)">{{
+                formatAmount(extendedMetrics.netMA30)
+              }}</span>
             </div>
           </div>
 
@@ -197,11 +217,15 @@
             </div>
             <div class="stat-item">
               <span class="stat-label">Savings Amount:</span>
-              <span class="stat-value">{{ savingsAmountLabel }}</span>
+              <span class="stat-value" :class="amountPolarityClass(savingsAmountValue)">{{
+                savingsAmountLabel
+              }}</span>
             </div>
             <div class="stat-item">
               <span class="stat-label">Avg Savings (positive):</span>
-              <span class="stat-value">{{ avgPositiveSavingsLabel }}</span>
+              <span class="stat-value" :class="amountPolarityClass(avgPositiveSavingsValue)">{{
+                avgPositiveSavingsLabel
+              }}</span>
             </div>
           </div>
         </div>
@@ -214,7 +238,7 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import api from '@/services/api'
 import { getRecurringTransactions } from '@/api/recurring'
-import { formatAmount } from '@/utils/format'
+import { amountPolarityClass, formatAmount } from '@/utils/format'
 import DailySpendingPanel from './DailySpendingPanel.vue'
 
 /**
@@ -749,11 +773,16 @@ const savingsRateLabel = computed(() => {
   return `${pct}%`
 })
 
-const savingsAmountLabel = computed(() => {
-  if (!filteredChartData.value.length) return 'N/A'
+const savingsAmountValue = computed(() => {
+  if (!filteredChartData.value.length) return null
   const totalIncome = detailSummary.value?.totalIncome ?? 0
   const totalExpensesAbs = Math.abs(detailSummary.value?.totalExpenses ?? 0)
-  return formatAmount(totalIncome - totalExpensesAbs)
+  return totalIncome - totalExpensesAbs
+})
+
+const savingsAmountLabel = computed(() => {
+  if (savingsAmountValue.value === null) return 'N/A'
+  return formatAmount(savingsAmountValue.value)
 })
 
 const positiveDaysLabel = computed(() => {
@@ -774,11 +803,15 @@ const negativeDaysLabel = computed(() => {
   return `${pct}% (${neg}/${n})`
 })
 
-const avgPositiveSavingsLabel = computed(() => {
+const avgPositiveSavingsValue = computed(() => {
   const values = filteredChartData.value.map((d) => d.net?.parsedValue || 0).filter((v) => v > 0)
-  if (!values.length) return 'N/A'
-  const avg = values.reduce((a, b) => a + b, 0) / values.length
-  return formatAmount(avg)
+  if (!values.length) return null
+  return values.reduce((a, b) => a + b, 0) / values.length
+})
+
+const avgPositiveSavingsLabel = computed(() => {
+  if (avgPositiveSavingsValue.value === null) return 'N/A'
+  return formatAmount(avgPositiveSavingsValue.value)
 })
 
 // Watch for chart data changes to recalculate
@@ -908,7 +941,7 @@ function clampDateString(value, min, max) {
 
 .stat-net.positive .stat-label,
 .stat-net.positive .stat-value {
-  color: var(--color-accent-cyan);
+  color: var(--color-accent-green);
 }
 
 .stat-net.negative .stat-label,
@@ -1091,6 +1124,14 @@ function clampDateString(value, min, max) {
   color: var(--color-text-light);
 }
 
+.stat-value.amount-positive {
+  color: var(--color-accent-green);
+}
+
+.stat-value.amount-negative {
+  color: var(--color-accent-red);
+}
+
 .badge-note {
   display: inline-block;
   margin-left: 0.25rem;
@@ -1108,7 +1149,7 @@ function clampDateString(value, min, max) {
 }
 
 .trend-up {
-  color: var(--color-accent-cyan);
+  color: var(--color-accent-green);
 }
 
 .trend-down {

--- a/frontend/src/components/statistics/__tests__/DailySpendingPanel.spec.js
+++ b/frontend/src/components/statistics/__tests__/DailySpendingPanel.spec.js
@@ -74,6 +74,7 @@ describe('DailySpendingPanel', () => {
 
     const rows = wrapper.findAll('.transaction-row')
     expect(rows[0].text()).toContain('Cafe')
+    expect(rows[0].find('.transaction-amount').classes()).toContain('amount-negative')
     expect(rows[1].text()).toContain('Coffee')
   })
 

--- a/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
+++ b/frontend/src/components/statistics/__tests__/FinancialSummary.spec.js
@@ -130,6 +130,9 @@ describe('FinancialSummary trends', () => {
     expect(incomeStat).toContain('$300.00')
     expect(expenseStat).toContain('($150.00)')
     expect(netStat).toContain('$150.00')
+    expect(wrapper.find('.stat-income .stat-value').classes()).toContain('amount-positive')
+    expect(wrapper.find('.stat-expenses .stat-value').classes()).toContain('amount-negative')
+    expect(wrapper.find('.stat-net .stat-value').classes()).toContain('amount-positive')
 
     expect(wrapper.find('.detail-date-helper').text()).toMatch(/2024/)
   })

--- a/frontend/src/utils/__tests__/format.spec.js
+++ b/frontend/src/utils/__tests__/format.spec.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { amountPolarityClass, formatAmount } from '../format'
+
+describe('format utilities', () => {
+  it('formats negative currency with accounting parentheses', () => {
+    expect(formatAmount(-20.1)).toBe('($20.10)')
+  })
+
+  it('classifies amount polarity for sitewide financial colors', () => {
+    expect(amountPolarityClass(42)).toBe('amount-positive')
+    expect(amountPolarityClass(-42)).toBe('amount-negative')
+    expect(amountPolarityClass(0)).toBe('amount-neutral')
+    expect(amountPolarityClass('not-a-number')).toBe('amount-neutral')
+  })
+})

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -22,3 +22,21 @@ export function formatAmount(amount) {
 
   return num < 0 ? `(${formatted})` : formatted
 }
+
+/**
+ * Return the shared polarity class for monetary values.
+ *
+ * Sitewide money displays use green for positive values, red for
+ * negative values, and inherit the surrounding text color for zero
+ * or non-numeric values. The returned classes reference theme variables
+ * so components can use the same financial semantics without hardcoded
+ * Tailwind palettes.
+ *
+ * @param {number|string|null|undefined} amount - Monetary value to classify.
+ * @returns {string} CSS utility class for the value polarity.
+ */
+export function amountPolarityClass(amount) {
+  const num = Number(amount || 0)
+  if (!Number.isFinite(num) || num === 0) return 'amount-neutral'
+  return num > 0 ? 'amount-positive' : 'amount-negative'
+}


### PR DESCRIPTION
### Motivation
- Ensure the Detail view on the main dashboard uses the same red=negative / green=positive styling as the rest of the site, and perform a focused formatting audit to apply consistent, maintainable fixes sitewide.

### Description
- Add a shared helper `amountPolarityClass` to `frontend/src/utils/format.js` and corresponding theme utilities (`amount-positive`, `amount-negative`, `amount-neutral`) in `frontend/src/assets/css/main.css` so money polarity is resolved centrally.
- Update the Financial Snapshot/Detail surface to apply the helper to income, expenses, net, averages, moving averages, and savings values, and split savings numeric value vs formatted label to allow correct coloring (changes in `frontend/src/components/statistics/FinancialSummary.vue`).
- Update the Daily Spending detail panel to use the same helper for average rows and recent transaction amounts (`frontend/src/components/statistics/DailySpendingPanel.vue`) and adjust local styles for amount classes.
- Update docs and tests: replace the old guide text in `docs/frontend/CURRENCY_FORMAT_GUIDE.md`, add unit tests for `format` helpers (`frontend/src/utils/__tests__/format.spec.js`), and adapt dashboard tests to assert polarity classes (`frontend/src/components/statistics/__tests__/FinancialSummary.spec.js`, `.../DailySpendingPanel.spec.js`).

### Testing
- Ran targeted unit tests with `npm run test -- src/utils/__tests__/format.spec.js src/components/statistics/__tests__/FinancialSummary.spec.js src/components/statistics/__tests__/DailySpendingPanel.spec.js --run`, and the targeted suites passed.
- Built the frontend with `npm run build` successfully, confirming production bundling succeeded.
- Ran the full test suite (`npm run test -- --run`) and `npm run lint`; these produced unrelated, pre-existing failures (a small set of forecast-chart/layout expectations and a parse error in `src/views/__tests__/Settings.spec.js`) and lint errors in other files not changed by this PR, so they remain outstanding and are documented in the PR notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540c5422388329b68097d65028ad86)